### PR TITLE
w3c: fix HTML syntax errors

### DIFF
--- a/index.php
+++ b/index.php
@@ -2129,7 +2129,7 @@ function install()
 
     // Display config form:
     list($timezone_form,$timezone_js) = templateTZform();
-    $timezone_html=''; if ($timezone_form!='') $timezone_html='<tr><td valign="top"><b>Timezone:</b></td><td>'.$timezone_form.'</td></tr>';
+    $timezone_html=''; if ($timezone_form!='') $timezone_html='<tr><td><b>Timezone:</b></td><td>'.$timezone_form.'</td></tr>';
 
     $PAGE = new pageBuilder;
     $PAGE->assign('timezone_html',$timezone_html);

--- a/tpl/includes.html
+++ b/tpl/includes.html
@@ -6,4 +6,4 @@
 <link rel="alternate" type="application/atom+xml" href="{$feedurl}?do=atom{$searchcrits}#" title="ATOM Feed" />
 <link href="images/favicon.ico#" rel="shortcut icon" type="image/x-icon" />
 <link type="text/css" rel="stylesheet" href="inc/shaarli.css?version={$version|urlencode}#" />
-{if="is_file('inc/user.css')"}<link type="text/css" rel="stylesheet" href="inc/user.css?version={$version}#" />{/if}
+{if="is_file('inc/user.css')"}<link type="text/css" rel="stylesheet" href="inc/user.css?version={$version|urlencode}#" />{/if}

--- a/tpl/install.html
+++ b/tpl/install.html
@@ -5,7 +5,7 @@
 <div id="install">
 <h1>Shaarli</h1>	
 It looks like it's the first time you run Shaarli. Please configure it:<br>
-<form method="POST" action="" name="installform" id="installform">
+<form method="POST" action="#" name="installform" id="installform">
 <table>
 <tr><td><b>Login:</b></td><td><input type="text" name="setlogin" size="30"></td></tr>
 <tr><td><b>Password:</b></td><td><input type="password" name="setpassword" size="30"></td></tr>

--- a/tpl/linklist.html
+++ b/tpl/linklist.html
@@ -52,7 +52,8 @@
                 <span class="linkarchive"><a href="https://web.archive.org/web/{$value.url|htmlspecialchars}">archive</a> - </span>
                 {/if}
                 <div class="linkqrcode"><a href="http://qrfree.kaywa.com/?l=1&amp;s=8&amp;d={$scripturl|urlencode}%3F{$value.linkdate|smallHash}"
-                    onclick="return showQrCode(this);" class="qrcode" data-permalink="{$scripturl}?{$value.linkdate|smallHash}"><img src="images/qrcode.png#" title="QR-Code"></a></div> -
+                    onclick="return showQrCode(this);" class="qrcode" data-permalink="{$scripturl}?{$value.linkdate|smallHash}">
+		    <img src="images/qrcode.png#" alt="QR-Code" title="{$value.localdate|htmlspecialchars}"></a></div> -
                 <a href="{$value.url|htmlspecialchars}"><span class="linkurl" title="Short link">{$value.url|htmlspecialchars}</span></a><br>
                 {if="$value.tags"}
                     <div class="linktaglist">


### PR DESCRIPTION
Fixes the remaining W3C validation errors reported in #64

All pages:
- add `urlencode` when passing the version to a custom stylesheet;
- set meaningful values of `alt` and `title` for QR-Code images.

Install page:
- the form's `action` attribute must be non-empty;
- the `valign` attribute is deprecated.

To validate the install page, you may need to comment the session check section at the beginning of the `install()` method in `index.php` (else, the session check will fail, and there'll be nothing to validate ;-) ).