### PR TITLE
improve tag cloud font size scaling

### DIFF
--- a/inc/shaarli.css
+++ b/inc/shaarli.css
@@ -562,7 +562,6 @@ a.qrcode img {
 }
 
 #cloudtag a {
-    font-weight:bold;
     color: black;
     text-decoration: none;
 }

--- a/index.php
+++ b/index.php
@@ -1251,8 +1251,9 @@ function renderPage()
         ksort($tags);
         $tagList=array();
         foreach($tags as $key=>$value)
+	// Tag font size scaling: default 15 and 30 logarithm bases affect scaling, 22 and 6 are arbitrary font sizes for max and min sizes.
         {
-            $tagList[$key] = array('count'=>$value,'size'=>max(40*$value/$maxcount,8));
+            $tagList[$key] = array('count'=>$value,'size'=>log($value, 15) / log($maxcount, 30) * (22-6) + 6);
         }
         $PAGE = new pageBuilder;
         $PAGE->assign('linkcount',count($LINKSDB));


### PR DESCRIPTION
- use logarithmic scales
- remove bold style

Helps distinguishing very frequent tags from less used ones.
Feel free to experiment with different values, this combination is what works well for me.

Screenshot: 
![](https://i.imgur.com/F8BsZpg.png)
