### PR TITLE
QRCode plugin: use url instead of real_url

### DIFF
--- a/application/LinkDB.php
+++ b/application/LinkDB.php
@@ -17,8 +17,10 @@
  *  - private:  Is this link private? 0=no, other value=yes
  *  - tags:     tags attached to this entry (separated by spaces)
  *  - title     Title of the link
- *  - url       URL of the link. Can be absolute or relative.
+ *  - url       URL of the link. Used for displayable links (no redirector, relative, etc.).
+ *              Can be absolute or relative.
  *              Relative URLs are permalinks (e.g.'?m-ukcw')
+ *  - real_url  Absolute processed URL.
  *
  * Implements 3 interfaces:
  *  - ArrayAccess: behaves like an associative array;

--- a/plugins/qrcode/qrcode.php
+++ b/plugins/qrcode/qrcode.php
@@ -17,7 +17,11 @@ function hook_qrcode_render_linklist($data)
     $qrcode_html = file_get_contents(PluginManager::$PLUGINS_PATH . '/qrcode/qrcode.html');
 
     foreach ($data['links'] as &$value) {
-        $qrcode = sprintf($qrcode_html, $value['real_url'], $value['real_url'], PluginManager::$PLUGINS_PATH);
+        $qrcode = sprintf($qrcode_html,
+            urlencode($value['url']),
+            $value['url'],
+            PluginManager::$PLUGINS_PATH
+        );
         $value['link_plugin'][] = $qrcode;
     }
 

--- a/tests/plugins/PlugQrcodeTest.php
+++ b/tests/plugins/PlugQrcodeTest.php
@@ -30,7 +30,7 @@ class PlugQrcodeTest extends PHPUnit_Framework_TestCase
             'title' => $str,
             'links' => array(
                 array(
-                    'real_url' => $str,
+                    'url' => $str,
                 )
             )
         );
@@ -39,7 +39,7 @@ class PlugQrcodeTest extends PHPUnit_Framework_TestCase
         $link = $data['links'][0];
         // data shouldn't be altered
         $this->assertEquals($str, $data['title']);
-        $this->assertEquals($str, $link['real_url']);
+        $this->assertEquals($str, $link['url']);
 
         // plugin data
         $this->assertEquals(1, count($link['link_plugin']));


### PR DESCRIPTION
Fixes #414 and avoid usage of redirector in QRCode.

Also fixed a bug with URL encoding.