### PR TITLE
LinkDB: do not access global variables

### DIFF
--- a/application/LinkDB.php
+++ b/application/LinkDB.php
@@ -27,6 +27,15 @@
  */
 class LinkDB implements Iterator, Countable, ArrayAccess
 {
+    // Links are stored as a PHP serialized string
+    private $datastore;
+
+    // Datastore PHP prefix
+    protected static $phpPrefix = '<?php /* ';
+
+    // Datastore PHP suffix
+    protected static $phpSuffix = ' */ ?>';
+
     // List of links (associative array)
     //  - key:   link date (e.g. "20110823_124546"),
     //  - value: associative array (keys: title, description...)
@@ -55,9 +64,9 @@ class LinkDB implements Iterator, Countable, ArrayAccess
      *
      * @param $isLoggedIn is the user logged in?
      */
-    function __construct($isLoggedIn, $hidePublicLinks)
+    function __construct($datastore, $isLoggedIn, $hidePublicLinks)
     {
-        // FIXME: do not access $GLOBALS, pass the datastore instead
+        $this->datastore = $datastore;
         $this->loggedIn = $isLoggedIn;
         $this->hidePublicLinks = $hidePublicLinks;
         $this->checkDB();
@@ -172,7 +181,7 @@ class LinkDB implements Iterator, Countable, ArrayAccess
      */
     private function checkDB()
     {
-        if (file_exists($GLOBALS['config']['DATASTORE'])) {
+        if (file_exists($this->datastore)) {
             return;
         }
 
@@ -201,9 +210,8 @@ class LinkDB implements Iterator, Countable, ArrayAccess
         // Write database to disk
         // TODO: raise an exception if the file is not write-able
         file_put_contents(
-            // FIXME: do not use $GLOBALS
-            $GLOBALS['config']['DATASTORE'],
-            PHPPREFIX.base64_encode(gzdeflate(serialize($this->links))).PHPSUFFIX
+            $this->datastore,
+            self::$phpPrefix.base64_encode(gzdeflate(serialize($this->links))).self::$phpSuffix
         );
     }
 
@@ -222,13 +230,12 @@ class LinkDB implements Iterator, Countable, ArrayAccess
         // Read data
         // Note that gzinflate is faster than gzuncompress.
         // See: http://www.php.net/manual/en/function.gzdeflate.php#96439
-        // FIXME: do not use $GLOBALS
         $this->links = array();
 
-        if (file_exists($GLOBALS['config']['DATASTORE'])) {
+        if (file_exists($this->datastore)) {
             $this->links = unserialize(gzinflate(base64_decode(
-                substr(file_get_contents($GLOBALS['config']['DATASTORE']),
-                       strlen(PHPPREFIX), -strlen(PHPSUFFIX)))));
+                substr(file_get_contents($this->datastore),
+                       strlen(self::$phpPrefix), -strlen(self::$phpSuffix)))));
         }
 
         // If user is not logged in, filter private links.
@@ -266,8 +273,8 @@ class LinkDB implements Iterator, Countable, ArrayAccess
             die('You are not authorized to change the database.');
         }
         file_put_contents(
-            $GLOBALS['config']['DATASTORE'],
-            PHPPREFIX.base64_encode(gzdeflate(serialize($this->links))).PHPSUFFIX
+            $this->datastore,
+            self::$phpPrefix.base64_encode(gzdeflate(serialize($this->links))).self::$phpSuffix
         );
         invalidateCaches();
     }

--- a/index.php
+++ b/index.php
@@ -41,8 +41,6 @@ $GLOBALS['config']['HIDE_PUBLIC_LINKS'] = false;
 if (is_file($GLOBALS['config']['DATADIR'].'/options.php')) require($GLOBALS['config']['DATADIR'].'/options.php');
 
 define('shaarli_version','0.0.45beta');
-define('PHPPREFIX','<?php /* '); // Prefix to encapsulate data in PHP code.
-define('PHPSUFFIX',' */ ?>'); // Suffix to encapsulate data in PHP code.
 // http://server.com/x/shaarli --> /shaarli/
 define('WEB_PATH', substr($_SERVER["REQUEST_URI"], 0, 1+strrpos($_SERVER["REQUEST_URI"], '/', 0)));
 
