### PR TITLE
Remove list bullets on linklist and removes margin on body

### DIFF
--- a/inc/shaarli.css
+++ b/inc/shaarli.css
@@ -5,6 +5,7 @@ body {
     font-size: 10pt;
     background-color: #ffffff;
     word-wrap: break-word;
+    margin: 0;
 }
 
 input, textarea {
@@ -360,6 +361,8 @@ h1 {
     background: -ms-linear-gradient(#F2F2F2, #ffffff);
     background: -o-linear-gradient(#F2F2F2, #ffffff);
     background: linear-gradient(#F2F2F2, #ffffff);
+    list-style: none;
+    margin-left: -40px;
 }
 
 /*


### PR DESCRIPTION
A little update on the css so the main theme is filling the whole page (no white border) and the list of links displays as expected (without a bullet). Maybe some more css refactoring is necessary but I guess it's enough for now.