### PR TITLE
Link filter refactoring

### DIFF
--- a/application/LinkDB.php
+++ b/application/LinkDB.php
@@ -351,7 +351,7 @@ You use the community supported version of the original Shaarli project, by Seba
      */
     public function filter($type, $request, $casesensitive = false, $privateonly = false) {
         $requestFilter = is_array($request) ? implode(' ', $request) : $request;
-        return $this->linkFilter->filter($type, $requestFilter, $casesensitive, $privateonly);
+        return $this->linkFilter->filter($type, trim($requestFilter), $casesensitive, $privateonly);
     }
 
     /**

--- a/application/LinkFilter.php
+++ b/application/LinkFilter.php
@@ -1,0 +1,259 @@
+<?php
+
+/**
+ * Class LinkFilter.
+ *
+ * Perform search and filter operation on link data list.
+ */
+class LinkFilter
+{
+    /**
+     * @var string permalinks.
+     */
+    public static $FILTER_HASH   = 'permalink';
+
+    /**
+     * @var string text search.
+     */
+    public static $FILTER_TEXT   = 'fulltext';
+
+    /**
+     * @var string tag filter.
+     */
+    public static $FILTER_TAG    = 'tags';
+
+    /**
+     * @var string filter by day.
+     */
+    public static $FILTER_DAY    = 'FILTER_DAY';
+
+    /**
+     * @var array all available links.
+     */
+    private $links;
+
+    /**
+     * @param array $links initialization.
+     */
+    public function __construct($links)
+    {
+        $this->links = $links;
+    }
+
+    /**
+     * Filter links according to parameters.
+     *
+     * @param string $type          Type of filter (eg. tags, permalink, etc.).
+     * @param string $request       Filter content.
+     * @param bool   $casesensitive Optional: Perform case sensitive filter if true.
+     * @param bool   $privateonly   Optional: Only returns private links if true.
+     *
+     * @return array filtered link list.
+     */
+    public function filter($type, $request, $casesensitive = false, $privateonly = false)
+    {
+        switch($type) {
+            case self::$FILTER_HASH:
+                return $this->filterSmallHash($request);
+                break;
+            case self::$FILTER_TEXT:
+                return $this->filterFulltext($request, $privateonly);
+                break;
+            case self::$FILTER_TAG:
+                return $this->filterTags($request, $casesensitive, $privateonly);
+                break;
+            case self::$FILTER_DAY:
+                return $this->filterDay($request);
+                break;
+            default:
+                return $this->noFilter($privateonly);
+        }
+    }
+
+    /**
+     * Unknown filter, but handle private only.
+     *
+     * @param bool $privateonly returns private link only if true.
+     *
+     * @return array filtered links.
+     */
+    private function noFilter($privateonly = false)
+    {
+        if (! $privateonly) {
+            krsort($this->links);
+            return $this->links;
+        }
+
+        $out = array();
+        foreach ($this->links as $value) {
+            if ($value['private']) {
+                $out[$value['linkdate']] = $value;
+            }
+        }
+
+        krsort($out);
+        return $out;
+    }
+
+    /**
+     * Returns the shaare corresponding to a smallHash.
+     *
+     * @param string $smallHash permalink hash.
+     *
+     * @return array $filtered array containing permalink data.
+     */
+    private function filterSmallHash($smallHash)
+    {
+        $filtered = array();
+        foreach ($this->links as $l) {
+            if ($smallHash == smallHash($l['linkdate'])) {
+                // Yes, this is ugly and slow
+                $filtered[$l['linkdate']] = $l;
+                return $filtered;
+            }
+        }
+        return $filtered;
+    }
+
+    /**
+     * Returns the list of links corresponding to a full-text search
+     *
+     * Searches:
+     *  - in the URLs, title and description;
+     *  - are case-insensitive.
+     *
+     * Example:
+     *    print_r($mydb->filterFulltext('hollandais'));
+     *
+     * mb_convert_case($val, MB_CASE_LOWER, 'UTF-8')
+     *  - allows to perform searches on Unicode text
+     *  - see https://github.com/shaarli/Shaarli/issues/75 for examples
+     *
+     * @param string $searchterms search query.
+     * @param bool   $privateonly return only private links if true.
+     *
+     * @return array search results.
+     */
+    private function filterFulltext($searchterms, $privateonly = false)
+    {
+        // FIXME: explode(' ',$searchterms) and perform a AND search.
+        // FIXME: accept double-quotes to search for a string "as is"?
+        $filtered = array();
+        $search = mb_convert_case($searchterms, MB_CASE_LOWER, 'UTF-8');
+        $explodedSearch = explode(' ', trim($search));
+        $keys = array('title', 'description', 'url', 'tags');
+
+        // Iterate over every stored link.
+        foreach ($this->links as $link) {
+            $found = false;
+
+            // ignore non private links when 'privatonly' is on.
+            if (! $link['private'] && $privateonly === true) {
+                continue;
+            }
+
+            // Iterate over searchable link fields.
+            foreach ($keys as $key) {
+                // Search full expression.
+                if (strpos(
+                    mb_convert_case($link[$key], MB_CASE_LOWER, 'UTF-8'),
+                    $search
+                ) !== false) {
+                    $found = true;
+                }
+
+                if ($found) {
+                    break;
+                }
+            }
+
+            if ($found) {
+                $filtered[$link['linkdate']] = $link;
+            }
+        }
+
+        krsort($filtered);
+        return $filtered;
+    }
+
+    /**
+     * Returns the list of links associated with a given list of tags
+     *
+     * You can specify one or more tags, separated by space or a comma, e.g.
+     *  print_r($mydb->filterTags('linux programming'));
+     *
+     * @param string $tags          list of tags separated by commas or blank spaces.
+     * @param bool   $casesensitive ignore case if false.
+     * @param bool   $privateonly   returns private links only.
+     *
+     * @return array filtered links.
+     */
+    public function filterTags($tags, $casesensitive = false, $privateonly = false)
+    {
+        $searchtags = $this->tagsStrToArray($tags, $casesensitive);
+        $filtered = array();
+
+        foreach ($this->links as $l) {
+            // ignore non private links when 'privatonly' is on.
+            if (! $l['private'] && $privateonly === true) {
+                continue;
+            }
+
+            $linktags = $this->tagsStrToArray($l['tags'], $casesensitive);
+
+            if (count(array_intersect($linktags, $searchtags)) == count($searchtags)) {
+                $filtered[$l['linkdate']] = $l;
+            }
+        }
+        krsort($filtered);
+        return $filtered;
+    }
+
+    /**
+     * Returns the list of articles for a given day, chronologically sorted
+     *
+     * Day must be in the form 'YYYYMMDD' (e.g. '20120125'), e.g.
+     *  print_r($mydb->filterDay('20120125'));
+     *
+     * @param string $day day to filter.
+     *
+     * @return array all link matching given day.
+     *
+     * @throws Exception if date format is invalid.
+     */
+    public function filterDay($day)
+    {
+        if (! checkDateFormat('Ymd', $day)) {
+            throw new Exception('Invalid date format');
+        }
+
+        $filtered = array();
+        foreach ($this->links as $l) {
+            if (startsWith($l['linkdate'], $day)) {
+                $filtered[$l['linkdate']] = $l;
+            }
+        }
+        ksort($filtered);
+        return $filtered;
+    }
+
+    /**
+     * Convert a list of tags (str) to an array. Also
+     * - handle case sensitivity.
+     * - accepts spaces commas as separator.
+     * - remove private tags for loggedout users.
+     *
+     * @param string $tags          string containing a list of tags.
+     * @param bool   $casesensitive will convert everything to lowercase if false.
+     *
+     * @return array filtered tags string.
+    */
+    public function tagsStrToArray($tags, $casesensitive)
+    {
+        // We use UTF-8 conversion to handle various graphemes (i.e. cyrillic, or greek)
+        $tagsOut = $casesensitive ? $tags : mb_convert_case($tags, MB_CASE_LOWER, 'UTF-8');
+        $tagsOut = str_replace(',', ' ', $tagsOut);
+
+        return explode(' ', trim($tagsOut));
+    }
+}

