### PR TITLE
Fixes #410 - Retrieve title fails in multiple cases

### DIFF
--- a/application/ApplicationUtils.php
+++ b/application/ApplicationUtils.php
@@ -19,7 +19,7 @@ class ApplicationUtils
      */
     public static function getLatestGitVersionCode($url, $timeout=2)
     {
-        list($headers, $data) = get_http_url($url, $timeout);
+        list($headers, $data) = get_http_response($url, $timeout);
 
         if (strpos($headers[0], '200 OK') === false) {
             error_log('Failed to retrieve ' . $url);

--- a/application/HttpUtils.php
+++ b/application/HttpUtils.php
@@ -13,7 +13,7 @@
  *  [1] = URL content (downloaded data)
  *
  * Example:
- *  list($headers, $data) = get_http_url('http://sebauvage.net/');
+ *  list($headers, $data) = get_http_response('http://sebauvage.net/');
  *  if (strpos($headers[0], '200 OK') !== false) {
  *      echo 'Data type: '.htmlspecialchars($headers['Content-Type']);
  *  } else {
@@ -24,31 +24,66 @@
  * @see http://php.net/manual/en/function.stream-context-create.php
  * @see http://php.net/manual/en/function.get-headers.php
  */
-function get_http_url($url, $timeout = 30, $maxBytes = 4194304)
+function get_http_response($url, $timeout = 30, $maxBytes = 4194304)
 {
+    $urlObj = new Url($url);
+    if (! filter_var($url, FILTER_VALIDATE_URL) || ! $urlObj->isHttp()) {
+        return array(array(0 => 'Invalid HTTP Url'), false);
+    }
+
     $options = array(
         'http' => array(
             'method' => 'GET',
             'timeout' => $timeout,
             'user_agent' => 'Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:23.0)'
-                         .' Gecko/20100101 Firefox/23.0'
+                         .' Gecko/20100101 Firefox/23.0',
+            'request_fulluri' => true,
         )
     );
 
     $context = stream_context_create($options);
+    stream_context_set_default($options);
+
+    list($headers, $finalUrl) = get_redirected_headers($urlObj->cleanup());
+    if (! $headers || strpos($headers[0], '200 OK') === false) {
+        return array($headers, false);
+    }
 
     try {
         // TODO: catch Exception in calling code (thumbnailer)
-        $content = file_get_contents($url, false, $context, -1, $maxBytes);
+        $content = file_get_contents($finalUrl, false, $context, -1, $maxBytes);
     } catch (Exception $exc) {
         return array(array(0 => 'HTTP Error'), $exc->getMessage());
     }
 
-    if (!$content) {
-        return array(array(0 => 'HTTP Error'), '');
+    return array($headers, $content);
+}
+
+/**
+ * Retrieve HTTP headers, following n redirections (temporary and permanent).
+ *
+ * @param string $url initial URL to reach.
+ * @param int $redirectionLimit max redirection follow..
+ *
+ * @return array
+ */
+function get_redirected_headers($url, $redirectionLimit = 3)
+{
+    $headers = get_headers($url, 1);
+
+    // Headers found, redirection found, and limit not reached.
+    if ($redirectionLimit-- > 0
+        && !empty($headers)
+        && (strpos($headers[0], '301') !== false || strpos($headers[0], '302') !== false)
+        && !empty($headers['Location'])) {
+
+        $redirection = is_array($headers['Location']) ? end($headers['Location']) : $headers['Location'];
+        if ($redirection != $url) {
+            return get_redirected_headers($redirection, $redirectionLimit);
+        }
     }
 
-    return array(get_headers($url, 1), $content);
+    return array($headers, $url);
 }
 
 /**

--- a/application/LinkUtils.php
+++ b/application/LinkUtils.php
@@ -1,0 +1,79 @@
+<?php
+
+/**
+ * Extract title from an HTML document.
+ *
+ * @param string $html HTML content where to look for a title.
+ *
+ * @return bool|string Extracted title if found, false otherwise.
+ */
+function html_extract_title($html)
+{
+    if (preg_match('!<title>(.*)</title>!is', $html, $matches)) {
+        return trim(str_replace("\n", ' ', $matches[1]));
+    }
+    return false;
+}
+
+/**
+ * Determine charset from downloaded page.
+ * Priority:
+ *   1. HTTP headers (Content type).
+ *   2. HTML content page (tag <meta charset>).
+ *   3. Use a default charset (default: UTF-8).
+ *
+ * @param array  $headers           HTTP headers array.
+ * @param string $htmlContent       HTML content where to look for charset.
+ * @param string $defaultCharset    Default charset to apply if other methods failed.
+ *
+ * @return string Determined charset.
+ */
+function get_charset($headers, $htmlContent, $defaultCharset = 'utf-8')
+{
+    if ($charset = headers_extract_charset($headers)) {
+        return $charset;
+    }
+
+    if ($charset = html_extract_charset($htmlContent)) {
+        return $charset;
+    }
+
+    return $defaultCharset;
+}
+
+/**
+ * Extract charset from HTTP headers if it's defined.
+ *
+ * @param array $headers HTTP headers array.
+ *
+ * @return bool|string Charset string if found (lowercase), false otherwise.
+ */
+function headers_extract_charset($headers)
+{
+    if (! empty($headers['Content-Type']) && strpos($headers['Content-Type'], 'charset=') !== false) {
+        preg_match('/charset="?([^; ]+)/i', $headers['Content-Type'], $match);
+        if (! empty($match[1])) {
+            return strtolower(trim($match[1]));
+        }
+    }
+
+    return false;
+}
+
+/**
+ * Extract charset HTML content (tag <meta charset>).
+ *
+ * @param string $html HTML content where to look for charset.
+ *
+ * @return bool|string Charset string if found, false otherwise.
+ */
+function html_extract_charset($html)
+{
+    // Get encoding specified in HTML header.
+    preg_match('#<meta .*charset="?([^">/]+)"? */?>#Usi', $html, $enc);
+    if (!empty($enc[1])) {
+        return strtolower($enc[1]);
+    }
+
+    return false;
+}

--- a/application/Url.php
+++ b/application/Url.php
@@ -118,7 +118,7 @@ class Url
      */
     public function __construct($url)
     {
-        $this->parts = parse_url($url);
+        $this->parts = parse_url(trim($url));
 
         if (!empty($url) && empty($this->parts['scheme'])) {
             $this->parts['scheme'] = 'http';
@@ -200,5 +200,14 @@ class Url
             return false;
         }
         return $this->parts['scheme'];
+    }
+
+    /**
+     * Test if the Url is an HTTP one.
+     *
+     * @return true is HTTP, false otherwise.
+     */
+    public function isHttp() {
+        return strpos(strtolower($this->parts['scheme']), 'http') !== false;
     }
 }

--- a/tests/HttpUtils/GetHttpUrlTest.php
+++ b/tests/HttpUtils/GetHttpUrlTest.php
@@ -6,7 +6,7 @@
 require_once 'application/HttpUtils.php';
 
 /**
- * Unitary tests for get_http_url()
+ * Unitary tests for get_http_response()
  */
 class GetHttpUrlTest extends PHPUnit_Framework_TestCase
 {
@@ -15,12 +15,15 @@ class GetHttpUrlTest extends PHPUnit_Framework_TestCase
      */
     public function testGetInvalidLocalUrl()
     {
-        list($headers, $content) = get_http_url('/non/existent', 1);
-        $this->assertEquals('HTTP Error', $headers[0]);
-        $this->assertRegexp(
-            '/failed to open stream: No such file or directory/',
-            $content
-        );
+        // Local
+        list($headers, $content) = get_http_response('/non/existent', 1);
+        $this->assertEquals('Invalid HTTP Url', $headers[0]);
+        $this->assertFalse($content);
+
+        // Non HTTP
+        list($headers, $content) = get_http_response('ftp://save.tld/mysave', 1);
+        $this->assertEquals('Invalid HTTP Url', $headers[0]);
+        $this->assertFalse($content);
     }
 
     /**
@@ -28,11 +31,8 @@ class GetHttpUrlTest extends PHPUnit_Framework_TestCase
      */
     public function testGetInvalidRemoteUrl()
     {
-        list($headers, $content) = get_http_url('http://non.existent', 1);
-        $this->assertEquals('HTTP Error', $headers[0]);
-        $this->assertRegexp(
-            '/Name or service not known/',
-            $content
-        );
+        list($headers, $content) = @get_http_response('http://non.existent', 1);
+        $this->assertFalse($headers);
+        $this->assertFalse($content);
     }
 }

--- a/tests/LinkUtilsTest.php
+++ b/tests/LinkUtilsTest.php
@@ -1,0 +1,85 @@
+<?php
+
+require_once 'application/LinkUtils.php';
+
+/**
+* Class LinkUtilsTest.
+*/
+class LinkUtilsTest extends PHPUnit_Framework_TestCase
+{
+    /**
+     * Test html_extract_title() when the title is found.
+     */
+    public function testHtmlExtractExistentTitle()
+    {
+        $title = 'Read me please.';
+        $html = '<html><meta>stuff</meta><title>'. $title .'</title></html>';
+        $this->assertEquals($title, html_extract_title($html));
+    }
+
+    /**
+     * Test html_extract_title() when the title is not found.
+     */
+    public function testHtmlExtractNonExistentTitle()
+    {
+        $html = '<html><meta>stuff</meta></html>';
+        $this->assertFalse(html_extract_title($html));
+    }
+
+    /**
+     * Test get_charset() with all priorities.
+     */
+    public function testGetCharset()
+    {
+        $headers = array('Content-Type' => 'text/html; charset=Headers');
+        $html = '<html><meta>stuff</meta><meta charset="Html"/></html>';
+        $default = 'default';
+        $this->assertEquals('headers', get_charset($headers, $html, $default));
+        $this->assertEquals('html', get_charset(array(), $html, $default));
+        $this->assertEquals($default, get_charset(array(), '', $default));
+        $this->assertEquals('utf-8', get_charset(array(), ''));
+    }
+
+    /**
+     * Test headers_extract_charset() when the charset is found.
+     */
+    public function testHeadersExtractExistentCharset()
+    {
+        $charset = 'x-MacCroatian';
+        $headers = array('Content-Type' => 'text/html; charset='. $charset);
+        $this->assertEquals(strtolower($charset), headers_extract_charset($headers));
+    }
+
+    /**
+     * Test headers_extract_charset() when the charset is not found.
+     */
+    public function testHeadersExtractNonExistentCharset()
+    {
+        $headers = array();
+        $this->assertFalse(headers_extract_charset($headers));
+
+        $headers = array('Content-Type' => 'text/html');
+        $this->assertFalse(headers_extract_charset($headers));
+    }
+
+    /**
+     * Test html_extract_charset() when the charset is found.
+     */
+    public function testHtmlExtractExistentCharset()
+    {
+        $charset = 'x-MacCroatian';
+        $html = '<html><meta>stuff2</meta><meta charset="'. $charset .'"/></html>';
+        $this->assertEquals(strtolower($charset), html_extract_charset($html));
+    }
+
+    /**
+     * Test html_extract_charset() when the charset is not found.
+     */
+    public function testHtmlExtractNonExistentCharset()
+    {
+        $html = '<html><meta>stuff</meta></html>';
+        $this->assertFalse(html_extract_charset($html));
+        $html = '<html><meta>stuff</meta><meta charset=""/></html>';
+        $this->assertFalse(html_extract_charset($html));
+    }
+}

--- a/tests/Url/UrlTest.php
+++ b/tests/Url/UrlTest.php
@@ -156,4 +156,22 @@ class UrlTest extends PHPUnit_Framework_TestCase
         $this->assertEquals($strOn, add_trailing_slash($strOn));
         $this->assertEquals($strOn, add_trailing_slash($strOff));
     }
+
+    /**
+     * Test valid HTTP url.
+     */
+    function testUrlIsHttp()
+    {
+        $url = new Url(self::$baseUrl);
+        $this->assertTrue($url->isHttp());
+    }
+
+    /**
+     * Test non HTTP url.
+     */
+    function testUrlIsNotHttp()
+    {
+        $url = new Url('ftp://save.tld/mysave');
+        $this->assertFalse($url->isHttp());
+    }
 }


### PR DESCRIPTION
  * `get_http_url()` renamed to `get_http_response()`.
  * Use the same HTTP context to retrieve response headers and content.
  * Follow HTTP 301 and 302 redirections to retrieve the title (default max 3 redirections).
  * Add `LinkUtils` to extract titles and charset.
  * Try to retrieve charset from HTTP headers first (new), then HTML content.
  * Use mb_string to re-encode title if necessary.