### PR TITLE
Fixes #378 - Plugin administration UI.

### DIFF
--- a/application/Config.php
+++ b/application/Config.php
@@ -74,6 +74,106 @@ function writeConfig($config, $isLoggedIn)
 }
 
 /**
+ * Process plugin administration form data and save it in an array.
+ *
+ * @param array $formData Data sent by the plugin admin form.
+ *
+ * @return array New list of enabled plugin, ordered.
+ *
+ * @throws PluginConfigOrderException Plugins can't be sorted because their order is invalid.
+ */
+function save_plugin_config($formData)
+{
+    // Make sure there are no duplicates in orders.
+    if (!validate_plugin_order($formData)) {
+        throw new PluginConfigOrderException();
+    }
+
+    $plugins = array();
+    $newEnabledPlugins = array();
+    foreach ($formData as $key => $data) {
+        if (startsWith($key, 'order')) {
+            continue;
+        }
+
+        // If there is no order, it means a disabled plugin has been enabled.
+        if (isset($formData['order_' . $key])) {
+            $plugins[(int) $formData['order_' . $key]] = $key;
+        }
+        else {
+            $newEnabledPlugins[] = $key;
+        }
+    }
+
+    // New enabled plugins will be added at the end of order.
+    $plugins = array_merge($plugins, $newEnabledPlugins);
+
+    // Sort plugins by order.
+    if (!ksort($plugins)) {
+        throw new PluginConfigOrderException();
+    }
+
+    $finalPlugins = array();
+    // Make plugins order continuous.
+    foreach ($plugins as $plugin) {
+        $finalPlugins[] = $plugin;
+    }
+
+    return $finalPlugins;
+}
+
+/**
+ * Validate plugin array submitted.
+ * Will fail if there is duplicate orders value.
+ *
+ * @param array $formData Data from submitted form.
+ *
+ * @return bool true if ok, false otherwise.
+ */
+function validate_plugin_order($formData)
+{
+    $orders = array();
+    foreach ($formData as $key => $value) {
+        // No duplicate order allowed.
+        if (in_array($value, $orders)) {
+            return false;
+        }
+
+        if (startsWith($key, 'order')) {
+            $orders[] = $value;
+        }
+    }
+
+    return true;
+}
+
+/**
+ * Affect plugin parameters values into plugins array.
+ *
+ * @param mixed $plugins Plugins array ($plugins[<plugin_name>]['parameters']['param_name'] = <value>.
+ * @param mixed $config  Plugins configuration.
+ *
+ * @return mixed Updated $plugins array.
+ */
+function load_plugin_parameter_values($plugins, $config)
+{
+    $out = $plugins;
+    foreach ($plugins as $name => $plugin) {
+        if (empty($plugin['parameters'])) {
+            continue;
+        }
+
+        foreach ($plugin['parameters'] as $key => $param) {
+            if (!empty($config[$key])) {
+                $out[$name]['parameters'][$key] = $config[$key];
+            }
+        }
+    }
+
+    return $out;
+}
+
+/**
  * Milestone 0.9 - shaarli/Shaarli#41: options.php is not supported anymore.
  * ==> if user is loggedIn, merge its content with config.php, then delete options.php.
  *
@@ -130,5 +230,19 @@ class UnauthorizedConfigException extends Exception
     public function __construct()
     {
         $this->message = 'You are not authorized to alter config.';
+    }
+}
+
+/**
+ * Exception used if an error occur while saving plugin configuration.
+ */
+class PluginConfigOrderException extends Exception
+{
+    /**
+     * Construct exception.
+     */
+    public function __construct()
+    {
+        $this->message = 'An error occurred while trying to save plugins loading order.';
     }
 }

--- a/application/Router.php
+++ b/application/Router.php
@@ -35,6 +35,10 @@ class Router
 
     public static $PAGE_LINKLIST = 'linklist';
 
