### PR TITLE
Fixes #456: Tag cloud does not sort tags (fully) alphabetically

### DIFF
--- a/index.php
+++ b/index.php
@@ -1203,11 +1203,25 @@ function renderPage()
 
         // We sort tags alphabetically, then choose a font size according to count.
         // First, find max value.
-        $maxcount=0; foreach($tags as $key=>$value) $maxcount=max($maxcount,$value);
-        ksort($tags);
+        $maxcount = 0;
+        foreach ($tags as $value) {
+            $maxcount = max($maxcount, $value);
+        }
+
+        // Sort tags alphabetically: case insensitive, support locale if avalaible.
+        uksort($tags, function($a, $b) {
+            // Collator is part of PHP intl.
+            if (class_exists('Collator')) {
+                $c = new Collator(setlocale(LC_ALL, 0));
+                return $c->compare($a, $b);
+            } else {
+                return strcasecmp($a, $b);
+            }
+        });
+
         $tagList=array();
         foreach($tags as $key=>$value)
-	// Tag font size scaling: default 15 and 30 logarithm bases affect scaling, 22 and 6 are arbitrary font sizes for max and min sizes.
+        // Tag font size scaling: default 15 and 30 logarithm bases affect scaling, 22 and 6 are arbitrary font sizes for max and min sizes.
         {
             $tagList[$key] = array('count'=>$value,'size'=>log($value, 15) / log($maxcount, 30) * (22-6) + 6);
         }


### PR DESCRIPTION
  * Use Collator class to sort tags using the locale (in PECL intl, included in most PHP installation).
  * Use strcasecmp if Collator is not found.

Both sorts are case insensitive.

#456 