### PR TITLE
Display notes as absolute urls.

### DIFF
--- a/doc/Mentions-of-Shaarli-in-"the-press".md
+++ b/doc/Mentions-of-Shaarli-in-"the-press".md
@@ -1,3 +1,0 @@
-This page lists the publications (physical or on the Internet) that mention Shaarli. It is by no means a complete list, and you are invited to add to it, should you spot a Shaarli mentioned in the wild.
-
-* http://www.linuxjournal.com/content/youre-boss-ubos

--- a/index.php
+++ b/index.php
@@ -1940,15 +1940,25 @@ function buildLinkList($PAGE,$LINKSDB)
     while ($i<$end && $i<count($keys))
     {
         $link = $linksToDisplay[$keys[$i]];
-        $link['description']=nl2br(keepMultipleSpaces(text2clickable(htmlspecialchars($link['description']))));
-        $title=$link['title'];
-        $classLi =  $i%2!=0 ? '' : 'publicLinkHightLight';
-        $link['class'] = ($link['private']==0 ? $classLi : 'private');
-        $link['localdate']=linkdate2locale($link['linkdate']);
-        $taglist = explode(' ',$link['tags']);
+        $title               = $link['title'];
+        $taglist             = explode(' ',$link['tags']);
         uasort($taglist, 'strcasecmp');
-        $link['taglist']=$taglist;
+
+        $classLi             = $i%2!=0 ? '' : 'publicLinkHightLight'; // This could really be done with just a css pseudoclass.
+
+        $link['description'] = nl2br(keepMultipleSpaces(text2clickable(htmlspecialchars($link['description']))));
+        $link['class']       = ($link['private']==0 ? $classLi : 'private');
+        $link['localdate']   = linkdate2locale($link['linkdate']);
+        $link['taglist']     = $taglist;
+
+        // Convert notes to absolute URLs
+        if ($link["url"][0]      === '?' && // Check for both signs of a note: starting with ? and 7 chars long. I doubt that you'll post any links that look like this.
+            strlen($link["url"]) === 7) {
+            $link["url"] = indexUrl() . $link["url"];
+        }
+
         $linkDisp[$keys[$i]] = $link;
+
         $i++;
     }
 


### PR DESCRIPTION
The deletion is related to Windows not handling quotes in filenames, see
 #179. It shouldn't delete the real file. Probably. Check it out.

![Shaarli Material really looks damn good.](https://cloud.githubusercontent.com/assets/373126/6886334/fa2d6748-d639-11e4-83d3-5825e846ee15.PNG)