+    public static $PAGE_PLUGINSADMIN = 'pluginadmin';
+
+    public static $PAGE_SAVE_PLUGINSADMIN = 'save_pluginadmin';
+
     /**
      * Reproducing renderPage() if hell, to avoid regression.
      *
@@ -110,6 +114,14 @@ class Router
 
         if (startswith($query, 'do='. self::$PAGE_IMPORT)) {
             return self::$PAGE_IMPORT;
+        }
+
+        if (startswith($query, 'do='. self::$PAGE_PLUGINSADMIN)) {
+            return self::$PAGE_PLUGINSADMIN;
+        }
+
+        if (startswith($query, 'do='. self::$PAGE_SAVE_PLUGINSADMIN)) {
+            return self::$PAGE_SAVE_PLUGINSADMIN;
         }
 
         return self::$PAGE_LINKLIST;

--- a/inc/plugin_admin.js
+++ b/inc/plugin_admin.js
@@ -1,0 +1,67 @@
+/**
+ * Change the position counter of a row.
+ *
+ * @param elem  Element Node to change.
+ * @param toPos int     New position.
+ */
+function changePos(elem, toPos)
+{
+    var elemName = elem.getAttribute('data-line')
+
+    elem.setAttribute('data-order', toPos);
+    var hiddenInput = document.querySelector('[name="order_'+ elemName +'"]');
+    hiddenInput.setAttribute('value', toPos);
+}
+
+/**
+ * Move a row up or down.
+ *
+ * @param pos  Element Node to move.
+ * @param move int     Move: +1 (down) or -1 (up)
+ */
+function changeOrder(pos, move)
+{
+    var newpos = parseInt(pos) + move;
+    var line = document.querySelector('[data-order="'+ pos +'"]');
+    var changeline = document.querySelector('[data-order="'+ newpos +'"]');
+    var parent = changeline.parentNode;
+
+    changePos(line, newpos);
+    changePos(changeline, parseInt(pos));
+    var changeItem = move < 0 ? changeline : changeline.nextSibling;
+    parent.insertBefore(line, changeItem);
+}
+
+/**
+ * Move a row up in the table.
+ *
+ * @param pos int row counter.
+ *
+ * @returns false
+ */
+function orderUp(pos)
+{
+    if (pos == 0) {
+        return false;
+    }
+    changeOrder(pos, -1);
+    return false;
+}
+
+/**
+ * Move a row down in the table.
+ *
+ * @param pos int row counter.
+ *
+ * @returns false
+ */
+function orderDown(pos)
+{
+    var lastpos = document.querySelector('[data-order]:last-child').getAttribute('data-order');
+    if (pos == lastpos) {
+        return false;
+    }
+
+    changeOrder(pos, +1);
+    return false;
+}

--- a/inc/shaarli.css
+++ b/inc/shaarli.css
@@ -1103,6 +1103,66 @@ ul.errors {
     float: left;
 }
 
