### PR TITLE
Daily page: date format in template

### DIFF
--- a/index.php
+++ b/index.php
@@ -1228,7 +1228,7 @@ function showDaily()
     $PAGE->assign('linksToDisplay',$linksToDisplay);
     $PAGE->assign('linkcount',count($LINKSDB));
     $PAGE->assign('cols', $columns);
-    $PAGE->assign('day',utf8_encode(strftime('%A %d, %B %Y',linkdate2timestamp($day.'_000000'))));
+    $PAGE->assign('day',linkdate2timestamp($day.'_000000'));
     $PAGE->assign('previousday',$previousday);
     $PAGE->assign('nextday',$nextday);
     $PAGE->renderPage('daily');

--- a/tpl/daily.html
+++ b/tpl/daily.html
@@ -13,7 +13,7 @@
 	  <a href="?do=dailyrss" title="1 RSS entry per day"><img src="images/feed-icon-14x14.png#" alt="rss_feed">Daily RSS Feed</a>
     </div>
     <div class="dailyTitle"><img src="../images/floral_left.png" width="51" height="50" class="nomobile" alt="floral_left"> The Daily Shaarli <img src="../images/floral_right.png" width="51" height="50" class="nomobile" alt="floral_right"></div>
-    <div class="dailyDate"><span class="nomobile">&mdash;&mdash;&mdash;&mdash;&mdash;&mdash;&mdash;&mdash;&mdash;&mdash;&mdash;</span> {$day} <span class="nomobile">&mdash;&mdash;&mdash;&mdash;&mdash;&mdash;&mdash;&mdash;&mdash;&mdash;&mdash;</span></div>
+    <div class="dailyDate"><span class="nomobile">&mdash;&mdash;&mdash;&mdash;&mdash;&mdash;&mdash;&mdash;&mdash;&mdash;&mdash;</span> {function="strftime('%A %d, %B %Y', $day)"} <span class="nomobile">&mdash;&mdash;&mdash;&mdash;&mdash;&mdash;&mdash;&mdash;&mdash;&mdash;&mdash;</span></div>
     <div class="clear"></div>
 
     {if="$linksToDisplay"}


### PR DESCRIPTION
It only concerns the date of the day in the main title.

Fixes #182

Note that daily RSS feed is not generated through templates. Date are still hard formatted in that case.

To template maintainers @AkibaTech @alexisju @dhoko @kalvn @misterair @Vinm @vivienhaese ([list found here](https://github.com/shaarli/Shaarli/wiki#themes--templates), don't know if it's accurate), if this PR is merged, you'll have to update your daily template like I did here [L16](https://github.com/shaarli/Shaarli/commit/4de71445d3d174b5ef3462a1c4470a95cc00017e#diff-ebe9fdf25292625e325af9880371a141R16).