### PR TITLE
Rain variables

### DIFF
--- a/cache/.htaccess
+++ b/cache/.htaccess
@@ -1,0 +1,2 @@
+Allow from none
+Deny from all

--- a/data/.htaccess
+++ b/data/.htaccess
@@ -1,0 +1,2 @@
+Allow from none
+Deny from all

--- a/index.php
+++ b/index.php
@@ -88,13 +88,6 @@ header("Pragma: no-cache");
 
 // Directories creations (Note that your web host may require differents rights than 705.)
 if (!is_writable(realpath(dirname(__FILE__)))) die('<pre>ERROR: Shaarli does not have the right to write in its own directory ('.realpath(dirname(__FILE__)).').</pre>');
-if (!is_file($GLOBALS['config']['DATADIR'].'/.htaccess')) { file_put_contents($GLOBALS['config']['DATADIR'].'/.htaccess',"Allow from none\nDeny from all\n"); } // Protect data files.
-// Second check to see if Shaarli can write in its directory, because on some hosts is_writable() is not reliable.
-if (!is_file($GLOBALS['config']['DATADIR'].'/.htaccess')) die('<pre>ERROR: Shaarli does not have the right to write in its data directory ('.realpath($GLOBALS['config']['DATADIR']).').</pre>');
-if ($GLOBALS['config']['ENABLE_LOCALCACHE'])
-{
-    if (!is_file($GLOBALS['config']['CACHEDIR'].'/.htaccess')) { file_put_contents($GLOBALS['config']['CACHEDIR'].'/.htaccess',"Allow from none\nDeny from all\n"); } // Protect data files.
-}
 
 // Handling of old config file which do not have the new parameters.
 if (empty($GLOBALS['title'])) $GLOBALS['title']='Shared links on '.htmlspecialchars(indexUrl());

--- a/pagecache/.htaccess
+++ b/pagecache/.htaccess
@@ -1,0 +1,2 @@
+Allow from none
+Deny from all

--- a/tmp/.htaccess
+++ b/tmp/.htaccess
@@ -1,0 +1,2 @@
+Allow from none
+Deny from all


### PR DESCRIPTION
Hi all!

I wish to add the ability to define where to store all writable files. I set up two variables for RainTPL. This way, it will be possible to install/setup Shaarli in two separate directory : one with write access, one with read only access.

I think it would be neat for package maintainer and, maybe, to have a multi-user deployment.

Would you like to check this, at least, the following ways:
- Is the idea valuable?
- Is there any error in it?
- Do you like my implementation?

Thanks in advance.
