### PR TITLE
Make ATOM toolbar button optional

### DIFF
--- a/index.php
+++ b/index.php
@@ -21,6 +21,7 @@ $GLOBALS['config']['BAN_AFTER'] = 4;        // Ban IP after this many failures.
 $GLOBALS['config']['BAN_DURATION'] = 1800;  // Ban duration for IP address after login failures (in seconds) (1800 sec. = 30 minutes)
 $GLOBALS['config']['OPEN_SHAARLI'] = false; // If true, anyone can add/edit/delete links without having to login
 $GLOBALS['config']['HIDE_TIMESTAMPS'] = false; // If true, the moment when links were saved are not shown to users that are not logged in.
+$GLOBALS['config']['SHOW_ATOM'] = false; // If true, an extra "ATOM feed" button will be displayed in the toolbar
 $GLOBALS['config']['ENABLE_THUMBNAILS'] = true; // Enable thumbnails in links.
 $GLOBALS['config']['CACHEDIR'] = 'cache'; // Cache directory for thumbnails for SLOW services (like flickr)
 $GLOBALS['config']['PAGECACHE'] = 'pagecache'; // Page cache directory.

--- a/tpl/page.header.html
+++ b/tpl/page.header.html
@@ -16,7 +16,9 @@
         <a href="?do=login">Login</a>
     {/if}
     <a href="{$feedurl}?do=rss{$searchcrits}" class="nomobile">RSS Feed</a>
-    <a href="{$feedurl}?do=atom{$searchcrits}" style="padding-left:10px;" class="nomobile">ATOM Feed</a>
+    {if="$GLOBALS['config']['SHOW_ATOM']"}
+        <a href="{$feedurl}?do=atom{$searchcrits}" style="padding-left:10px;" class="nomobile">ATOM Feed</a>
+    {/if}
     <a href="?do=tagcloud">Tag cloud</a>
     <a href="?do=picwall{$searchcrits}">Picture wall</a>
     <a href="?do=daily">Daily</a>


### PR DESCRIPTION
- ATOM button display is now configurable using the SHOW_ATOM variable in index.php or data/options.php (defaults to false)
- Fixes https://github.com/shaarli/Shaarli/issues/24
