### PR TITLE
Initialize plugin parameters array to avoid unnecessary warning.

### DIFF
--- a/index.php
+++ b/index.php
@@ -111,7 +111,8 @@ $GLOBALS['config']['UPDATECHECK_INTERVAL'] = 86400;
 //);
 $GLOBALS['config']['ENABLED_PLUGINS'] = array('qrcode');
 
-//$GLOBALS['plugins']['WALLABAG_URL'] = 'https://demo.wallabag.org/';
+// Initialize plugin parameters array.
+$GLOBALS['plugins'] = array();
 
 // PubSubHubbub support. Put an empty string to disable, or put your hub url here to enable.
 $GLOBALS['config']['PUBSUBHUB_URL'] = '';


### PR DESCRIPTION
Fixes a bug where accessing `$GLOBALS['plugins']` raised a warning if no previous plugin settings has been set.