### PR TITLE
Add a generic rule to run PHPCS against different coding standards

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,6 +36,10 @@ static_analysis_summary: code_sniffer_source copy_paste mess_detector_summary
 
 code_sniffer: code_sniffer_full
 
+### - errors filtered by coding standard: PEAR, PSR1, PSR2, Zend...
+PHPCS_%:
+	@$(BIN)/phpcs $(PHP_SOURCE) --report-full --report-width=200 --standard=$*
+
 ### - errors by Git author
 code_sniffer_blame:
 	@$(BIN)/phpcs $(PHP_SOURCE) --report-gitblame


### PR DESCRIPTION
Relates to #95

Usage
 - list available standards
   `$ ./vendor/bin/phpcs -i`
 - run PHPCS against a given standard
   `$ make PHPCS_<standard>`

Examples
```bash
$ make PHPCS_PSR1
$ make PHPCS_Zend
```

As the target is generic (parametrizable), I chose a different naming style to avoid conflicts with the existing `code_sniffer_<type>` targets.