### PR TITLE
Fixes #325 - Shaarli does not recognize saved links

### DIFF
--- a/application/Url.php
+++ b/application/Url.php
@@ -81,6 +81,10 @@ class Url
     public function __construct($url)
     {
         $this->parts = parse_url($url);
+
+        if (!empty($url) && empty($this->parts['scheme'])) {
+            $this->parts['scheme'] = 'http';
+        }
     }
 
     /**
@@ -146,5 +150,17 @@ class Url
         $this->cleanupQuery();
         $this->cleanupFragment();
         return $this->__toString();
+    }
+
+    /**
+     * Get URL scheme.
+     *
+     * @return string the URL scheme or false if none is provided.
+     */
+    public function getScheme() {
+        if (!isset($this->parts['scheme'])) {
+            return false;
+        }
+        return $this->parts['scheme'];
     }
 }

--- a/index.php
+++ b/index.php
@@ -1497,8 +1497,8 @@ function renderPage()
             $description = (empty($_GET['description']) ? '' : $_GET['description']);
             $tags = (empty($_GET['tags']) ? '' : $_GET['tags'] );
             $private = (!empty($_GET['private']) && $_GET['private'] === "1" ? 1 : 0);
-            // If this is an HTTP link, we try go get the page to extract the title (otherwise we will to straight to the edit form.)
-            if (empty($title) && $url->getScheme() == 'http') {
+            // If this is an HTTP(S) link, we try go get the page to extract the title (otherwise we will to straight to the edit form.)
+            if (empty($title) && strpos($url->getScheme(), 'http') !== false) {
                 list($status,$headers,$data) = getHTTP($url,4); // Short timeout to keep the application responsive.
                 // FIXME: Decode charset according to specified in either 1) HTTP response headers or 2) <head> in html
                 if (strpos($status,'200 OK')!==false) {

--- a/tests/UrlTest.php
+++ b/tests/UrlTest.php
@@ -151,4 +151,20 @@ class UrlTest extends PHPUnit_Framework_TestCase
             $url->cleanup()
         );
     }
+
+    /**
+     * Test default http scheme.
+     */
+    public function testDefaultScheme() {
+        $url = new Url(self::$baseUrl);
+        $this->assertEquals('http', $url->getScheme());
+        $url = new Url('domain.tld');
+        $this->assertEquals('http', $url->getScheme());
+        $url = new Url('ssh://domain.tld');
+        $this->assertEquals('ssh', $url->getScheme());
+        $url = new Url('ftp://domain.tld');
+        $this->assertEquals('ftp', $url->getScheme());
+        $url = new Url('git://domain.tld/push?pull=clone#checkout');
+        $this->assertEquals('git', $url->getScheme());
+    }
 }


### PR DESCRIPTION
PHP doesn't seem to autoconvert objects to strings when they're use as array indexes.

Fixes regression introduced in d9d776af19fd0a191f82525991dafbb56e1bcfcb

Note that this feature is pretty light: if URL's strings doesn't match perfectly, it won't be regognize (eg. HTTP/HTTPS).

#325