### PR TITLE
Remove $feedurl from RSS links

### DIFF
--- a/tpl/includes.html
+++ b/tpl/includes.html
@@ -2,8 +2,8 @@
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 <meta name="format-detection" content="telephone=no" />
 <meta name="viewport" content="width=device-width,initial-scale=1.0" />
-<link rel="alternate" type="application/rss+xml" href="{$feedurl}?do=rss{$searchcrits}#" title="RSS Feed" />
-<link rel="alternate" type="application/atom+xml" href="{$feedurl}?do=atom{$searchcrits}#" title="ATOM Feed" />
+<link rel="alternate" type="application/rss+xml" href="?do=rss{$searchcrits}#" title="RSS Feed" />
+<link rel="alternate" type="application/atom+xml" href="?do=atom{$searchcrits}#" title="ATOM Feed" />
 <link href="images/favicon.ico#" rel="shortcut icon" type="image/x-icon" />
 <link type="text/css" rel="stylesheet" href="inc/shaarli.css?version={$version|urlencode}#" />
 {if="is_file('inc/user.css')"}<link type="text/css" rel="stylesheet" href="inc/user.css?version={$version}#" />{/if}

--- a/tpl/page.header.html
+++ b/tpl/page.header.html
@@ -15,9 +15,9 @@
     {else}
         <a href="?do=login">Login</a>
     {/if}
-    <a href="{$feedurl}?do=rss{$searchcrits}" class="nomobile">RSS Feed</a>
+    <a href="?do=rss{$searchcrits}" class="nomobile">RSS Feed</a>
     {if="$GLOBALS['config']['SHOW_ATOM']"}
-        <a href="{$feedurl}?do=atom{$searchcrits}" class="nomobile">ATOM Feed</a>
+        <a href="?do=atom{$searchcrits}" class="nomobile">ATOM Feed</a>
     {/if}
     <a href="?do=tagcloud">Tag cloud</a>
     <a href="?do=picwall{$searchcrits}">Picture wall</a>


### PR DESCRIPTION
Other links haven't $feedurl var. Behind a reverse proxy with a path, rss point to server/?do=rss instead of server/path/?do=rss