### PR TITLE
Fix: data/config.php was not imported

### DIFF
--- a/index.php
+++ b/index.php
@@ -63,6 +63,11 @@ checkphpversion();
 error_reporting(E_ALL^E_WARNING);  // See all error except warnings.
 //error_reporting(-1); // See all errors (for debugging only)
 
+// User configuration
+if (is_file($GLOBALS['config']['CONFIG_FILE'])) {
+    require_once $GLOBALS['config']['CONFIG_FILE'];
+}
+
 // Shaarli library
 require_once 'application/LinkDB.php';
 require_once 'application/Utils.php';
@@ -103,9 +108,10 @@ if (empty($GLOBALS['titleLink'])) $GLOBALS['titleLink']='?';
 // I really need to rewrite Shaarli with a proper configuation manager.
 
 // Run config screen if first run:
-if (!is_file($GLOBALS['config']['CONFIG_FILE'])) install();
+if (! is_file($GLOBALS['config']['CONFIG_FILE'])) {
+    install();
+}
 
-require $GLOBALS['config']['CONFIG_FILE'];  // Read login/password hash into $GLOBALS.
 $GLOBALS['title'] = !empty($GLOBALS['title']) ? escape($GLOBALS['title']) : '';
 $GLOBALS['titleLink'] = !empty($GLOBALS['titleLink']) ? escape($GLOBALS['titleLink']) : '';
 $GLOBALS['redirector'] = !empty($GLOBALS['redirector']) ? escape($GLOBALS['redirector']) : '';


### PR DESCRIPTION
## Issue
Relates to #255, see [l. 41](https://github.com/shaarli/Shaarli/commit/e92f1ba59edb9fd60b185dc633e64a62dffe3b04#diff-828e0013b8f3bc1bb22b4f57172b019dL41)

This issue was reported by @alexisju on Gitter, it prevents setting Shaarli options such as custom themes.

## How to test
### Setup a local environment
With the following configuration:
* Apache 2
* PHP 5.6.10
* user sites enabled, e.g. `/home/user/public_html/somedir` is served as `http://localhost/~user/somedir`
* Apache user is `http`

I've set up a simple environment using the [albinomouse-template](https://github.com/alexisju/albinomouse-template) repository, on the [am-dev](https://github.com/alexisju/albinomouse-template/tree/am-dev) branch:

```bash
$ cd ~/public_html

# clone repositories
$ git clone https://github.com/virtualtam/Shaarli.git -b fix/read-config shaarli
$ pushd shaarli/tpl
$ git clone https://github.com/alexisju/albinomouse-template.git -b am-dev
$ popd

# set access rights for Apache
$ chgrp -R http shaarli
$ chmod g+rwx shaarli shaarli/cache shaarli/data shaarli/pagecache shaarli/tmp
```

### Get config written
* go to the freshly installed site
* fill the install form
* log in to Shaarli

### Edit & check custom config entries
```bash
# the file should be owned by Apache, thus not writeable => sudo
$ sudo sed -i s=tpl=tpl/albinomouse-template=g shaarli/data/config.php
```

Go back to Shaarli: the custom template should now be used ;-)