--- a/application/Utils.php
+++ b/application/Utils.php
@@ -72,12 +72,14 @@ function sanitizeLink(&$link)
 
 /**
  * Checks if a string represents a valid date
+
+ * @param string $format The expected DateTime format of the string
+ * @param string $string A string-formatted date
  *
- * @param string        a string-formatted date
- * @param format        the expected DateTime format of the string
- * @return              whether the string is a valid date
- * @see                 http://php.net/manual/en/class.datetime.php
- * @see                 http://php.net/manual/en/datetime.createfromformat.php
+ * @return bool whether the string is a valid date
+ *
+ * @see http://php.net/manual/en/class.datetime.php
+ * @see http://php.net/manual/en/datetime.createfromformat.php
  */
 function checkDateFormat($format, $string)
 {

--- a/index.php
+++ b/index.php
@@ -1298,12 +1298,14 @@ function renderPage()
 
         if (isset($params['searchtags'])) {
             $tags = explode(' ', $params['searchtags']);
-            $tags=array_diff($tags, array($_GET['removetag'])); // Remove value from array $tags.
-            if (count($tags)==0) {
+            // Remove value from array $tags.
+            $tags = array_diff($tags, array($_GET['removetag']));
+            $params['searchtags'] = implode(' ',$tags);
+
+            if (empty($params['searchtags'])) {
                 unset($params['searchtags']);
-            } else {
-                $params['searchtags'] = implode(' ',$tags);
             }
+
             unset($params['page']); // We also remove page (keeping the same page has no sense, since the results are different)
         }
         header('Location: ?'.http_build_query($params));

--- a/tests/LinkDBTest.php
+++ b/tests/LinkDBTest.php
@@ -302,217 +302,6 @@ class LinkDBTest extends PHPUnit_Framework_TestCase
     }
 
     /**
-     * Filter links using a tag
-     */
-    public function testFilterOneTag()
-    {
-        $this->assertEquals(
-            3,
-            sizeof(self::$publicLinkDB->filterTags('web', false))
-        );
-
-        $this->assertEquals(
-            4,
-            sizeof(self::$privateLinkDB->filterTags('web', false))
-        );
-    }
-
-    /**
-     * Filter links using a tag - case-sensitive
-     */
-    public function testFilterCaseSensitiveTag()
-    {
-        $this->assertEquals(
-            0,
-            sizeof(self::$privateLinkDB->filterTags('mercurial', true))
-        );
-
-        $this->assertEquals(
-            1,
-            sizeof(self::$privateLinkDB->filterTags('Mercurial', true))
-        );
-    }
-
-    /**
-     * Filter links using a tag combination
-     */
-    public function testFilterMultipleTags()
-    {
-        $this->assertEquals(
-            1,
-            sizeof(self::$publicLinkDB->filterTags('dev cartoon', false))
-        );
-
-        $this->assertEquals(
-            2,
-            sizeof(self::$privateLinkDB->filterTags('dev cartoon', false))
-        );
-    }
-
-    /**
-     * Filter links using a non-existent tag
-     */
-    public function testFilterUnknownTag()
-    {
-        $this->assertEquals(
-            0,
-            sizeof(self::$publicLinkDB->filterTags('null', false))
-        );
-    }
-
-    /**
-     * Return links for a given day
-     */
-    public function testFilterDay()
-    {
-        $this->assertEquals(
-            2,
-            sizeof(self::$publicLinkDB->filterDay('20121206'))
-        );
-
-        $this->assertEquals(
-            3,
-            sizeof(self::$privateLinkDB->filterDay('20121206'))
-        );
-    }
-
-    /**
-     * 404 - day not found
-     */
-    public function testFilterUnknownDay()
-    {
-        $this->assertEquals(
-            0,
-            sizeof(self::$publicLinkDB->filterDay('19700101'))
-        );
-
-        $this->assertEquals(
-            0,
-            sizeof(self::$privateLinkDB->filterDay('19700101'))
-        );
-    }
-
-    /**
-     * Use an invalid date format
-     * @expectedException              Exception
-     * @expectedExceptionMessageRegExp /Invalid date format/
-     */
-    public function testFilterInvalidDayWithChars()
-    {
-        self::$privateLinkDB->filterDay('Rainy day, dream away');
-    }
-
-    /**
-     * Use an invalid date format
-     * @expectedException              Exception
-     * @expectedExceptionMessageRegExp /Invalid date format/
-     */
-    public function testFilterInvalidDayDigits()
-    {
-        self::$privateLinkDB->filterDay('20');
-    }
-
-    /**
-     * Retrieve a link entry with its hash
-     */
-    public function testFilterSmallHash()
-    {
-        $links = self::$privateLinkDB->filterSmallHash('IuWvgA');
-
-        $this->assertEquals(
-            1,
-            sizeof($links)
-        );
-
-        $this->assertEquals(
-            'MediaGoblin',
-            $links['20130614_184135']['title']
-        );
-        
-    }
-
-    /**
-     * No link for this hash
-     */
-    public function testFilterUnknownSmallHash()
-    {
-        $this->assertEquals(
-            0,
-            sizeof(self::$privateLinkDB->filterSmallHash('Iblaah'))
-        );
-    }
-
-    /**
-     * Full-text search - result from a link's URL
-     */
-    public function testFilterFullTextURL()
-    {
-        $this->assertEquals(
-            2,
-            sizeof(self::$publicLinkDB->filterFullText('ars.userfriendly.org'))
-        );
-    }
-
-    /**
-     * Full-text search - result from a link's title only
-     */
-    public function testFilterFullTextTitle()
-    {
-        // use miscellaneous cases
-        $this->assertEquals(
-            2,
-            sizeof(self::$publicLinkDB->filterFullText('userfriendly -'))
-        );
-        $this->assertEquals(
-            2,
-            sizeof(self::$publicLinkDB->filterFullText('UserFriendly -'))
-        );
-        $this->assertEquals(
-            2,
-            sizeof(self::$publicLinkDB->filterFullText('uSeRFrIendlY -'))
-        );
-
-        // use miscellaneous case and offset
-        $this->assertEquals(
-            2,
-            sizeof(self::$publicLinkDB->filterFullText('RFrIendL'))
-        );
-    }
-
-    /**
-     * Full-text search - result from the link's description only
-     */
-    public function testFilterFullTextDescription()
-    {
-        $this->assertEquals(
-            1,
-            sizeof(self::$publicLinkDB->filterFullText('media publishing'))
-        );
-    }
-
-    /**
-     * Full-text search - result from the link's tags only
-     */
-    public function testFilterFullTextTags()
-    {
-        $this->assertEquals(
-            2,
-            sizeof(self::$publicLinkDB->filterFullText('gnu'))
-        );
-    }
-
-    /**
-     * Full-text search - result set from mixed sources
-     */
-    public function testFilterFullTextMixed()
-    {
-        $this->assertEquals(
-            2,
-            sizeof(self::$publicLinkDB->filterFullText('free software'))
-        );
-    }
-
-    /**
      * Test real_url without redirector.
      */
     public function testLinkRealUrlWithoutRedirector()
@@ -533,5 +322,29 @@ class LinkDBTest extends PHPUnit_Framework_TestCase
         foreach($db as $link) {
             $this->assertStringStartsWith($redirector, $link['real_url']);
         }
+    }
+
+    /**
+     * Test filter with string.
+     */
+    public function testFilterString()
+    {
+        $tags = 'dev cartoon';
+        $this->assertEquals(
+            2,
+            count(self::$privateLinkDB->filter(LinkFilter::$FILTER_TAG, $tags, true, false))
+        );
+    }
+
+    /**
+     * Test filter with string.
+     */
+    public function testFilterArray()
+    {
+        $tags = array('dev', 'cartoon');
+        $this->assertEquals(
+            2,
+            count(self::$privateLinkDB->filter(LinkFilter::$FILTER_TAG, $tags, true, false))
+        );
     }
 }

