### PR TITLE
Bugfix: do not store plugin errors in data.php

### DIFF
--- a/index.php
+++ b/index.php
@@ -679,8 +679,8 @@ class pageBuilder
             $this->tpl->assign('pagetitle', $GLOBALS['pagetitle']);
         }
         $this->tpl->assign('shaarlititle', empty($GLOBALS['title']) ? 'Shaarli': $GLOBALS['title']);
-        if (!empty($GLOBALS['plugins']['errors'])) {
-            $this->tpl->assign('plugin_errors', $GLOBALS['plugins']['errors']);
+        if (!empty($GLOBALS['plugin_errors'])) {
+            $this->tpl->assign('plugin_errors', $GLOBALS['plugin_errors']);
         }
     }
 

--- a/plugins/readityourself/readityourself.php
+++ b/plugins/readityourself/readityourself.php
@@ -14,7 +14,7 @@ if (is_file(PluginManager::$PLUGINS_PATH . '/readityourself/config.php')) {
 }
 
 if (!isset($GLOBALS['plugins']['READITYOUSELF_URL'])) {
-    $GLOBALS['plugins']['errors'][] = 'Readityourself plugin error: '.
+    $GLOBALS['plugin_errors'][] = 'Readityourself plugin error: '.
         'Please define "$GLOBALS[\'plugins\'][\'READITYOUSELF_URL\']" '.
         'in "plugins/readityourself/config.php" or in your Shaarli config.php file.';
 }

--- a/plugins/wallabag/wallabag.php
+++ b/plugins/wallabag/wallabag.php
@@ -10,7 +10,7 @@ if (is_file(PluginManager::$PLUGINS_PATH . '/wallabag/config.php')) {
 }
 
 if (!isset($GLOBALS['plugins']['WALLABAG_URL'])) {
-    $GLOBALS['plugins']['errors'][] = 'Wallabag plugin error: '.
+    $GLOBALS['plugin_errors'][] = 'Wallabag plugin error: '.
         'Please define "$GLOBALS[\'plugins\'][\'WALLABAG_URL\']" '.
         'in "plugins/wallabag/config.php" or in your Shaarli config.php file.';
 }


### PR DESCRIPTION
Before this, calling writeConfig() would have write error messages in data.php, because it uses 'plugins' array which is used for plugin configuration.

Causing the message error to appear everytime.