### PR TITLE
fix: use PHP_EOL for carriage returns in file logs

### DIFF
--- a/application/Utils.php
+++ b/application/Utils.php
@@ -16,7 +16,7 @@ function logm($logFile, $clientIp, $message)
 {
     file_put_contents(
         $logFile,
-        date('Y/m/d H:i:s').' - '.$clientIp.' - '.strval($message).'\n',
+        date('Y/m/d H:i:s').' - '.$clientIp.' - '.strval($message).PHP_EOL,
         FILE_APPEND
     );
 }

--- a/tests/UtilsTest.php
+++ b/tests/UtilsTest.php
@@ -51,7 +51,7 @@ class UtilsTest extends PHPUnit_Framework_TestCase
     protected function getLastLogEntry()
     {
         $logFile = file(self::$testLogFile);
-        return explode(' - ', trim(array_pop($logFile), '\n'));
+        return explode(' - ', trim(array_pop($logFile), PHP_EOL));
     }
 
     /**


### PR DESCRIPTION
Relates to #436