--- a/tests/LinkFilterTest.php
+++ b/tests/LinkFilterTest.php
@@ -1,0 +1,242 @@
+<?php
+
+require_once 'application/LinkFilter.php';
+
+/**
+ * Class LinkFilterTest.
+ */
+class LinkFilterTest extends PHPUnit_Framework_TestCase
+{
+    /**
+     * @var LinkFilter instance.
+     */
+    protected static $linkFilter;
+
+    /**
+     * Instanciate linkFilter with ReferenceLinkDB data.
+     */
+    public static function setUpBeforeClass()
+    {
+        $refDB = new ReferenceLinkDB();
+        self::$linkFilter = new LinkFilter($refDB->getLinks());
+    }
+
+    /**
+     * Blank filter.
+     */
+    public function testFilter()
+    {
+        $this->assertEquals(
+            6,
+            count(self::$linkFilter->filter('', ''))
+        );
+
+        // Private only.
+        $this->assertEquals(
+            2,
+            count(self::$linkFilter->filter('', '', false, true))
+        );
+    }
+
+    /**
+     * Filter links using a tag
+     */
+    public function testFilterOneTag()
+    {
+        $this->assertEquals(
+            4,
+            count(self::$linkFilter->filter(LinkFilter::$FILTER_TAG, 'web', false))
+        );
+
+        // Private only.
+        $this->assertEquals(
+            1,
+            count(self::$linkFilter->filter(LinkFilter::$FILTER_TAG, 'web', false, true))
+        );
+    }
+
+    /**
+     * Filter links using a tag - case-sensitive
+     */
+    public function testFilterCaseSensitiveTag()
+    {
+        $this->assertEquals(
+            0,
+            count(self::$linkFilter->filter(LinkFilter::$FILTER_TAG, 'mercurial', true))
+        );
+
+        $this->assertEquals(
+            1,
+            count(self::$linkFilter->filter(LinkFilter::$FILTER_TAG, 'Mercurial', true))
+        );
+    }
+
+    /**
+     * Filter links using a tag combination
+     */
+    public function testFilterMultipleTags()
+    {
+        $this->assertEquals(
+            2,
+            count(self::$linkFilter->filter(LinkFilter::$FILTER_TAG, 'dev cartoon', false))
+        );
+    }
+
+    /**
+     * Filter links using a non-existent tag
+     */
+    public function testFilterUnknownTag()
+    {
+        $this->assertEquals(
+            0,
+            count(self::$linkFilter->filter(LinkFilter::$FILTER_TAG, 'null', false))
+        );
+    }
+
+    /**
+     * Return links for a given day
+     */
+    public function testFilterDay()
+    {
+        $this->assertEquals(
+            3,
+            count(self::$linkFilter->filter(LinkFilter::$FILTER_DAY, '20121206'))
+        );
+    }
+
+    /**
+     * 404 - day not found
+     */
+    public function testFilterUnknownDay()
+    {
+        $this->assertEquals(
+            0,
+            count(self::$linkFilter->filter(LinkFilter::$FILTER_DAY, '19700101'))
+        );
+    }
+
+    /**
+     * Use an invalid date format
+     * @expectedException              Exception
+     * @expectedExceptionMessageRegExp /Invalid date format/
+     */
+    public function testFilterInvalidDayWithChars()
+    {
+        self::$linkFilter->filter(LinkFilter::$FILTER_DAY, 'Rainy day, dream away');
+    }
+
+    /**
+     * Use an invalid date format
+     * @expectedException              Exception
+     * @expectedExceptionMessageRegExp /Invalid date format/
+     */
+    public function testFilterInvalidDayDigits()
+    {
+        self::$linkFilter->filter(LinkFilter::$FILTER_DAY, '20');
+    }
+
+    /**
+     * Retrieve a link entry with its hash
+     */
+    public function testFilterSmallHash()
+    {
+        $links = self::$linkFilter->filter(LinkFilter::$FILTER_HASH, 'IuWvgA');
+
+        $this->assertEquals(
+            1,
+            count($links)
+        );
+
+        $this->assertEquals(
+            'MediaGoblin',
+            $links['20130614_184135']['title']
+        );
+    }
+
+    /**
+     * No link for this hash
+     */
+    public function testFilterUnknownSmallHash()
+    {
+        $this->assertEquals(
+            0,
+            count(self::$linkFilter->filter(LinkFilter::$FILTER_HASH, 'Iblaah'))
+        );
+    }
+
+    /**
+     * Full-text search - result from a link's URL
+     */
+    public function testFilterFullTextURL()
+    {
+        $this->assertEquals(
+            2,
+            count(self::$linkFilter->filter(LinkFilter::$FILTER_TEXT, 'ars.userfriendly.org'))
+        );
+    }
+
+    /**
+     * Full-text search - result from a link's title only
+     */
+    public function testFilterFullTextTitle()
+    {
+        // use miscellaneous cases
+        $this->assertEquals(
+            2,
+            count(self::$linkFilter->filter(LinkFilter::$FILTER_TEXT, 'userfriendly -'))
+        );
+        $this->assertEquals(
+            2,
+            count(self::$linkFilter->filter(LinkFilter::$FILTER_TEXT, 'UserFriendly -'))
+        );
+        $this->assertEquals(
+            2,
+            count(self::$linkFilter->filter(LinkFilter::$FILTER_TEXT, 'uSeRFrIendlY -'))
+        );
+
+        // use miscellaneous case and offset
+        $this->assertEquals(
+            2,
+            count(self::$linkFilter->filter(LinkFilter::$FILTER_TEXT, 'RFrIendL'))
+        );
+    }
+
+    /**
+     * Full-text search - result from the link's description only
+     */
+    public function testFilterFullTextDescription()
+    {
+        $this->assertEquals(
+            1,
+            count(self::$linkFilter->filter(LinkFilter::$FILTER_TEXT, 'media publishing'))
+        );
+    }
+
+    /**
+     * Full-text search - result from the link's tags only
+     */
+    public function testFilterFullTextTags()
+    {
+        $this->assertEquals(
+            2,
+            count(self::$linkFilter->filter(LinkFilter::$FILTER_TEXT, 'gnu'))
+        );
+
+        // Private only.
+        $this->assertEquals(
+            1,
+            count(self::$linkFilter->filter(LinkFilter::$FILTER_TEXT, 'web', false, true))
+        );
+    }
+
+    /**
+     * Full-text search - result set from mixed sources
+     */
+    public function testFilterFullTextMixed()
+    {
+        $this->assertEquals(
+            2,
+            count(self::$linkFilter->filter(LinkFilter::$FILTER_TEXT, 'free software'))
+        );
+    }
+}

