### PR TITLE
Fixes #356 -  adding a link should return added link's hash

### DIFF
--- a/application/Utils.php
+++ b/application/Utils.php
@@ -97,12 +97,12 @@ function checkDateFormat($format, $string)
  */
 function generateLocation($referer, $host, $loopTerms = array())
 {
-    $final_referer = '?';
+    $finalReferer = '?';
 
     // No referer if it contains any value in $loopCriteria.
     foreach ($loopTerms as $value) {
         if (strpos($referer, $value) !== false) {
-            return $final_referer;
+            return $finalReferer;
         }
     }
 
@@ -111,11 +111,12 @@ function generateLocation($referer, $host, $loopTerms = array())
         $host = substr($host, 0, $pos);
     }
 
-    if (!empty($referer) && strpos(parse_url($referer, PHP_URL_HOST), $host) !== false) {
-        $final_referer = $referer;
+    $refererHost = parse_url($referer, PHP_URL_HOST);
+    if (!empty($referer) && (strpos($refererHost, $host) !== false || startsWith('?', $refererHost))) {
+        $finalReferer = $referer;
     }
 
-    return $final_referer;
+    return $finalReferer;
 }
 
 /**

--- a/index.php
+++ b/index.php
@@ -1354,10 +1354,14 @@ function renderPage()
         pubsubhub();
 
         // If we are called from the bookmarklet, we must close the popup:
-        if (isset($_GET['source']) && ($_GET['source']=='bookmarklet' || $_GET['source']=='firefoxsocialapi')) { echo '<script>self.close();</script>'; exit; }
-        $returnurl = ( !empty($_POST['returnurl']) ? escape($_POST['returnurl']) : '?' );
-        $returnurl .= '#'.smallHash($_POST['lf_linkdate']);  // Scroll to the link which has been edited.
+        if (isset($_GET['source']) && ($_GET['source']=='bookmarklet' || $_GET['source']=='firefoxsocialapi')) {
+            echo '<script>self.close();</script>';
+            exit;
+        }
+
+        $returnurl = !empty($_POST['returnurl']) ? escape($_POST['returnurl']): '?';
         $location = generateLocation($returnurl, $_SERVER['HTTP_HOST'], array('addlink', 'post', 'edit_link'));
+        $location .= '#'.smallHash($_POST['lf_linkdate']);  // Scroll to the link which has been edited.
         header('Location: '. $location); // After saving the link, redirect to the page the user was on.
         exit;
     }

--- a/tests/UtilsTest.php
+++ b/tests/UtilsTest.php
@@ -118,6 +118,8 @@ class UtilsTest extends PHPUnit_Framework_TestCase
         $this->assertEquals($ref, generateLocation($ref, 'localhost'));
         $ref = 'http://localhost:8080/?test';
         $this->assertEquals($ref, generateLocation($ref, 'localhost:8080'));
+        $ref = '?localreferer#hash';
+        $this->assertEquals($ref, generateLocation($ref, 'localhost:8080'));
     }
 
     /**


### PR DESCRIPTION
Not related, but already discussed in #354:
* allow redirection on relative urls in generateLocation

cf #357 