### PR TITLE
CachedPage: move to a proper file, add tests

### DIFF
--- a/application/Cache.php
+++ b/application/Cache.php
@@ -7,26 +7,18 @@
  * Purges all cached pages
  *
  * @param string $pageCacheDir page cache directory
+ *
+ * @return mixed an error string if the directory is missing
  */
 function purgeCachedPages($pageCacheDir)
 {
     if (! is_dir($pageCacheDir)) {
-        return;
+        $error = 'Cannot purge '.$pageCacheDir.': no directory';
+        error_log($error);
+        return $error;
     }
 
-    // TODO: check write access to the cache directory
-
-    $handler = opendir($pageCacheDir);
-    if ($handler == false) {
-        return;
-    }
-
-    while (($filename = readdir($handler)) !== false) {
-        if (endsWith($filename, '.cache')) {
-                unlink($pageCacheDir.'/'.$filename);
-        }
-    }
-    closedir($handler);
+    array_map('unlink', glob($pageCacheDir.'/*.cache'));
 }
 
 /**

--- a/application/Cache.php
+++ b/application/Cache.php
@@ -1,0 +1,46 @@
+<?php
+/**
+ * Cache utilities
+ */
+
+/**
+ * Purges all cached pages
+ *
+ * @param string $pageCacheDir page cache directory
+ */
+function purgeCachedPages($pageCacheDir)
+{
+    if (! is_dir($pageCacheDir)) {
+        return;
+    }
+
+    // TODO: check write access to the cache directory
+
+    $handler = opendir($pageCacheDir);
+    if ($handler == false) {
+        return;
+    }
+
+    while (($filename = readdir($handler)) !== false) {
+        if (endsWith($filename, '.cache')) {
+                unlink($pageCacheDir.'/'.$filename);
+        }
+    }
+    closedir($handler);
+}
+
+/**
+ * Invalidates caches when the database is changed or the user logs out.
+ *
+ * @param string $pageCacheDir page cache directory
+ */
+function invalidateCaches($pageCacheDir)
+{
+    // Purge cache attached to session.
+    if (isset($_SESSION['tags'])) {
+        unset($_SESSION['tags']);
+    }
+
+    // Purge page cache shared by sessions.
+    purgeCachedPages($pageCacheDir);
+}

--- a/application/CachedPage.php
+++ b/application/CachedPage.php
@@ -1,0 +1,63 @@
+<?php
+/**
+ * Simple cache system, mainly for the RSS/ATOM feeds
+ */
+class CachedPage
+{
+    // Directory containing page caches
+    private $cacheDir;
+
+    // Full URL of the page to cache -typically the value returned by pageUrl()
+    private $url;
+
+    // Should this URL be cached (boolean)?
+    private $shouldBeCached;
+
+    // Name of the cache file for this URL
+    private $filename;
+
+    /**
+     * Creates a new CachedPage
+     *
+     * @param string $cacheDir       page cache directory
+     * @param string $url            page URL
+     * @param bool   $shouldBeCached whether this page needs to be cached
+     */
+    public function __construct($cacheDir, $url, $shouldBeCached)
+    {
+        // TODO: check write access to the cache directory
+        $this->cacheDir = $cacheDir;
+        $this->url = $url;
+        $this->filename = $this->cacheDir.'/'.sha1($url).'.cache';
+        $this->shouldBeCached = $shouldBeCached;
+    }
+
+    /**
+     * Returns the cached version of a page, if it exists and should be cached
+     *
+     * @return a cached version of the page if it exists, null otherwise
+     */
+    public function cachedVersion()
+    {
+        if (!$this->shouldBeCached) {
+            return null;
+        }
+        if (is_file($this->filename)) {
+            return file_get_contents($this->filename);
+        }
+        return null;
+    }
+
+    /**
+     * Puts a page in the cache
+     *
+     * @param string $pageContent XML content to cache
+     */
+    public function cache($pageContent)
+    {
+        if (!$this->shouldBeCached) {
+            return;
+        }
+        file_put_contents($this->filename, $pageContent);
+    }
+}

--- a/application/LinkDB.php
+++ b/application/LinkDB.php
@@ -269,8 +269,10 @@ You use the community supported version of the original Shaarli project, by Seba
 
     /**
      * Saves the database from memory to disk
+     *
+     * @param string $pageCacheDir page cache directory
      */