--- a/tests/utils/ReferenceLinkDB.php
+++ b/tests/utils/ReferenceLinkDB.php
@@ -124,4 +124,9 @@ class ReferenceLinkDB
     {
         return $this->_privateCount;
     }
+
+    public function getLinks()
+    {
+        return $this->_links;
+    }
 }

--- a/tpl/linklist.html
+++ b/tpl/linklist.html
@@ -7,15 +7,24 @@
 <body>
 <div id="pageheader">
     {include="page.header"}
+
     <div id="headerform" class="search">
         <form method="GET" class="searchform" name="searchform">
-            <input type="text" tabindex="1" id="searchform_value" name="searchterm" placeholder="Search text" value="">
+            <input type="text" tabindex="1" id="searchform_value" name="searchterm" placeholder="Search text"
+               {if="!empty($search_crits) && $search_type=='fulltext'"}
+                    value="{$search_crits}"
+               {/if}
+            >
             <input type="submit" value="Search" class="bigbutton">
         </form>
         <form method="GET" class="tagfilter" name="tagfilter">
-            <input type="text" tabindex="2" name="searchtags" id="tagfilter_value" placeholder="Filter by tag" value=""
-                   autocomplete="off" class="awesomplete" data-multiple data-minChars="1"
-                   data-list="{loop="$tags"}{$key}, {/loop}">
+            <input type="text" tabindex="2" name="searchtags" id="tagfilter_value" placeholder="Filter by tag"
+                {if="!empty($search_crits) && $search_type=='tags'"}
+                    value="{function="implode(' ', $search_crits)"}"
+                {/if}
+                autocomplete="off" class="awesomplete" data-multiple data-minChars="1"
+                data-list="{loop="$tags"}{$key}, {/loop}">
+            >
             <input type="submit" value="Search" class="bigbutton">
         </form>
         {loop="$plugins_header.fields_toolbar"}

--- a/tpl/linklist.html
+++ b/tpl/linklist.html
@@ -53,7 +53,7 @@
             <div id="searchcriteria">{$result_count} results for tags <i>
             {loop="search_crits"}
                 <span class="linktag" title="Remove tag">
-                    <a href="?removetag={$value}">{$value} <span class="remove">x</span></a>
+                    <a href="?removetag={function="urlencode($value)"}">{$value} <span class="remove">x</span></a>
                 </span>
             {/loop}</i></div>
         {/if}


### PR DESCRIPTION
  * introduce class LinkFilter to handle link filter operation (and lighten LinkDB).
  * handle 'private only' in filtering.
  * update template to prefill search fields with current search terms.
  * coding style.
  * unit test (mostly move from LinkDB to LinkFilter).

PS: preparation for #358 #315 and 'AND' search.