### PR TITLE
Session: use session_regenerate_id() to obtain a fresh session id and…

### DIFF
--- a/application/Utils.php
+++ b/application/Utils.php
@@ -156,7 +156,7 @@ function is_session_id_valid($sessionId)
         return false;
     }
 
-    if (!preg_match('/^[a-z0-9]{2,32}$/i', $sessionId)) {
+    if (!preg_match('/^[-,a-z0-9]{1,128}$/i', $sessionId)) {
         return false;
     }
 

--- a/index.php
+++ b/index.php
@@ -92,14 +92,16 @@ ini_set('session.use_only_cookies', 1);
 // Prevent PHP form using sessionID in URL if cookies are disabled.
 ini_set('session.use_trans_sid', false);
 
-// Regenerate session id if invalid or not defined in cookie.
-if (isset($_COOKIE['shaarli']) && !is_session_id_valid($_COOKIE['shaarli'])) {
-    $_COOKIE['shaarli'] = uniqid();
-}
 session_name('shaarli');
 // Start session if needed (Some server auto-start sessions).
 if (session_id() == '') {
     session_start();
+}
+
+// Regenerate session id if invalid or not defined in cookie.
+if (isset($_COOKIE['shaarli']) && !is_session_id_valid($_COOKIE['shaarli'])) {
+    session_regenerate_id(true);
+    $_COOKIE['shaarli'] = session_id();
 }
 
 include "inc/rain.tpl.class.php"; //include Rain TPL

--- a/tests/UtilsTest.php
+++ b/tests/UtilsTest.php
@@ -156,7 +156,7 @@ class UtilsTest extends PHPUnit_Framework_TestCase
      */
     public function testIsSessionIdValid()
     {
-        $this->assertTrue(is_session_id_valid('azertyuiop123456789AZERTYUIOP1aA'));
+        $this->assertTrue(is_session_id_valid('iXJWB-H1w439c02a4ff8770d3a652d344-QhXGZlJsBPQnaeAGaG,SmZFcYxYsxtjXdlslXQn8UyHB0ZkGZeiN5ZAsUsR38YcICkTe1197k7pt5g7b10nq2sqp4bfssf'));
     }
 
     /**
@@ -167,5 +167,6 @@ class UtilsTest extends PHPUnit_Framework_TestCase
         $this->assertFalse(is_session_id_valid(''));
         $this->assertFalse(is_session_id_valid(array()));
         $this->assertFalse(is_session_id_valid('c0ZqcWF3VFE2NmJBdm1HMVQ0ZHJ3UmZPbTFsNGhkNHI='));
+        $this->assertFalse(is_session_id_valid('c0asFsAfSffsAOfsdvZqcWF3VFE2d43asfNmJBdm1HMV3a8AsQ0ZHJ3UmZPbTFsNGhkNHI='));
     }
 }


### PR DESCRIPTION
… allow for different server configurations.

Improves on https://github.com/shaarli/Shaarli/pull/306
Relates to https://github.com/shaarli/Shaarli/issues/335, https://github.com/shaarli/Shaarli/pull/336, https://github.com/shaarli/Shaarli/pull/338

Issue:
- PHP regenerates the session ID itself if the ID is not conforming to the configured hash function
- the regex does not cover cases where session settings have been changed serverside

Fixes:
- use native function to regenerate the session ID and assign it to the cookie
- extends regex to match internal session verification function of PHP

Information:
- https://secure.php.net/manual/en/session.configuration.php#ini.session.hash-function
- https://secure.php.net/manual/en/session.configuration.php#ini.session.hash-bits-per-character
- https://github.com/php/php-src/blob/master/ext/session/session.c#L449

Signed-off-by: Cy4n1d3 <cy4n1d3@gmail.com>