-    public function savedb()
+    public function savedb($pageCacheDir)
     {
         if (!$this->_loggedIn) {
             // TODO: raise an Exception instead
@@ -280,7 +282,7 @@ You use the community supported version of the original Shaarli project, by Seba
             $this->_datastore,
             self::$phpPrefix.base64_encode(gzdeflate(serialize($this->_links))).self::$phpSuffix
         );
-        invalidateCaches();
+        invalidateCaches($pageCacheDir);
     }
 
     /**
@@ -439,4 +441,3 @@ You use the community supported version of the original Shaarli project, by Seba
         return $linkDays;
     }
 }
-?>

--- a/tests/CacheTest.php
+++ b/tests/CacheTest.php
@@ -27,11 +27,14 @@ class CachedTest extends PHPUnit_Framework_TestCase
     {
         if (! is_dir(self::$testCacheDir)) {
             mkdir(self::$testCacheDir);
+        } else {
+            array_map('unlink', glob(self::$testCacheDir.'/*'));
         }
         
         foreach (self::$pages as $page) {
             file_put_contents(self::$testCacheDir.'/'.$page.'.cache', $page);
         }
+        file_put_contents(self::$testCacheDir.'/intru.der', 'ShouldNotBeThere');
     }
 
     /**
@@ -42,7 +45,20 @@ class CachedTest extends PHPUnit_Framework_TestCase
         purgeCachedPages(self::$testCacheDir);
         foreach (self::$pages as $page) {
             $this->assertFileNotExists(self::$testCacheDir.'/'.$page.'.cache');
-        }        
+        }
+
+        $this->assertFileExists(self::$testCacheDir.'/intru.der');
+    }
+
+    /**
+     * Purge cached pages - missing directory
+     */
+    public function testPurgeCachedPagesMissingDir()
+    {
+        $this->assertEquals(
+            'Cannot purge tests/dummycache_missing: no directory',
+            purgeCachedPages(self::$testCacheDir.'_missing')
+        );
     }
 
     /**

--- a/tests/CacheTest.php
+++ b/tests/CacheTest.php
@@ -1,0 +1,63 @@
+<?php
+/**
+ * Cache tests
+ */
+
+// required to access $_SESSION array
+session_start();
+
+require_once 'application/Cache.php';
+
+/**
+ * Unitary tests for cached pages
+ */
+class CachedTest extends PHPUnit_Framework_TestCase
+{
+    // test cache directory
+    protected static $testCacheDir = 'tests/dummycache';
+
+    // dummy cached file names / content
+    protected static $pages = array('a', 'toto', 'd7b59c');
+
+
+    /**
+     * Populate the cache with dummy files
+     */
+    public function setUp()
+    {
+        if (! is_dir(self::$testCacheDir)) {
+            mkdir(self::$testCacheDir);
+        }
+        
+        foreach (self::$pages as $page) {
+            file_put_contents(self::$testCacheDir.'/'.$page.'.cache', $page);
+        }
+    }
+
+    /**
+     * Purge cached pages
+     */
+    public function testPurgeCachedPages()
+    {
+        purgeCachedPages(self::$testCacheDir);
+        foreach (self::$pages as $page) {
+            $this->assertFileNotExists(self::$testCacheDir.'/'.$page.'.cache');
+        }        
+    }
+
+    /**
+     * Purge cached pages and session cache
+     */
+    public function testInvalidateCaches()
+    {
+        $this->assertArrayNotHasKey('tags', $_SESSION);
+        $_SESSION['tags'] = array('goodbye', 'cruel', 'world');
+
+        invalidateCaches(self::$testCacheDir);
+        foreach (self::$pages as $page) {
+            $this->assertFileNotExists(self::$testCacheDir.'/'.$page.'.cache');
+        }        
+
+        $this->assertArrayNotHasKey('tags', $_SESSION);
+    }
+}