@@ -700,6 +698,7 @@ function showRSS()
 
     // If cached was not found (or not usable), then read the database and build the response:
     $LINKSDB = new LinkDB(
+        $GLOBALS['config']['DATASTORE'],
         isLoggedIn() || $GLOBALS['config']['OPEN_SHAARLI'],
         $GLOBALS['config']['HIDE_PUBLIC_LINKS']
     );
@@ -780,6 +779,7 @@ function showATOM()
 
 // Read links from database (and filter private links if used it not logged in).
     $LINKSDB = new LinkDB(
+        $GLOBALS['config']['DATASTORE'],
         isLoggedIn() || $GLOBALS['config']['OPEN_SHAARLI'],
         $GLOBALS['config']['HIDE_PUBLIC_LINKS']
     );
@@ -866,6 +866,7 @@ function showDailyRSS()
 
 // Read links from database (and filter private links if used it not logged in).
     $LINKSDB = new LinkDB(
+        $GLOBALS['config']['DATASTORE'],
         isLoggedIn() || $GLOBALS['config']['OPEN_SHAARLI'],
         $GLOBALS['config']['HIDE_PUBLIC_LINKS']
     );
@@ -937,6 +938,7 @@ function showDailyRSS()
 function showDaily()
 {
     $LINKSDB = new LinkDB(
+        $GLOBALS['config']['DATASTORE'],
         isLoggedIn() || $GLOBALS['config']['OPEN_SHAARLI'],
         $GLOBALS['config']['HIDE_PUBLIC_LINKS']
     );
@@ -1006,6 +1008,7 @@ function showDaily()
 function renderPage()
 {
     $LINKSDB = new LinkDB(
+        $GLOBALS['config']['DATASTORE'],
         isLoggedIn() || $GLOBALS['config']['OPEN_SHAARLI'],
         $GLOBALS['config']['HIDE_PUBLIC_LINKS']
     );
@@ -1587,6 +1590,7 @@ function importFile()
 {
     if (!(isLoggedIn() || $GLOBALS['config']['OPEN_SHAARLI'])) { die('Not allowed.'); }
     $LINKSDB = new LinkDB(
+        $GLOBALS['config']['DATASTORE'],
         isLoggedIn() || $GLOBALS['config']['OPEN_SHAARLI'],
         $GLOBALS['config']['HIDE_PUBLIC_LINKS']
     );

--- a/tests/LinkDBTest.php
+++ b/tests/LinkDBTest.php
@@ -7,9 +7,6 @@ require_once 'application/LinkDB.php';
 require_once 'application/Utils.php';
 require_once 'tests/utils/ReferenceLinkDB.php';
 
-define('PHPPREFIX', '<?php /* ');
-define('PHPSUFFIX', ' */ ?>');
-
 
 /**
  * Unitary tests for LinkDB
@@ -38,11 +35,10 @@ class LinkDBTest extends PHPUnit_Framework_TestCase
     public static function setUpBeforeClass()
     {
         self::$refDB = new ReferenceLinkDB();
-        self::$refDB->write(self::$testDatastore, PHPPREFIX, PHPSUFFIX);
+        self::$refDB->write(self::$testDatastore);
 
-        $GLOBALS['config']['DATASTORE'] = self::$testDatastore;
-        self::$publicLinkDB = new LinkDB(false, false);
-        self::$privateLinkDB = new LinkDB(true, false);
+        self::$publicLinkDB = new LinkDB(self::$testDatastore, false, false);
+        self::$privateLinkDB = new LinkDB(self::$testDatastore, true, false);
     }
 
     /**
@@ -50,7 +46,6 @@ class LinkDBTest extends PHPUnit_Framework_TestCase
      */
     protected function setUp()
     {
-        $GLOBALS['config']['DATASTORE'] = self::$testDatastore;
         if (file_exists(self::$testDatastore)) {
             unlink(self::$testDatastore);
         }
@@ -76,7 +71,7 @@ class LinkDBTest extends PHPUnit_Framework_TestCase
      */
     public function testConstructLoggedIn()
     {
-        new LinkDB(true, false);
+        new LinkDB(self::$testDatastore, true, false);
         $this->assertFileExists(self::$testDatastore);
     }
 
@@ -85,7 +80,7 @@ class LinkDBTest extends PHPUnit_Framework_TestCase
      */
     public function testConstructLoggedOut()
     {
-        new LinkDB(false, false);
+        new LinkDB(self::$testDatastore, false, false);
         $this->assertFileExists(self::$testDatastore);
     }
 
@@ -97,8 +92,7 @@ class LinkDBTest extends PHPUnit_Framework_TestCase
      */
     public function testConstructDatastoreNotWriteable()
     {
-        $GLOBALS['config']['DATASTORE'] = 'null/store.db';
-        new LinkDB(false, false);
+        new LinkDB('null/store.db', false, false);
     }
 
     /**
@@ -106,7 +100,7 @@ class LinkDBTest extends PHPUnit_Framework_TestCase
      */
     public function testCheckDBNew()
     {
-        $linkDB = new LinkDB(false, false);
+        $linkDB = new LinkDB(self::$testDatastore, false, false);
         unlink(self::$testDatastore);
         $this->assertFileNotExists(self::$testDatastore);
 
@@ -126,7 +120,7 @@ class LinkDBTest extends PHPUnit_Framework_TestCase
      */
     public function testCheckDBLoad()
     {
-        $linkDB = new LinkDB(false, false);
+        $linkDB = new LinkDB(self::$testDatastore, false, false);
         $this->assertEquals(
             self::$dummyDatastoreSHA1,
             sha1_file(self::$testDatastore)
@@ -147,8 +141,8 @@ class LinkDBTest extends PHPUnit_Framework_TestCase
      */
     public function testReadEmptyDB()
     {
-        file_put_contents(self::$testDatastore, PHPPREFIX.'S7QysKquBQA='.PHPSUFFIX);
-        $emptyDB = new LinkDB(false, false);
+        file_put_contents(self::$testDatastore, '<?php /* S7QysKquBQA= */ ?>');
+        $emptyDB = new LinkDB(self::$testDatastore, false, false);
         $this->assertEquals(0, sizeof($emptyDB));
         $this->assertEquals(0, count($emptyDB));
     }
@@ -180,7 +174,7 @@ class LinkDBTest extends PHPUnit_Framework_TestCase
      */
     public function testSaveDB()
     {
-        $testDB = new LinkDB(true, false);
+        $testDB = new LinkDB(self::$testDatastore, true, false);
         $dbSize = sizeof($testDB);
 
         $link = array(
@@ -198,7 +192,7 @@ class LinkDBTest extends PHPUnit_Framework_TestCase
 
         $testDB->savedb();
 
-        $testDB = new LinkDB(true, false);
+        $testDB = new LinkDB(self::$testDatastore, true, false);
         $this->assertEquals($dbSize + 1, sizeof($testDB));
     }
 
@@ -222,7 +216,7 @@ class LinkDBTest extends PHPUnit_Framework_TestCase
      */
     public function testCountHiddenPublic()
     {
-        $linkDB = new LinkDB(false, true);
+        $linkDB = new LinkDB(self::$testDatastore, false, true);
 
         $this->assertEquals(
             0,

--- a/tests/utils/ReferenceLinkDB.php
+++ b/tests/utils/ReferenceLinkDB.php
@@ -93,11 +93,11 @@ class ReferenceLinkDB
     /**
      * Writes data to the datastore
      */
-    public function write($filename, $prefix, $suffix)
+    public function write($filename)
     {
         file_put_contents(
             $filename,
-            $prefix.base64_encode(gzdeflate(serialize($this->links))).$suffix
+            '<?php /* '.base64_encode(gzdeflate(serialize($this->links))).' */ ?>'
         );
     }
 


### PR DESCRIPTION
Relates to #218

Removes "hidden" access to the following variables:
 - $GLOBALS['config']['datastore']
 - PHPPREFIX
 - PHPSUFFIX

NOTE: may need to be rebased after merging #238 