### PR TITLE
Working on shaarli/Shaarli#92 (Change tag suggestions behavior):

### DIFF
--- a/tpl/changetag.html
+++ b/tpl/changetag.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
 <head>{include="includes"}
-{if="empty($GLOBALS['disablejquery'])"}<script src="inc/jquery.min.js#"></script><script src="inc/jquery-ui.min.js#"></script>{/if}
+{if="empty($GLOBALS['disablejquery'])"}<script src="inc/jquery-1.11.2.min.js#"></script><script src="inc/jquery-ui-1.11.2.min.js#"></script>{/if}
 </head>
 <body onload="document.changetag.fromtag.focus();">
 <div id="pageheader">
@@ -19,7 +19,13 @@
 <script>
 $(document).ready(function()
 {
-    $('#fromtag').autocomplete({source:'{$source}?ws=singletag',minLength:1});
+    $('#fromtag').autocomplete({
+		source:'{$source}?ws=singletag',minLength:0,
+		focus: function( event, ui ) {
+			event.preventDefault(); // without this: keyboard movements reset the input to ''
+			$(this).val(ui.item.label);
+		}
+	});
 });
 </script>
 {/if}

--- a/tpl/editlink.html
+++ b/tpl/editlink.html
@@ -36,7 +36,13 @@
 <script>
 $(document).ready(function()
 {
-    $('#lf_tags').autocomplete({source:'{$source}?ws=tags',minLength:1});
+    $('#lf_tags').autocomplete({
+		source:'{$source}?ws=tags',minLength:0,
+		focus: function( event, ui ) {
+			event.preventDefault(); // without this: keyboard movements reset the input to ''
+			$(this).val(ui.item.label);
+		}
+	});
 });
 </script>
 {/if}


### PR DESCRIPTION
  * Using a very basic system of frecency: tag sorted by last used, then by most used
  * JQuery UI autocomplete is now triggered with 0 chars
  * JQuery UI autocomplete allow user to use UP and DOWN arrow keys
  * Limit number of autocomplete answers up to 10
  * Fixes a bug in changetag.tpl where the wrong jquery lib files where called

It's not perfect, but I think that's a good start especially using @s1dh use case:

  * Lurking a feed focused on a subject, let's say PHP.
  * Shaaring *"How to Symfony"* tagged `tutorial php symfony`.
  * Shaaring *"PHP is shitty, I use Haskell because I'm cool"*: down key in tag field will show the most used of the 3 previous tags used - so probably `php` because it's the main theme here.

By the way if you shaare a link related to another subject between those two, this feature will reveal itself kinda useless. But it's better than what we have now, and it was easy to do.

Of course, the basic autocomplete is still working.