--- a/tests/CachedPageTest.php
+++ b/tests/CachedPageTest.php
@@ -1,0 +1,121 @@
+<?php
+/**
+ * PageCache tests
+ */
+
+require_once 'application/CachedPage.php';
+
+/**
+ * Unitary tests for cached pages
+ */
+class CachedPageTest extends PHPUnit_Framework_TestCase
+{
+    // test cache directory
+    protected static $testCacheDir = 'tests/pagecache';
+    protected static $url = 'http://shaar.li/?do=atom';
+    protected static $filename;
+
+    /**
+     * Create the cache directory if needed
+     */
+    public static function setUpBeforeClass()
+    {
+        if (! is_dir(self::$testCacheDir)) {
+            mkdir(self::$testCacheDir);
+        }
+        self::$filename = self::$testCacheDir.'/'.sha1(self::$url).'.cache';
+    }
+
+    /**
+     * Reset the page cache
+     */
+    public function setUp()
+    {
+        if (file_exists(self::$filename)) {
+            unlink(self::$filename);
+        }
+    }
+
+    /**
+     * Create a new cached page
+     */
+    public function testConstruct()
+    {
+        new CachedPage(self::$testCacheDir, '', true);
+        new CachedPage(self::$testCacheDir, '', false);
+        new CachedPage(self::$testCacheDir, 'http://shaar.li/?do=rss', true);
+        new CachedPage(self::$testCacheDir, 'http://shaar.li/?do=atom', false);
+    }
+
+    /**
+     * Cache a page's content
+     */
+    public function testCache()
+    {
+        $page = new CachedPage(self::$testCacheDir, self::$url, true);
+
+        $this->assertFileNotExists(self::$filename);
+        $page->cache('<p>Some content</p>');
+        $this->assertFileExists(self::$filename);
+        $this->assertEquals(
+            '<p>Some content</p>',
+            file_get_contents(self::$filename)
+        );
+    }
+
+    /**
+     * "Cache" a page's content - the page is not to be cached
+     */
+    public function testShouldNotCache()
+    {
+        $page = new CachedPage(self::$testCacheDir, self::$url, false);
+
+        $this->assertFileNotExists(self::$filename);
+        $page->cache('<p>Some content</p>');
+        $this->assertFileNotExists(self::$filename);
+    }
+
+    /**
+     * Return a page's cached content
+     */
+    public function testCachedVersion()
+    {
+        $page = new CachedPage(self::$testCacheDir, self::$url, true);
+
+        $this->assertFileNotExists(self::$filename);
+        $page->cache('<p>Some content</p>');
+        $this->assertFileExists(self::$filename);
+        $this->assertEquals(
+            '<p>Some content</p>',
+            $page->cachedVersion()
+        );
+    }
+
+    /**
+     * Return a page's cached content - the file does not exist
+     */
+    public function testCachedVersionNoFile()
+    {
+        $page = new CachedPage(self::$testCacheDir, self::$url, true);
+
+        $this->assertFileNotExists(self::$filename);
+        $this->assertEquals(
+            null,
+            $page->cachedVersion()
+        );
+    }
+
+    /**
+     * Return a page's cached content - the page is not to be cached
+     */
+    public function testNoCachedVersion()
+    {
+        $page = new CachedPage(self::$testCacheDir, self::$url, false);
+
+        $this->assertFileNotExists(self::$filename);
+        $this->assertEquals(
+            null,
+            $page->cachedVersion()
+        );
+    }
+}

--- a/tests/LinkDBTest.php
+++ b/tests/LinkDBTest.php
@@ -3,6 +3,7 @@
  * Link datastore tests
  */
 
+require_once 'application/Cache.php';
 require_once 'application/LinkDB.php';
 require_once 'application/Utils.php';
 require_once 'tests/utils/ReferenceLinkDB.php';
@@ -180,11 +181,7 @@ class LinkDBTest extends PHPUnit_Framework_TestCase
             'tags'=>'unit test'
         );
         $testDB[$link['linkdate']] = $link;
-
-        // TODO: move PageCache to a proper class/file
-        function invalidateCaches() {}
-
-        $testDB->savedb();
+        $testDB->savedb('tests');
 
         $testDB = new LinkDB(self::$testDatastore, true, false);
         $this->assertEquals($dbSize + 1, sizeof($testDB));
@@ -514,4 +511,3 @@ class LinkDBTest extends PHPUnit_Framework_TestCase
         );
     }
 }
-?>

--- a/tests/utils/ReferenceLinkDB.php
+++ b/tests/utils/ReferenceLinkDB.php
@@ -125,4 +125,3 @@ class ReferenceLinkDB
         return $this->_privateCount;
     }
 }
-?>


### PR DESCRIPTION
Modifications
 - rename `pageCache` to `CachedPage`
 - move utilities to `Cache`
 - do not access globals
 - apply coding rules
 - update LinkDB and test code
 - add test coverage