### PR TITLE
Add a .gitattributes to ease repository management

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,28 @@
+# Set default behavior
+*       text=auto eol=lf
+
+# Ensure sources are processed
+*.css   text
+*.html  text diff=html
+*.js    text
+*.md    text
+*.php   text diff=php
+
+# Do not alter images nor minified scripts
+*.ico           binary
+*.jpg           binary
+*.png           binary
+*.min.css       binary
+*.min.js        binary
+
+# Exclude from Git archives
+.gitattributes  export-ignore
+.gitignore      export-ignore
+.travis.yml     export-ignore
+composer.json   export-ignore
+doc/**/*.json   export-ignore
+doc/**/*.md     export-ignore
+Doxyfile        export-ignore
+Makefile        export-ignore
+phpunit.xml     export-ignore
+tests/          export-ignore


### PR DESCRIPTION
TL;DR: let Git cleverly handle line endings and diffs, tidy release archives a bit ;-)

Features:
- enforce LF (Unix) line endings
- omit dev/test resources & code from Git(Hub) archives
- treat minified resources (CSS, JS) as binaries to avoid cluttered diffs

Resources:
- http://git-scm.com/docs/gitattributes
- https://git-scm.com/book/en/v2/Customizing-Git-Git-Attributes
- https://help.github.com/articles/dealing-with-line-endings/
- http://adaptivepatchwork.com/2012/03/01/mind-the-end-of-your-line/
- https://github.com/Danimoth/gitattributes