### PR TITLE
Allow uppercase letters in PHP sessionid format

### DIFF
--- a/application/Utils.php
+++ b/application/Utils.php
@@ -156,7 +156,7 @@ function is_session_id_valid($sessionId)
         return false;
     }
 
-    if (!preg_match('/^[a-z0-9]{2,32}$/', $sessionId)) {
+    if (!preg_match('/^[a-z0-9]{2,32}$/i', $sessionId)) {
         return false;
     }
 

--- a/tests/UtilsTest.php
+++ b/tests/UtilsTest.php
@@ -156,7 +156,7 @@ class UtilsTest extends PHPUnit_Framework_TestCase
      */
     public function testIsSessionIdValid()
     {
-        $this->assertTrue(is_session_id_valid('123456789012345678901234567890az'));
+        $this->assertTrue(is_session_id_valid('azertyuiop123456789AZERTYUIOP1aA'));
     }
 
     /**


### PR DESCRIPTION
Fixes shaarli/Shaarli#335 - Wrong login/password since v0.5.2

Regression introduced in 06b6660a7e8891c6e1c47815cf50ee5b2ef5f270

@virtualtam @nodiscc This is a critical bug. Should we recreate v0.5.2 with this commit included?