### PR TITLE
Add exclusion in tag search

### DIFF
--- a/application/LinkDB.php
+++ b/application/LinkDB.php
@@ -340,7 +340,7 @@ You use the community supported version of the original Shaarli project, by Seba
      *
      * @return array filtered links
      */
-    public function filter($type, $request, $casesensitive = false, $privateonly = false)
+    public function filter($type = '', $request = '', $casesensitive = false, $privateonly = false)
     {
         $linkFilter = new LinkFilter($this->_links);
         $requestFilter = is_array($request) ? implode(' ', $request) : $request;

--- a/application/Updater.php
+++ b/application/Updater.php
@@ -131,6 +131,21 @@ class Updater
 
         return true;
     }
+
+    /**
+     * Rename tags starting with a '-' to work with tag exclusion search.
+     */
+    public function updateMethodRenameDashTags()
+    {
+        $linklist = $this->linkDB->filter();
+        foreach ($linklist as $link) {
+            $link['tags'] = preg_replace('/(^| )\-/', '$1', $link['tags']);
+            $link['tags'] = implode(' ', array_unique(LinkFilter::tagsStrToArray($link['tags'], true)));
+            $this->linkDB[$link['linkdate']] = $link;
+        }
+        $this->linkDB->savedb($this->config['config']['PAGECACHE']);
+        return true;
+    }
 }
 
 /**

--- a/index.php
+++ b/index.php
@@ -1558,6 +1558,8 @@ function renderPage()
         }
         // Remove multiple spaces.
         $tags = trim(preg_replace('/\s\s+/', ' ', $_POST['lf_tags']));
+        // Remove first '-' char in tags.
+        $tags = preg_replace('/(^| )\-/', '$1', $tags);
         // Remove duplicates.
         $tags = implode(' ', array_unique(explode(' ', $tags)));
         $linkdate = $_POST['lf_linkdate'];

--- a/tests/LinkDBTest.php
+++ b/tests/LinkDBTest.php
@@ -276,7 +276,8 @@ class LinkDBTest extends PHPUnit_Framework_TestCase
                 'media' => 1,
                 'software' => 1,
                 'stallman' => 1,
-                'free' => 1
+                'free' => 1,
+                '-exclude' => 1,
             ),
             self::$publicLinkDB->allTags()
         );
@@ -295,7 +296,8 @@ class LinkDBTest extends PHPUnit_Framework_TestCase
                 'html' => 1,
                 'w3c' => 1,
                 'css' => 1,
-                'Mercurial' => 1
+                'Mercurial' => 1,
+                '-exclude' => 1,
             ),
             self::$privateLinkDB->allTags()
         );

--- a/tests/LinkFilterTest.php
+++ b/tests/LinkFilterTest.php
@@ -254,4 +254,20 @@ class LinkFilterTest extends PHPUnit_Framework_TestCase
             count(self::$linkFilter->filter(LinkFilter::$FILTER_TEXT, 'free software'))
         );
     }
+
+    /**
+     * Tag search with exclusion.
+     */
+    public function testTagFilterWithExclusion()
+    {
+        $this->assertEquals(
+            1,
+            count(self::$linkFilter->filter(LinkFilter::$FILTER_TAG, 'gnu -free'))
+        );
+
+        $this->assertEquals(
+            5,
+            count(self::$linkFilter->filter(LinkFilter::$FILTER_TAG, '-free'))
+        );
+    }
 }

--- a/tests/Updater/UpdaterTest.php
+++ b/tests/Updater/UpdaterTest.php
@@ -14,6 +14,11 @@ class UpdaterTest extends PHPUnit_Framework_TestCase
     private static $configFields;
 
     /**
+     * @var string Path to test datastore.
+     */
+    protected static $testDatastore = 'sandbox/datastore.php';
+
+    /**
      * Executed before each test.
      */
     public function setUp()
@@ -31,6 +36,7 @@ class UpdaterTest extends PHPUnit_Framework_TestCase
             'config' => array(
                 'CONFIG_FILE' => 'tests/Updater/config.php',
                 'DATADIR' => 'tests/Updater',
+                'PAGECACHE' => 'sandbox/pagecache',
                 'config1' => 'config1data',
                 'config2' => 'config2data',
             )
@@ -223,5 +229,17 @@ class UpdaterTest extends PHPUnit_Framework_TestCase
 
         include self::$configFields['config']['CONFIG_FILE'];
         $this->assertEquals(self::$configFields['login'], $GLOBALS['login']);
+    }
+
+    public function testRenameDashTags()
+    {
+        $refDB = new ReferenceLinkDB();
+        $refDB->write(self::$testDatastore);
+        $linkDB = new LinkDB(self::$testDatastore, true, false);
+        $this->assertEmpty($linkDB->filter(LinkFilter::$FILTER_TAG, 'exclude'));
+        $updater = new Updater(array(), self::$configFields, $linkDB, true);
+        $updater->updateMethodRenameDashTags();
+        var_dump($linkDB->filter(LinkFilter::$FILTER_TAG, 'exclude'));
+        $this->assertNotEmpty($linkDB->filter(LinkFilter::$FILTER_TAG, 'exclude'));
     }
 }

--- a/tests/utils/ReferenceLinkDB.php
+++ b/tests/utils/ReferenceLinkDB.php
@@ -19,7 +19,7 @@ class ReferenceLinkDB
             'Richard Stallman and the Free Software Revolution',
             0,
             '20150310_114633',
-            'free gnu software stallman'
+            'free gnu software stallman -exclude'
         );
 
         $this->addLink(


### PR DESCRIPTION
> This PR is based on #442. Please review the second commit only.

  * Searching '-mytag' will now exlude all shaares with 'mytag' tag.
  * All tags starting with a '-' are renamed without it (through the Updater).
  * Unit tests.

Minor code changes:

 * LinkDB->filter() can now take no parameters (get all link depending on logged status).
 * tagsStrToArray() is now static and filters blank tags.

Partial fix of #358 