### PR TITLE
tools: check file/directory permissions for Shaarli resources

### DIFF
--- a/application/ApplicationUtils.php
+++ b/application/ApplicationUtils.php
@@ -1,0 +1,69 @@
+<?php
+/**
+ * Shaarli (application) utilities
+ */
+class ApplicationUtils
+{
+
+    /**
+     * Checks Shaarli has the proper access permissions to its resources
+     *
+     * @param array $globalConfig The $GLOBALS['config'] array
+     *
+     * @return array A list of the detected configuration issues
+     */
+    public static function checkResourcePermissions($globalConfig)
+    {
+        $errors = array();
+
+        // Check script and template directories are readable
+        foreach (array(
+            'application',
+            'inc',
+            'plugins',
+            $globalConfig['RAINTPL_TPL']
+        ) as $path) {
+            if (! is_readable(realpath($path))) {
+                $errors[] = '"'.$path.'" directory is not readable';
+            }
+        }
+
+        // Check cache and data directories are readable and writeable
+        foreach (array(
+            $globalConfig['CACHEDIR'],
+            $globalConfig['DATADIR'],
+            $globalConfig['PAGECACHE'],
+            $globalConfig['RAINTPL_TMP']
+        ) as $path) {
+            if (! is_readable(realpath($path))) {
+                $errors[] = '"'.$path.'" directory is not readable';
+            }
+            if (! is_writable(realpath($path))) {
+                $errors[] = '"'.$path.'" directory is not writable';
+            }
+        }
+
+        // Check configuration files are readable and writeable
+        foreach (array(
+            $globalConfig['CONFIG_FILE'],
+            $globalConfig['DATASTORE'],
+            $globalConfig['IPBANS_FILENAME'],
+            $globalConfig['LOG_FILE'],
+            $globalConfig['UPDATECHECK_FILENAME']
+        ) as $path) {
+            if (! is_file(realpath($path))) {
+                # the file may not exist yet
+                continue;
+            }
+
+            if (! is_readable(realpath($path))) {
+                $errors[] = '"'.$path.'" file is not readable';
+            }
+            if (! is_writable(realpath($path))) {
+                $errors[] = '"'.$path.'" file is not writable';
+            }
+        }
+
+        return $errors;
+    }
+}

--- a/application/FileUtils.php
+++ b/application/FileUtils.php
@@ -1,0 +1,19 @@
+<?php
+/**
+ * Exception class thrown when a filesystem access failure happens
+ */
+class IOException extends Exception
+{
+    private $path;
+
+    /**
+     * Construct a new IOException
+     *
+     * @param string $path path to the ressource that cannot be accessed
+     */
+    public function __construct($path)
+    {
+        $this->path = $path;
+        $this->message = 'Error accessing '.$this->path;
+    }
+}

--- a/tests/ApplicationUtilsTest.php
+++ b/tests/ApplicationUtilsTest.php
@@ -1,0 +1,69 @@
+<?php
+/**
+ * ApplicationUtils' tests
+ */
+
+require_once 'application/ApplicationUtils.php';
+
+
+/**
+ * Unitary tests for Shaarli utilities
+ */
+class ApplicationUtilsTest extends PHPUnit_Framework_TestCase
+{
+    /**
+     * Checks resource permissions for the current Shaarli installation
+     */
+    public function testCheckCurrentResourcePermissions()
+    {
+        $config = array(
+            'CACHEDIR' => 'cache',
+            'CONFIG_FILE' => 'data/config.php',
+            'DATADIR' => 'data',
+            'DATASTORE' => 'data/datastore.php',
+            'IPBANS_FILENAME' => 'data/ipbans.php',
+            'LOG_FILE' => 'data/log.txt',
+            'PAGECACHE' => 'pagecache',
+            'RAINTPL_TMP' => 'tmp',
+            'RAINTPL_TPL' => 'tpl',
+            'UPDATECHECK_FILENAME' => 'data/lastupdatecheck.txt'
+        );
+        $this->assertEquals(
+            array(),
+            ApplicationUtils::checkResourcePermissions($config)
+        );
+    }
+
+    /**
+     * Checks resource permissions for a non-existent Shaarli installation
+     */
+    public function testCheckCurrentResourcePermissionsErrors()
+    {
+        $config = array(
+            'CACHEDIR' => 'null/cache',
+            'CONFIG_FILE' => 'null/data/config.php',
+            'DATADIR' => 'null/data',
+            'DATASTORE' => 'null/data/store.php',
+            'IPBANS_FILENAME' => 'null/data/ipbans.php',
+            'LOG_FILE' => 'null/data/log.txt',
+            'PAGECACHE' => 'null/pagecache',
+            'RAINTPL_TMP' => 'null/tmp',
+            'RAINTPL_TPL' => 'null/tpl',
+            'UPDATECHECK_FILENAME' => 'null/data/lastupdatecheck.txt'
+        );
+        $this->assertEquals(
+            array(
+                '"null/tpl" directory is not readable',
+                '"null/cache" directory is not readable',
+                '"null/cache" directory is not writable',
+                '"null/data" directory is not readable',
+                '"null/data" directory is not writable',
+                '"null/pagecache" directory is not readable',
+                '"null/pagecache" directory is not writable',
+                '"null/tmp" directory is not readable',
+                '"null/tmp" directory is not writable'
+            ),
+            ApplicationUtils::checkResourcePermissions($config)
+        );
+    }
+}

--- a/tests/LinkDBTest.php
+++ b/tests/LinkDBTest.php
@@ -4,6 +4,7 @@
  */
 
 require_once 'application/Cache.php';
+require_once 'application/FileUtils.php';
 require_once 'application/LinkDB.php';
 require_once 'application/Utils.php';
 require_once 'tests/utils/ReferenceLinkDB.php';
@@ -87,8 +88,8 @@ class LinkDBTest extends PHPUnit_Framework_TestCase
     /**
      * Attempt to instantiate a LinkDB whereas the datastore is not writable
      *
-     * @expectedException              PHPUnit_Framework_Error_Warning
-     * @expectedExceptionMessageRegExp /failed to open stream: No such file or directory/
+     * @expectedException              IOException
+     * @expectedExceptionMessageRegExp /Error accessing null/
      */
     public function testConstructDatastoreNotWriteable()
     {


### PR DESCRIPTION
Relates to #40

Additions:
 - FileUtils: IOException
 - ApplicationUtils:
   - check if Shaarli resources are accessible with sufficient permissions
   - basic test coverage
 - index.php:
   - check access permissions and redirect to an error page if needed:
     - before running the first installation

Modifications:
 - LinkDB:
   - factorize datastore write code
   - check if the datastore
     (exists AND is writeable) OR (doesn't exist AND its parent dir is writable)
   - raise an IOException if needed