### PR TITLE
travis: add PHP 7 to the tested environments

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 sudo: false
 language: php
 php:
+  - 7.0
   - 5.6
   - 5.5
   - 5.4


### PR DESCRIPTION
Reminder:
- PHP 5.4 is reaching End Of Life on 2015-09-14
- PHP 7 RC1 has been released on 2015-08-21
- PHP 7 RC2 is due on 2015-09-03
- ...
- PHP 7 is to be released on 2015-11-12