### PR TITLE
use urlencode in tagcloud links

### DIFF
--- a/tpl/tagcloud.html
+++ b/tpl/tagcloud.html
@@ -6,7 +6,7 @@
 <center>
 <div id="cloudtag">
     {loop="tags"}
-    <span style="color:#99f; font-size:9pt; padding-left:5px; padding-right:2px;">{$value.count}</span><a href="?searchtags={$key|htmlspecialchars}" style="font-size:{$value.size}pt; font-weight:bold; color:black; text-decoration:none">{$key|htmlspecialchars}</a>
+    <span style="color:#99f; font-size:9pt; padding-left:5px; padding-right:2px;">{$value.count}</span><a href="?searchtags={$key|urlencode}" style="font-size:{$value.size}pt; font-weight:bold; color:black; text-decoration:none">{$key|htmlspecialchars}</a>
     {/loop}
 </div>
 </center>


### PR DESCRIPTION
- prevents unproper escaping of characters like '&'
- fixes https://github.com/sebsauvage/Shaarli/issues/85
- fixes https://github.com/shaarli/Shaarli/issues/48