+#pluginsadmin {
+    width: 80%;
+    padding: 20px 0 0 20px;
+}
+
+#pluginsadmin section {
+    padding: 20px 0;
+}
+
+#pluginsadmin .plugin_parameters {
+    margin: 10px 0;
+}
+
+#pluginsadmin h1 {
+    font-style: normal;
+}
+
+#pluginsadmin h2 {
+    font-size: 1.4em;
+    font-weight: bold;
+}
+
+#pluginsadmin table {
+    width: 100%;
+}
+
+#pluginsadmin table, #pluginsadmin th, #pluginsadmin td {
+    border-width: 1px 0;
+    border-style: solid;
+    border-color: #c0c0c0;
+}
+
+#pluginsadmin table th {
+    font-weight: bold;
+    padding: 10px 0;
+}
+
+#pluginsadmin table td {
+    padding: 5px 0;
+}
+
+#pluginsadmin input[type=submit] {
+    margin: 10px 0;
+}
+
+#pluginsadmin .plugin_parameter {
+    padding: 5px 0;
+    border-width: 1px 0;
+    border-style: solid;
+    border-color: #c0c0c0;
+}
+
+#pluginsadmin .float_label {
+    float: left;
+    width: 20%;
+}
+
+#pluginsadmin a {
+    color: black;
+}
 /* 404 page */
 .error-container {
 

--- a/plugins/addlink_toolbar/addlink_toolbar.meta
+++ b/plugins/addlink_toolbar/addlink_toolbar.meta
@@ -1,0 +1,1 @@
+description="Adds the addlink input on the linklist page."

--- a/plugins/archiveorg/archiveorg.meta
+++ b/plugins/archiveorg/archiveorg.meta
@@ -1,0 +1,1 @@
+description="For each link, add an Archive.org icon."

--- a/plugins/demo_plugin/demo_plugin.meta
+++ b/plugins/demo_plugin/demo_plugin.meta
@@ -1,0 +1,1 @@
+description="A demo plugin covering all use cases for template designers and plugin developers."

--- a/plugins/playvideos/playvideos.meta
+++ b/plugins/playvideos/playvideos.meta
@@ -1,0 +1,1 @@
+description="Add a button in the toolbar allowing to watch all videos."

--- a/plugins/qrcode/qrcode.meta
+++ b/plugins/qrcode/qrcode.meta
@@ -1,0 +1,1 @@
+description="For each link, add a QRCode icon ."

--- a/plugins/readityourself/readityourself.meta
+++ b/plugins/readityourself/readityourself.meta
@@ -1,0 +1,2 @@
+description="For each link, add a ReadItYourself icon to save the shaared URL."
+parameters=READITYOUSELF_URL;

--- a/plugins/readityourself/readityourself.php
+++ b/plugins/readityourself/readityourself.php
@@ -13,7 +13,7 @@ if (is_file(PluginManager::$PLUGINS_PATH . '/readityourself/config.php')) {
     include PluginManager::$PLUGINS_PATH . '/readityourself/config.php';
 }
 
-if (!isset($GLOBALS['plugins']['READITYOUSELF_URL'])) {
+if (empty($GLOBALS['plugins']['READITYOUSELF_URL'])) {
     $GLOBALS['plugin_errors'][] = 'Readityourself plugin error: '.
         'Please define "$GLOBALS[\'plugins\'][\'READITYOUSELF_URL\']" '.
         'in "plugins/readityourself/config.php" or in your Shaarli config.php file.';

--- a/plugins/wallabag/wallabag.meta
+++ b/plugins/wallabag/wallabag.meta
@@ -1,0 +1,2 @@
+description="For each link, add a Wallabag icon to save it in your instance."
+parameters="WALLABAG_URL"

--- a/plugins/wallabag/wallabag.php
+++ b/plugins/wallabag/wallabag.php
@@ -11,7 +11,7 @@ if (is_file(PluginManager::$PLUGINS_PATH . '/wallabag/config.php')) {
     include PluginManager::$PLUGINS_PATH . '/wallabag/config.php';
 }
 
-if (!isset($GLOBALS['plugins']['WALLABAG_URL'])) {
+if (empty($GLOBALS['plugins']['WALLABAG_URL'])) {
     $GLOBALS['plugin_errors'][] = 'Wallabag plugin error: '.
         'Please define "$GLOBALS[\'plugins\'][\'WALLABAG_URL\']" '.
         'in "plugins/wallabag/config.php" or in your Shaarli config.php file.';

--- a/tests/ConfigTest.php
+++ b/tests/ConfigTest.php
@@ -174,4 +174,113 @@ class ConfigTest extends PHPUnit_Framework_TestCase
         include self::$configFields['config']['CONFIG_FILE'];
         $this->assertEquals(self::$configFields['login'], $GLOBALS['login']);
     }
+
+    /**
+     * Test save_plugin_config with valid data.
+     *
+     * @throws PluginConfigOrderException
+     */
+    public function testSavePluginConfigValid()
+    {
+        $data = array(
+            'order_plugin1' => 2,   // no plugin related
+            'plugin2' => 0,         // new - at the end
+            'plugin3' => 0,         // 2nd
+            'order_plugin3' => 8,
+            'plugin4' => 0,         // 1st
+            'order_plugin4' => 5,
+        );
+
+        $expected = array(
+            'plugin3',
+            'plugin4',
+            'plugin2',
+        );
+
+        $out = save_plugin_config($data);
+        $this->assertEquals($expected, $out);
+    }
+
+    /**
+     * Test save_plugin_config with invalid data.
+     *
+     * @expectedException              PluginConfigOrderException
+     */
+    public function testSavePluginConfigInvalid()
+    {
+        $data = array(
+            'plugin2' => 0,
+            'plugin3' => 0,
+            'order_plugin3' => 0,
+            'plugin4' => 0,
+            'order_plugin4' => 0,
+        );
+
+        save_plugin_config($data);
+    }
+
+    /**
+     * Test save_plugin_config without data.
+     */
+    public function testSavePluginConfigEmpty()
+    {
+        $this->assertEquals(array(), save_plugin_config(array()));
+    }
+
+    /**
+     * Test validate_plugin_order with valid data.
+     */
+    public function testValidatePluginOrderValid()
+    {
+        $data = array(
+            'order_plugin1' => 2,
+            'plugin2' => 0,
+            'plugin3' => 0,
+            'order_plugin3' => 1,
+            'plugin4' => 0,
+            'order_plugin4' => 5,
+        );
+
+        $this->assertTrue(validate_plugin_order($data));
+    }
+
+    /**
+     * Test validate_plugin_order with invalid data.
+     */
+    public function testValidatePluginOrderInvalid()
+    {
+        $data = array(
+            'order_plugin1' => 2,
+            'order_plugin3' => 1,
+            'order_plugin4' => 1,
+        );
+
+        $this->assertFalse(validate_plugin_order($data));
+    }
+
+    /**
+     * Test load_plugin_parameter_values.
+     */
+    public function testLoadPluginParameterValues()
+    {
+        $plugins = array(
+            'plugin_name' => array(
+                'parameters' => array(
+                    'param1' => true,
+                    'param2' => false,
+                    'param3' => '',
+                )
+            )
+        );
+
+        $parameters = array(
+            'param1' => 'value1',
+            'param2' => 'value2',
+        );
+
+        $result = load_plugin_parameter_values($plugins, $parameters);
+        $this->assertEquals('value1', $result['plugin_name']['parameters']['param1']);
+        $this->assertEquals('value2', $result['plugin_name']['parameters']['param2']);
+        $this->assertEquals('', $result['plugin_name']['parameters']['param3']);
+    }
 }

--- a/tests/PluginManagerTest.php
+++ b/tests/PluginManagerTest.php
@@ -63,4 +63,23 @@ class PluginManagerTest extends PHPUnit_Framework_TestCase
 
         $pluginManager->load(array('nope', 'renope'));
     }
+
+    /**
+     * Test plugin metadata loading.
+     */
+    public function testGetPluginsMeta()
+    {
+        $pluginManager = PluginManager::getInstance();
+
+        PluginManager::$PLUGINS_PATH = self::$pluginPath;
+        $pluginManager->load(array(self::$pluginName));
+
+        $expectedParameters = array(
+            'pop' => '',
+            'hip' => '',
+        );
+        $meta = $pluginManager->getPluginsMeta();
+        $this->assertEquals('test plugin', $meta[self::$pluginName]['description']);
+        $this->assertEquals($expectedParameters, $meta[self::$pluginName]['parameters']);
+    }
 }

--- a/tests/plugins/test/test.meta
+++ b/tests/plugins/test/test.meta
@@ -1,0 +1,2 @@
+description="test plugin"
+parameters="pop;hip"

--- a/tpl/pluginsadmin.html
+++ b/tpl/pluginsadmin.html
@@ -1,0 +1,131 @@
+<!DOCTYPE html>
+<html>
+<head>{include="includes"}</head>
+<body>
+<div id="pageheader">
+  {include="page.header"}
+</div>
+
+<noscript>
+  <div>
+    <ul class="errors">
+      <li>You need to enable Javascript to change plugin loading order.</li>
+    </ul>
+  </div>
+  <div class="clear"></div>
+</noscript>
+
+<div id="pluginsadmin">
+  <form action="?do=save_pluginadmin" method="POST">
+    <section id="enabled_plugins">
+      <h1>Enabled Plugins</h1>
+
+      <div>
+        {if="count($enabledPlugins)==0"}
+          <p>No plugin enabled.</p>
+        {else}
+          <table id="plugin_table">
+            <thead>
+            <tr>
+              <th class="center">Disable</th>
+              <th class="center">Order</th>
+              <th>Name</th>
+              <th>Description</th>
+            </tr>
+            </thead>
+            <tbody>
+            {loop="$enabledPlugins"}
+              <tr data-line="{$key}" data-order="{$counter}">
+                <td class="center"><input type="checkbox" name="{$key}" checked="checked"></td>
+                <td class="center">
+                  <a href="#"
+                     onclick="return orderUp(this.parentNode.parentNode.getAttribute('data-order'));">
+                    ▲
+                  </a>
+                  <a href="#"
+                     onclick="return orderDown(this.parentNode.parentNode.getAttribute('data-order'));">
+                    ▼
+                  </a>
+                  <input type="hidden" name="order_{$key}" value="{$counter}">
+                </td>
+                <td>{$key}</td>
+                <td>{$value.description}</td>
+              </tr>
+            {/loop}
+            </tbody>
+          </table>
+        {/if}
+      </div>
+    </section>
+
+    <section id="disabled_plugins">
+      <h1>Disabled Plugins</h1>
+
+      <div>
+        {if="count($disabledPlugins)==0"}
+          <p>No plugin disabled.</p>
+        {else}
+          <table>
+            <tr>
+              <th class="center">Enable</th>
+              <th>Name</th>
+              <th>Description</th>
+            </tr>
+            {loop="$disabledPlugins"}
+              <tr>
+                <td class="center"><input type="checkbox" name="{$key}"></td>
+                <td>{$key}</td>
+                <td>{$value.description}</td>
+              </tr>
+            {/loop}
+          </table>
+        {/if}
+      </div>
+
+      <div class="center">
+        <input type="submit" value="Save"/>
+      </div>
+    </section>
+  </form>
+
+  <form action="?do=save_pluginadmin" method="POST">
+    <section id="plugin_parameters">
+      <h1>Enabled Plugin Parameters</h1>
+
+      <div>
+        {if="count($enabledPlugins)==0"}
+          <p>No plugin enabled.</p>
+        {else}
+          {loop="$enabledPlugins"}
+            {if="count($value.parameters) > 0"}
+              <div class="plugin_parameters">
+                <h2>{$key}</h2>
+                {loop="$value.parameters"}
+                  <div class="plugin_parameter">
+                    <div class="float_label">
+                      <label for="{$key}">
+                        <code>{$key}</code>
+                      </label>
+                    </div>
+                    <div class="float_input">
+                      <input name="{$key}" value="{$value}" id="{$key}"/>
+                    </div>
+                  </div>
+                {/loop}
+              </div>
+            {/if}
+          {/loop}
+        {/if}
+        <div class="center">
+          <input type="submit" name="parameters_form" value="Save"/>
+        </div>
+      </div>
+    </section>
+  </form>
+
+</div>
+{include="page.footer"}
+
+<script src="inc/plugin_admin.js#"></script>
+</body>
+</html>

--- a/tpl/tools.html
+++ b/tpl/tools.html
@@ -5,11 +5,18 @@
 <div id="pageheader">
 	{include="page.header"}
 	<div id="toolsdiv">
-		{if="!$GLOBALS['config']['OPEN_SHAARLI']"}<a href="?do=changepasswd"><b>Change password</b>  <span>: Change your password.</span></a><br><br>{/if}
-		<a href="?do=configure"><b>Configure your Shaarli</b> <span>:  Change Title, timezone...</span></a><br><br>
-		<a href="?do=changetag"><b>Rename/delete tags</b> <span>:  Rename or delete a tag in all links</span></a><br><br>
-		<a href="?do=import"><b>Import</b> <span>:  Import Netscape html bookmarks (as exported from Firefox, Chrome, Opera, delicious...)</span></a> <br><br>
-		<a href="?do=export"><b>Export</b> <span>:  Export Netscape html bookmarks (which can be imported in Firefox, Chrome, Opera, delicious...)</span></a><br><br>
+		<a href="?do=configure"><b>Configure your Shaarli</b><span>: Change Title, timezone...</span></a>
+		<br><br>
+		<a href="?do=pluginadmin"><b>Plugin administration</b><span>: Enable, disable and configure plugins.</span></a>
+    <br><br>
+		{if="!$GLOBALS['config']['OPEN_SHAARLI']"}<a href="?do=changepasswd"><b>Change password</b><span>: Change your password.</span></a>
+    <br><br>{/if}
+		<a href="?do=changetag"><b>Rename/delete tags</b><span>: Rename or delete a tag in all links</span></a>
+    <br><br>
+		<a href="?do=import"><b>Import</b><span>: Import Netscape html bookmarks (as exported from Firefox, Chrome, Opera, delicious...)</span></a>
+    <br><br>
+		<a href="?do=export"><b>Export</b><span>: Export Netscape html bookmarks (which can be imported in Firefox, Chrome, Opera, delicious...)</span></a>
+    <br><br>
 		<a class="smallbutton"
 		   onclick="return alertBookmarklet();"
 		   href="javascript:(


### PR DESCRIPTION
## Features

From the administration panel, users can:

 * See all plugin name and description available.
 * Enable/disable plugins.
 * Change loading order of their plugins (affects for example shaares icon order).
 * Affect and change plugins parameters.

## Plugin developer side

Every plugin needs a `<plugin_name>.meta` file which is in fact an `.ini` file (`KEY="VALUE"`) to be listed in plugin administration.

Each file contain two keys:

  * `description`: plugin description
  * `parameters`: user parameter names, separated by a `;`.

> Note: In PHP, `parse_ini_file()` seems to want strings to be between by quotes `"` in the ini file.

## Theme maintainers

There is a new page: `pluginsadmin.html`. It needs to be added to your theme. I'll update documentation later.

Aside from classic RainTPL loops, plugins order is handle by JavaScript. You can use `plugin_admin.js`, only if:

  * you're using a table.
  * you call `orderUp()` and `orderUp()` onclick on arrows.
  * you add `data-line` and `data-order` to your rows.

Otherwise, theme maintainers can use their own JS as long as this field is send by the form:

    <input type="hidden" name="order_{$key}" value="{$counter}">

## Other

  * In `tools.html`, moved "Change password" after Shaarli and plugins configuration.
  * Unit tests.
  * 2 new page in `Router`: `pluginadmin` and `save_pluginadmin`.

## Preview

![screenshot](http://i.imgur.com/vh7TFCq.png)

## TODO

- [x] Documentation!