### PR TITLE
Daily - Display date as today if no articles published

### DIFF
--- a/index.php
+++ b/index.php
@@ -555,9 +555,12 @@ function endsWith($haystack,$needle,$case=true)
     PS: I could have used strptime(), but it does not exist on Windows. I'm too kind. */
 function linkdate2timestamp($linkdate)
 {
-    $Y=$M=$D=$h=$m=$s=0;
-    sscanf($linkdate,'%4d%2d%2d_%2d%2d%2d',$Y,$M,$D,$h,$m,$s);
-    return mktime($h,$m,$s,$M,$D,$Y);
+    if(strcmp($linkdate, '_000000') !== 0 || !$linkdate){
+        $Y=$M=$D=$h=$m=$s=0;
+        $r = sscanf($linkdate,'%4d%2d%2d_%2d%2d%2d',$Y,$M,$D,$h,$m,$s);
+        return mktime($h,$m,$s,$M,$D,$Y);
+    }
+    return time();
 }
 
 /*  Converts a linkdate time (YYYYMMDD_HHMMSS) of an article to a RFC822 date.


### PR DESCRIPTION
On "The Daily Shaarli" page (index.php?do=daily), the date is "Tuesday
30, November 1999" if no articles have been published/shared.

This patch checks the parameter ($linkdate) before the mktime call to
prevent and generate the "day 0" string.
mktime(0,0,0,0,0,0) returns 943916400 (hum?)

Since this error only appears when nothing has been published, feel free to ignore this pull request.
I didn't test widely.