### PR TITLE
Private/Hidden tags

### DIFF
--- a/application/LinkDB.php
+++ b/application/LinkDB.php
@@ -264,8 +264,15 @@ You use the community supported version of the original Shaarli project, by Seba
         foreach ($this->_links as &$link) {
             // Keep the list of the mapping URLs-->linkdate up-to-date.
             $this->_urls[$link['url']] = $link['linkdate'];
+
             // Sanitize data fields.
             sanitizeLink($link);
+
+            // Remove private tags if the user is not logged in.
+            if (! $this->_loggedIn) {
+                $link['tags'] = preg_replace('/(^| )\.[^($| )]+/', '', $link['tags']);
+            }
+
             // Do not use the redirector for internal links (Shaarli note URL starting with a '?').
             if (!empty($this->_redirector) && !startsWith($link['url'], '?')) {
                 $link['real_url'] = $this->_redirector . urlencode($link['url']);

--- a/tests/LinkDBTest.php
+++ b/tests/LinkDBTest.php
@@ -298,6 +298,7 @@ class LinkDBTest extends PHPUnit_Framework_TestCase
                 'css' => 1,
                 'Mercurial' => 1,
                 '-exclude' => 1,
+                '.hidden' => 1,
             ),
             self::$privateLinkDB->allTags()
         );
@@ -347,6 +348,24 @@ class LinkDBTest extends PHPUnit_Framework_TestCase
         $this->assertEquals(
             2,
             count(self::$privateLinkDB->filter(LinkFilter::$FILTER_TAG, $tags, true, false))
+        );
+    }
+
+    /**
+     * Test hidden tags feature:
+     *  tags starting with a dot '.' are only visible when logged in.
+     */
+    public function testHiddenTags()
+    {
+        $tags = '.hidden';
+        $this->assertEquals(
+            1,
+            count(self::$privateLinkDB->filter(LinkFilter::$FILTER_TAG, $tags, true, false))
+        );
+
+        $this->assertEquals(
+            0,
+            count(self::$publicLinkDB->filter(LinkFilter::$FILTER_TAG, $tags, true, false))
         );
     }
 }

--- a/tests/Updater/UpdaterTest.php
+++ b/tests/Updater/UpdaterTest.php
@@ -239,7 +239,6 @@ class UpdaterTest extends PHPUnit_Framework_TestCase
         $this->assertEmpty($linkDB->filter(LinkFilter::$FILTER_TAG, 'exclude'));
         $updater = new Updater(array(), self::$configFields, $linkDB, true);
         $updater->updateMethodRenameDashTags();
-        var_dump($linkDB->filter(LinkFilter::$FILTER_TAG, 'exclude'));
         $this->assertNotEmpty($linkDB->filter(LinkFilter::$FILTER_TAG, 'exclude'));
     }
 }

--- a/tests/utils/ReferenceLinkDB.php
+++ b/tests/utils/ReferenceLinkDB.php
@@ -28,7 +28,7 @@ class ReferenceLinkDB
             'A free software media publishing platform',
             0,
             '20130614_184135',
-            'gnu media web'
+            'gnu media web .hidden'
         );
 
         $this->addLink(


### PR DESCRIPTION
Tags starting with a dot '.' are now private.
They can only be seen and searched when logged in.

Fixes #315 
<sub>it was easier than I thought</sub>

Note: gonna need rebase with #442 and #446.