### PR TITLE
Fixes #468: don't trim description

### DIFF
--- a/index.php
+++ b/index.php
@@ -1588,7 +1588,7 @@ function renderPage()
         $link = array(
             'title' => trim($_POST['lf_title']),
             'url' => $url,
-            'description' => trim($_POST['lf_description']),
+            'description' => $_POST['lf_description'],
             'private' => (isset($_POST['lf_private']) ? 1 : 0),
             'linkdate' => $linkdate,
             'tags' => str_replace(',', ' ', $tags)


### PR DESCRIPTION
Spaces at the start of shaares can be intended. Eg: markdown plugin.

#468 

\+ coding style