### PR TITLE
Add PhpStorm project folder and files to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,7 @@ pagecache
 
 # Ignore raintpl generated pages
 *.rtpl.php
+
+# PhpStorm / IntelliJ
+.idea/
+*.iml


### PR DESCRIPTION
The title speaks for itself. Other files [could be ignored](https://www.gitignore.io/api/phpstorm), but I don't think it's required.