### PR TITLE
Write in plugin configuration files through pluginsadmin.html

### DIFF
--- a/application/Config.php
+++ b/application/Config.php
@@ -74,6 +74,41 @@ function writeConfig($config, $isLoggedIn)
 }
 
 /**
+ * Write plugin settings in its specific config.php file if it exists.
+ *
+ * @param string $plugin   Name of the plugin.
+ * @param array  $settings The settings to save:
+ *                              - key: setting name.
+ *                              - value: setting value.
+ *
+ * @return boolean true if the settings are saved, false otherwise.
+ *
+ * @throws Exception File write failed.
+ */
+function write_plugin_config($plugin, $settings)
+{
+    $settingsFile = PluginManager::$PLUGINS_PATH . '/' . $plugin . '/config.php';
+    if (! is_file($settingsFile) || ! is_writable($settingsFile)) {
+        return false;
+    }
+
+    $configStr = '<?php '. PHP_EOL;
+    foreach ($settings as $key => $value) {
+        $configStr .= '$GLOBALS[\'plugins\'][\''. $key .'\'] = '. var_export($value, true) .';'. PHP_EOL;
+    }
+
+    if (!file_put_contents($settingsFile, $configStr)
+        || strcmp(file_get_contents($settingsFile), $configStr) != 0
+    ) {
+        throw new Exception(
+            'Shaarli couldn\'t write the plugin settings.
+            Please make sure Shaarli has the right to write in the folder is it installed in.'
+        );
+    }
+    return true;
+}
+
+/**
  * Process plugin administration form data and save it in an array.
  *
  * @param array $formData Data sent by the plugin admin form.

--- a/index.php
+++ b/index.php
@@ -1799,8 +1799,20 @@ HTML;
         try {
             if (isset($_POST['parameters_form'])) {
                 unset($_POST['parameters_form']);
+                $pluginSave = array();
                 foreach ($_POST as $param => $value) {
                     $GLOBALS['plugins'][$param] = escape($value);
+                    // Link parameters to their plugin.
+                    foreach ($pluginManager->getPluginsMeta() as $plugin => $meta) {
+                        if (in_array($param, array_keys($meta['parameters']))) {
+                            $pluginSave[$plugin][$param] = escape($value);
+                        }
+                    }
+                }
+
+                // Save parameters into specific plugin config.php files.
+                foreach ($pluginSave as $key => $value) {
+                    write_plugin_config($key, $value);
                 }
             }
             else {

--- a/tests/ConfigTest.php
+++ b/tests/ConfigTest.php
@@ -14,6 +14,18 @@ class ConfigTest extends PHPUnit_Framework_TestCase
     private static $configFields;
 
     /**
+     * Path to tests plugin.
+     * @var string $pluginPath
+     */
+    private static $pluginPath = 'tests/plugins';
+
+    /**
+     * Test plugin.
+     * @var string $pluginName
+     */
+    private static $pluginName = 'test';
+
+    /**
      * Executed before each test.
      */
     public function setUp()
@@ -46,6 +58,9 @@ class ConfigTest extends PHPUnit_Framework_TestCase
     {
         if (is_file(self::$configFields['config']['CONFIG_FILE'])) {
             unlink(self::$configFields['config']['CONFIG_FILE']);
+        }
+        if (is_file(self::$pluginPath . '/' . self::$pluginName . '/config.php')) {
+            unlink(self::$pluginPath . '/' . self::$pluginName . '/config.php');
         }
     }
 
@@ -282,5 +297,26 @@ class ConfigTest extends PHPUnit_Framework_TestCase
         $this->assertEquals('value1', $result['plugin_name']['parameters']['param1']);
         $this->assertEquals('value2', $result['plugin_name']['parameters']['param2']);
         $this->assertEquals('', $result['plugin_name']['parameters']['param3']);
+    }
+
+    /**
+     * Test write_plugin_config():
+     *   1. Without an existing file: don't write.
+     *   2. With an existing file: write.
+     */
+    public function testWritePluginConfig() {
+        $settings = array(
+            'SETTING_1' => 'value 1',
+            'SETTING_2' => 'value 2',
+        );
+        PluginManager::$PLUGINS_PATH = self::$pluginPath;
+
+        $this->assertFalse(write_plugin_config(self::$pluginName, $settings));
+        $settingsFile = PluginManager::$PLUGINS_PATH . '/' . self::$pluginName . '/config.php';
+        touch($settingsFile);
+        $this->assertTrue(write_plugin_config(self::$pluginName, $settings));
+        include $settingsFile;
+        $this->assertEquals($settings['SETTING_1'], $GLOBALS['plugins']['SETTING_1']);
+        $this->assertEquals($settings['SETTING_2'], $GLOBALS['plugins']['SETTING_2']);
     }
 }


### PR DESCRIPTION
Fixes #464 

> By design, `plugins/<plugin>/config.php` overrides `config.php` for this specific plugin. But when you save settings in the plugin admin page, the plugin config file is not set (it only has effect on global `config.php`).

It's a bit complicated in `index.php` because plugin settings share the same `array` and I didn't want to change `pluginsadmin.html` *and* existing settings.