### PR TITLE
PHP: ensure 5.3 compatibility

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ php:
   - 5.6
   - 5.5
   - 5.4
+  - 5.3
 install:
   - composer self-update
   - composer install

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ Password: `demo`
 
 ## Installing
 
-Shaarli requires php 5.4. `php-gd` is optional and provides thumbnail resizing.
+Shaarli requires PHP 5.3. `php-gd` is optional and provides thumbnail resizing.
 
  * Download the latest stable release from https://github.com/shaarli/Shaarli/releases
  * Unpack the archive in a directory on your web server

--- a/application/Config.php
+++ b/application/Config.php
@@ -19,10 +19,10 @@
 function writeConfig($config, $isLoggedIn)
 {
     // These fields are required in configuration.
-    $MANDATORY_FIELDS = [
+    $MANDATORY_FIELDS = array(
         'login', 'hash', 'salt', 'timezone', 'title', 'titleLink',
         'redirector', 'disablesessionprotection', 'privateLinkByDefault'
-    ];
+    );
 
     if (!isset($config['config']['CONFIG_FILE'])) {
         throw new MissingFieldConfigException('CONFIG_FILE');

--- a/application/TimeZone.php
+++ b/application/TimeZone.php
@@ -1,0 +1,110 @@
+<?php
+/**
+ * Generates the timezone selection form and JavaScript.
+ *
+ * Note: 'UTC/UTC' is mapped to 'UTC' to form a valid option
+ *
+ * Example: preselect Europe/Paris
+ *  list($htmlform, $js) = templateTZform('Europe/Paris');
+ *
+ * @param string $preselected_timezone preselected timezone (optional)
+ *
+ * @return an array containing the generated HTML form and Javascript code
+ **/
+function generateTimeZoneForm($preselected_timezone='')
+{
+    // Select the first available timezone if no preselected value is passed
+    if ($preselected_timezone == '') {
+        $l = timezone_identifiers_list();
+        $preselected_timezone = $l[0];
+    }
+
+    // Try to split the provided timezone
+    $spos = strpos($preselected_timezone, '/');
+    $pcontinent = substr($preselected_timezone, 0, $spos);
+    $pcity = substr($preselected_timezone, $spos+1);
+
+    // Display config form:
+    $timezone_form = '';
+    $timezone_js = '';
+
+    // The list is in the form 'Europe/Paris', 'America/Argentina/Buenos_Aires'...
+    // We split the list in continents/cities.
+    $continents = array();
+    $cities = array();
+
+    // TODO: use a template to generate the HTML/Javascript form
+
+    foreach (timezone_identifiers_list() as $tz) {
+        if ($tz == 'UTC') {
+            $tz = 'UTC/UTC';
+        }
+        $spos = strpos($tz, '/');
+
+        if ($spos !== false) {
+            $continent = substr($tz, 0, $spos);
+            $city = substr($tz, $spos+1);
+            $continents[$continent] = 1;
+
+            if (!isset($cities[$continent])) {
+                $cities[$continent] = '';
+            }
+            $cities[$continent] .= '<option value="'.$city.'"';
+            if ($pcity == $city) {
+                $cities[$continent] .= ' selected="selected"';
+            }
+            $cities[$continent] .= '>'.$city.'</option>';
+        }
+    }
+
+    $continents_html = '';
+    $continents = array_keys($continents);
+
+    foreach ($continents as $continent) {
+        $continents_html .= '<option  value="'.$continent.'"';
+        if ($pcontinent == $continent) {
+            $continents_html .= ' selected="selected"';
+        }
+        $continents_html .= '>'.$continent.'</option>';
+    }
+
+    // Timezone selection form
+    $timezone_form = 'Continent:';
+    $timezone_form .= '<select name="continent" id="continent" onChange="onChangecontinent();">';
+    $timezone_form .= $continents_html.'</select>';
+    $timezone_form .= '&nbsp;&nbsp;&nbsp;&nbsp;City:';
+    $timezone_form .= '<select name="city" id="city">'.$cities[$pcontinent].'</select><br />';
+
+    // Javascript handler - updates the city list when the user selects a continent
+    $timezone_js = '<script>';
+    $timezone_js .= 'function onChangecontinent() {';
+    $timezone_js .= 'document.getElementById("city").innerHTML =';
+    $timezone_js .= ' citiescontinent[document.getElementById("continent").value]; }';
+    $timezone_js .= 'var citiescontinent = '.json_encode($cities).';';
+    $timezone_js .= '</script>';
+
+    return array($timezone_form, $timezone_js);
+}
+
+/**
+ * Tells if a continent/city pair form a valid timezone
+ *
+ * Note: 'UTC/UTC' is mapped to 'UTC'
+ *
+ * @param string $continent the timezone continent
+ * @param string $city      the timezone city
+ *
+ * @return whether continent/city is a valid timezone
+ */
+function isTimeZoneValid($continent, $city)
+{
+    if ($continent == 'UTC' && $city == 'UTC') {
+        return true;
+    }
+
+    return in_array(
+        $continent.'/'.$city,
+        timezone_identifiers_list()
+    );
+}
+?>

--- a/application/Utils.php
+++ b/application/Utils.php
@@ -48,7 +48,7 @@ function endsWith($haystack, $needle, $case=true)
  */
 function nl2br_escaped($html)
 {
-    return str_replace('>','&gt;',str_replace('<','&lt;',nl2br($html)));
+    return str_replace('>', '&gt;', str_replace('<', '&lt;', nl2br($html)));
 }
 
 /**
@@ -117,3 +117,24 @@ function generateLocation($referer, $host, $loopTerms = array())
 
     return $final_referer;
 }
+
+/**
+ * Checks the PHP version to ensure Shaarli can run
+ *
+ * @param string $minVersion minimum PHP required version
+ * @param string $curVersion current PHP version (use PHP_VERSION)
+ *
+ * @throws Exception    the PHP version is not supported
+ */
+function checkPHPVersion($minVersion, $curVersion)
+{
+    if (version_compare($curVersion, $minVersion) < 0) {
+        throw new Exception(
+            'Your PHP version is obsolete!'
+            .' Shaarli requires at least PHP '.$minVersion.', and thus cannot run.'
+            .' Your PHP version has known security vulnerabilities and should be'
+            .' updated as soon as possible.'
+        );
+    }
+}
+?>

--- a/tests/ConfigTest.php
+++ b/tests/ConfigTest.php
@@ -18,7 +18,7 @@ class ConfigTest extends PHPUnit_Framework_TestCase
      */
     public function setUp()
     {
-        self::$_configFields = [
+        self::$_configFields = array(
             'login' => 'login',
             'hash' => 'hash',
             'salt' => 'salt',
@@ -28,13 +28,13 @@ class ConfigTest extends PHPUnit_Framework_TestCase
             'redirector' => '',
             'disablesessionprotection' => false,
             'privateLinkByDefault' => false,
-            'config' => [
+            'config' => array(
                 'CONFIG_FILE' => 'tests/config.php',
                 'DATADIR' => 'tests',
                 'config1' => 'config1data',
                 'config2' => 'config2data',
-            ]
-        ];
+            )
+        );
     }
 
     /**

--- a/tests/LinkDBTest.php
+++ b/tests/LinkDBTest.php
@@ -228,12 +228,12 @@ class LinkDBTest extends PHPUnit_Framework_TestCase
     public function testDays()
     {
         $this->assertEquals(
-            ['20121206', '20130614', '20150310'],
+            array('20121206', '20130614', '20150310'),
             self::$publicLinkDB->days()
         );
 
         $this->assertEquals(
-            ['20121206', '20130614', '20141125', '20150310'],
+            array('20121206', '20130614', '20141125', '20150310'),
             self::$privateLinkDB->days()
         );
     }
@@ -269,7 +269,7 @@ class LinkDBTest extends PHPUnit_Framework_TestCase
     public function testAllTags()
     {
         $this->assertEquals(
-            [
+            array(
                 'web' => 3,
                 'cartoon' => 2,
                 'gnu' => 2,
@@ -279,12 +279,12 @@ class LinkDBTest extends PHPUnit_Framework_TestCase
                 'software' => 1,
                 'stallman' => 1,
                 'free' => 1
-            ],
+            ),
             self::$publicLinkDB->allTags()
         );
 
         $this->assertEquals(
-            [
+            array(
                 'web' => 4,
                 'cartoon' => 3,
                 'gnu' => 2,
@@ -298,7 +298,7 @@ class LinkDBTest extends PHPUnit_Framework_TestCase
                 'w3c' => 1,
                 'css' => 1,
                 'Mercurial' => 1
-            ],
+            ),
             self::$privateLinkDB->allTags()
         );
     }

--- a/tests/TimeZoneTest.php
+++ b/tests/TimeZoneTest.php
@@ -1,0 +1,83 @@
+<?php
+/**
+ * TimeZone's tests
+ */
+
+require_once 'application/TimeZone.php';
+
+/**
+ * Unitary tests for timezone utilities
+ */
+class TimeZoneTest extends PHPUnit_Framework_TestCase
+{
+    /**
+     * Generate a timezone selection form
+     */
+    public function testGenerateTimeZoneForm()
+    {
+        $generated = generateTimeZoneForm();
+
+        // HTML form
+        $this->assertStringStartsWith('Continent:<select', $generated[0]);
+        $this->assertContains('selected="selected"', $generated[0]);
+        $this->assertStringEndsWith('</select><br />', $generated[0]);
+
+        // Javascript handler
+        $this->assertStringStartsWith('<script>', $generated[1]);
+        $this->assertContains(
+            '<option value=\"Bermuda\">Bermuda<\/option>',
+            $generated[1]
+        );
+        $this->assertStringEndsWith('</script>', $generated[1]);
+    }
+
+    /**
+     * Generate a timezone selection form, with a preselected timezone
+     */
+    public function testGenerateTimeZoneFormPreselected()
+    {
+        $generated = generateTimeZoneForm('Antarctica/Syowa');
+
+        // HTML form
+        $this->assertStringStartsWith('Continent:<select', $generated[0]);
+        $this->assertContains(
+            'value="Antarctica" selected="selected"',
+            $generated[0]
+        );
+        $this->assertContains(
+            'value="Syowa" selected="selected"',
+            $generated[0]
+        );
+        $this->assertStringEndsWith('</select><br />', $generated[0]);
+
+
+        // Javascript handler
+        $this->assertStringStartsWith('<script>', $generated[1]);
+        $this->assertContains(
+            '<option value=\"Bermuda\">Bermuda<\/option>',
+            $generated[1]
+        );
+        $this->assertStringEndsWith('</script>', $generated[1]);
+    }
+
+    /**
+     * Check valid timezones
+     */
+    public function testValidTimeZone()
+    {
+        $this->assertTrue(isTimeZoneValid('America', 'Argentina/Ushuaia'));
+        $this->assertTrue(isTimeZoneValid('Europe', 'Oslo'));
+        $this->assertTrue(isTimeZoneValid('UTC', 'UTC'));
+    }
+
+    /**
+     * Check invalid timezones
+     */
+    public function testInvalidTimeZone()
+    {
+        $this->assertFalse(isTimeZoneValid('CEST', 'CEST'));
+        $this->assertFalse(isTimeZoneValid('Europe', 'Atlantis'));
+        $this->assertFalse(isTimeZoneValid('Middle_Earth', 'Moria'));
+    }
+}
+?>

--- a/tests/UtilsTest.php
+++ b/tests/UtilsTest.php
@@ -109,7 +109,7 @@ class UtilsTest extends PHPUnit_Framework_TestCase
      */
     public function testGenerateLocationLoop() {
         $ref = 'http://localhost/?test';
-        $this->assertEquals('?', generateLocation($ref, 'localhost', ['test']));
+        $this->assertEquals('?', generateLocation($ref, 'localhost', array('test')));
     }
 
     /**
@@ -119,4 +119,36 @@ class UtilsTest extends PHPUnit_Framework_TestCase
         $ref = 'http://somewebsite.com/?test';
         $this->assertEquals('?', generateLocation($ref, 'localhost'));
     }
+
+    /**
+     * Check supported PHP versions
+     */
+    public function testCheckSupportedPHPVersion()
+    {
+        $minVersion = '5.3';
+        checkPHPVersion($minVersion, '5.4.32');
+        checkPHPVersion($minVersion, '5.5');
+        checkPHPVersion($minVersion, '5.6.10');
+    }
+
+    /**
+     * Check a unsupported PHP version
+     * @expectedException              Exception
+     * @expectedExceptionMessageRegExp /Your PHP version is obsolete/
+     */
+    public function testCheckSupportedPHPVersion51()
+    {
+        checkPHPVersion('5.3', '5.1.0');
+    }
+
+    /**
+     * Check another unsupported PHP version
+     * @expectedException              Exception
+     * @expectedExceptionMessageRegExp /Your PHP version is obsolete/
+     */
+    public function testCheckSupportedPHPVersion52()
+    {
+        checkPHPVersion('5.3', '5.2');
+    }
 }
+?>


### PR DESCRIPTION
Relates to #250

Modifications
- add PHP 5.3 to Travis environments
- rewrite array declarations: explicitely use array() instead of []
- move checkPHPVersion to application/Utils.php
- move timezone functions to application/TimeZone.php
- improve test coverage
- bump required version from 5.1.0 to 5.3.x