### PR TITLE
add link: in case of empty URL (self-post), prepend "Note: " to the title

### DIFF
--- a/index.php
+++ b/index.php
@@ -1587,7 +1587,11 @@ function renderPage()
  						}
  					}
             }
-            if ($url=='') $url='?'.smallHash($linkdate); // In case of empty URL, this is just a text (with a link that point to itself)
+            if ($url=='') // In case of empty URL, this is just a text (with a link that points to itself)
+            {
+                $url='?'.smallHash($linkdate);
+                $title='Note: ';
+            }
             $link = array('linkdate'=>$linkdate,'title'=>$title,'url'=>$url,'description'=>$description,'tags'=>$tags,'private'=>$private);
         }
 


### PR DESCRIPTION
Used when the user does `Add link` -> no URL -> `Add` (to write short articles/posts).
The item title will be set to "Note: " by default.
Thanks to @qwertygc in https://github.com/shaarli/Shaarli/pull/23
