### PR TITLE
Add a default value to ENABLE_UPDATECHECK to avoid unnecessary warning

### DIFF
--- a/index.php
+++ b/index.php
@@ -50,6 +50,9 @@ $GLOBALS['config']['LOG_FILE'] = $GLOBALS['config']['DATADIR'].'/log.txt';
 // For updates check of Shaarli
 $GLOBALS['config']['UPDATECHECK_FILENAME'] = $GLOBALS['config']['DATADIR'].'/lastupdatecheck.txt';
 
+// Set ENABLE_UPDATECHECK to disabled by default.
+$GLOBALS['config']['ENABLE_UPDATECHECK'] = false;
+
 // RainTPL cache directory (keep the trailing slash!)
 $GLOBALS['config']['RAINTPL_TMP'] = 'tmp/';
 // Raintpl template directory (keep the trailing slash!)


### PR DESCRIPTION
If the checkbox is not set at installation, the key is never saved in `config.php` so it raises a warning.