### PR TITLE
json_encode removed

### DIFF
--- a/index.php
+++ b/index.php
@@ -2239,45 +2239,6 @@ function install()
     exit;
 }
 
-if (!function_exists('json_encode')) {
-    function json_encode($data) {
-        switch ($type = gettype($data)) {
-            case 'NULL':
-                return 'null';
-            case 'boolean':
-                return ($data ? 'true' : 'false');
-            case 'integer':
-            case 'double':
-            case 'float':
-                return $data;
-            case 'string':
-                return '"' . addslashes($data) . '"';
-            case 'object':
-                $data = get_object_vars($data);
-            case 'array':
-                $output_index_count = 0;
-                $output_indexed = array();
-                $output_associative = array();
-                foreach ($data as $key => $value) {
-                    $output_indexed[] = json_encode($value);
-                    $output_associative[] = json_encode($key) . ':' . json_encode($value);
-                    if ($output_index_count !== NULL && $output_index_count++ !== $key) {
-                        $output_index_count = NULL;
-                    }
-                }
-                if ($output_index_count !== NULL) {
-                    return '[' . implode(',', $output_indexed) . ']';
-                } else {
-                    return '{' . implode(',', $output_associative) . '}';
-                }
-            default:
-                return ''; // Not supported
-        }
-    }
-}
-
-
-
 /* Because some f*cking services like flickr require an extra HTTP request to get the thumbnail URL,
    I have deported the thumbnail URL code generation here, otherwise this would slow down page generation.
    The following function takes the URL a link (e.g. a flickr page) and return the proper thumbnail.


### PR DESCRIPTION
cleanup: remove json_encode() (built-in since PHP 5.2)
See http://php.net/manual/en/function.json-encode.php