### PR TITLE
Implemented a little more sophisticated searching

### DIFF
--- a/application/LinkFilter.php
+++ b/application/LinkFilter.php
@@ -136,16 +136,21 @@ class LinkFilter
      */
     private function filterFulltext($searchterms, $privateonly = false)
     {
-        // FIXME: explode(' ',$searchterms) and perform a AND search.
-        // FIXME: accept double-quotes to search for a string "as is"?
-        $filtered = array();
-        $search = mb_convert_case($searchterms, MB_CASE_LOWER, 'UTF-8');
+        $search = mb_convert_case(html_entity_decode($searchterms), MB_CASE_LOWER, 'UTF-8');
         $explodedSearch = explode(' ', trim($search));
         $keys = array('title', 'description', 'url', 'tags');
+        $found = true;
+        $searchExactPhrase = false;
 
+        // Check if we're using double-quotes to search for the exact string
+        if ($search[0] == '"' && $search[strlen($search) - 1] == '"') {
+            $searchExactPhrase = true;
+            
+            // Remove the double-quotes as they are not what we search for
+            $search = substr($search, 1, -1);
+        }
         // Iterate over every stored link.
         foreach ($this->links as $link) {
-            $found = false;
 
             // ignore non private links when 'privatonly' is on.
             if (! $link['private'] && $privateonly === true) {
@@ -154,19 +159,39 @@ class LinkFilter
 
             // Iterate over searchable link fields.
             foreach ($keys as $key) {
-                // Search full expression.
-                if (strpos(
-                    mb_convert_case($link[$key], MB_CASE_LOWER, 'UTF-8'),
-                    $search
-                ) !== false) {
-                    $found = true;
-                }
+                // Be optimistic
+                $found = true;
+                
+                $haystack = mb_convert_case($link[$key], MB_CASE_LOWER, 'UTF-8');
 
+                // When searching for the exact phrase
+                if ( $searchExactPhrase) {
+                	// check if it's in the haystack
+                	if (strpos($haystack, $search) !== false) {
+                        // found it in this key, no need to look at other keys
+                        break;
+                	}
+                	else {
+                		$found = false;
+                	}
+                }
+                else {
+                    // Iterate over keywords, if keyword is not found,
+                    // no need to check for the others. We want all or nothing.
+                    foreach($explodedSearch as $keyword) {
+                         if(strpos($haystack, $keyword) === false) {
+                           $found = false;
+                           break;
+                      }
+                    }
+                }
+                
+                // One of the fields of the link matches, no need to check the other.
                 if ($found) {
                     break;
                 }
             }
-
+            
             if ($found) {
                 $filtered[$link['linkdate']] = $link;
             }

--- a/tests/LinkFilterTest.php
+++ b/tests/LinkFilterTest.php
@@ -173,6 +173,11 @@ class LinkFilterTest extends PHPUnit_Framework_TestCase
             2,
             count(self::$linkFilter->filter(LinkFilter::$FILTER_TEXT, 'ars.userfriendly.org'))
         );
+        
+        $this->assertEquals(
+            2,
+            count(self::$linkFilter->filter(LinkFilter::$FILTER_TEXT, 'ars org'))
+        );
     }
 
     /**
@@ -208,8 +213,18 @@ class LinkFilterTest extends PHPUnit_Framework_TestCase
     {
         $this->assertEquals(
             1,
-            count(self::$linkFilter->filter(LinkFilter::$FILTER_TEXT, 'media publishing'))
+            count(self::$linkFilter->filter(LinkFilter::$FILTER_TEXT, 'publishing media'))
         );
+        
+        $this->assertEquals(
+            1,
+            count(self::$linkFilter->filter(LinkFilter::$FILTER_TEXT, 'mercurial w3c'))
+        );
+        
+        $this->assertEquals(
+            2,
+            count(self::$linkFilter->filter(LinkFilter::$FILTER_TEXT, '"free software"'))
+        );        
     }
 
     /**


### PR DESCRIPTION
This implements two ways of searching through Shaarlies link archives:

- exact phrase enclosed in double-quotes, like `"foo bar baz"`
- all words in no particular order, like `foo bar baz`

It is in reference to issue #435.

The following examples refer to the data in the [demo installation](http://shaarlidemo.tuxfamily.org/Shaarli/). The demo installation does not have this search enabled.

Examples.
Searching for `learn use` finds the "Welcome to Shaarli!" note. Think of this search as `learn AND use`.
Searching for `"learn use"` finds nothing because it searches for this exact phrase, while `"learn how to use"` finds the very same note.

Searching is still limited to individual fields of an item. Searching for `clone public` does not find the "Welcome to Shaarli!" note, since `clone` appears in the title, while `public` appears in the description.

Note: This changes the default search behavior of Shaarli. Right now, Shaarli will always search for the exact phrase, no matter if the keywords are enclosed in double-quotes or not. With this patch, it will default to searching for all words in no particular order with the old way only happening when enclosing the keywords in double quotes.