### PR TITLE
[WIP]bookmarks: refactor the import functions

### DIFF
--- a/application/BookmarkUtils.php
+++ b/application/BookmarkUtils.php
@@ -1,0 +1,149 @@
+<?php
+/**
+ * Bookmark import utilities
+ */
+
+/**
+ * Generates a Javascript alert call to display the import status
+ *
+ * @param string $filename    name of the file to import
+ * @param int    $filesize    size of the file to import
+ * @param int    $importCount how many links were imported
+ */
+function generate_import_notification($filename, $filesize, $importCount=0)
+{
+    $alert = '<script>alert("File '.$filename;
+    $alert .= ' ('.$filesize.' bytes) ';
+    if ($importCount == 0) {
+        $alert .= 'has an unknown file format. Nothing was imported.';
+    } else {
+        $alert .= 'was successfully processed: '.$importCount.' links imported.';
+    }
+    $alert .= '");document.location=\'?\';</script>';
+    return $alert;
+}
+
+/**
+ * Imports bookmark from an uploaded file
+ *
+ * @param array $globals the $GLOBALS array
+ * @param array $post    the $_POST array
+ * @param array $files   the $_FILES array
+ */
+function import_bookmark_file($globals, $post, $files)
+{
+    $linkDb = new LinkDB(
+        $globals['config']['DATASTORE'],
+        isLoggedIn(),
+        $globals['config']['HIDE_PUBLIC_LINKS'],
+        $globals['redirector']
+    );
+
+    $filename = $files['filetoupload']['name'];
+    $filesize = $files['filetoupload']['size'];
+    $data = file_get_contents($files['filetoupload']['tmp_name']);
+
+    // Sniff file type
+    if (! startsWith($data, '<!DOCTYPE NETSCAPE-Bookmark-file-1>')) {
+        echo generate_import_notification($filename, $filesize);
+        return;
+    }
+
+    // Should the links be imported as private?
+    $private = (empty($post['private']) ? 0 : 1);
+
+    // Should the imported links overwrite existing ones?
+    $overwrite = !empty($post['overwrite']);
+
+    $importCount = 0;
+
+    // Standard Netscape-style bookmark file
+    foreach (explode('<DT>', $data) as $html) {
+        $link = array(
+            'linkdate' => '',
+            'title' => '',
+            'url' => '',
+            'description' => '',
+            'tags' => '',
+            'private' => 0
+        );
+
+        $d = explode('<DD>', $html);
+
+        if (startswith($d[0], '<A ')) {
+            if (isset($d[1])) {
+                // Get description (optional)
+                $link['description'] = html_entity_decode(trim($d[1]), ENT_QUOTES, 'UTF-8');
+            }
+
+            // Get title
+            preg_match('!<A .*?>(.*?)</A>!i',$d[0],$matches);
+            $link['title'] = (isset($matches[1]) ? trim($matches[1]) : '');
+            $link['title'] = html_entity_decode($link['title'], ENT_QUOTES, 'UTF-8');
+
+            // Get all other attributes
+            preg_match_all('! ([A-Z_]+)=\"(.*?)"!i', $html, $matches, PREG_SET_ORDER);
+
+            $raw_add_date = 0;
+
+            foreach ($matches as $m) {
+                $attr = $m[1];
+                $value = $m[2];
+                if ($attr == 'HREF') {
+                    $link['url'] = html_entity_decode($value, ENT_QUOTES, 'UTF-8');
+                } else if ($attr == 'ADD_DATE') {
+                    $raw_add_date = intval($value);
+                    if ($raw_add_date > 30000000000) {
+                        // If larger than year 2920, then was likely stored in milliseconds
+                        // instead of seconds
+                        $raw_add_date /= 1000;
+                    }
+                } elseif ($attr == 'PRIVATE') {
+                    $link['private'] = ($value == '0' ? 0 : 1);
+                } elseif ($attr == 'TAGS') {
+                    $link['tags'] = html_entity_decode(
+                        str_replace(',', ' ', $value),
+                        ENT_QUOTES,
+                        'UTF-8'
+                    );
+                }
+            }
+            if ($link['url'] != '') {
+                if ($private == 1) {
+                    $link['private'] = 1;
+                }
+                // Check if the link is already in the datastore
+                $dblink = $linkDb->getLinkFromUrl($link['url']);
+
+                if ($dblink == false) {
+                   // Link not in database, let's import it...
+                   if (empty($raw_add_date)) {
+                       // Bookmark file with no ADD_DATE
+                       $raw_add_date = time();
+                   }
+
+                   /* Make sure date/time is not already used by another link.
+                    * Some bookmark files have several different links with the same ADD_DATE
+                    *
+                    * We increment date by 1 second until we find a date which is not used in DB,
+                    * so that links that have the same date/time are more or less kept grouped
+                    * by date, but do not conflict.
+                    */
+                   while (! empty($linkDb[date('Ymd_His', $raw_add_date)])) {
+                       $raw_add_date++;
+                   }
+                   $link['linkdate'] = date('Ymd_His', $raw_add_date);
+                   $linkDb[$link['linkdate']] = $link;
+                   $importCount++;
+                } else if ($overwrite) {
+                    // If overwrite is required, we import link data, except date/time.
+                    $link['linkdate'] = $dblink['linkdate'];
+                    $linkDb[$link['linkdate']] = $link;
+                    $importCount++;
+                }
+            }
+        }
+    }
+    $linkDb->savedb($globals['config']['PAGECACHE']);
+    echo generate_import_notification($filename, $filesize, $importCount);
+}

--- a/index.php
+++ b/index.php
@@ -152,6 +152,7 @@ if (is_file($GLOBALS['config']['CONFIG_FILE'])) {
 
 // Shaarli library
 require_once 'application/ApplicationUtils.php';
+require_once 'application/BookmarkUtils.php';
 require_once 'application/Cache.php';
 require_once 'application/CachedPage.php';
 require_once 'application/FileUtils.php';
@@ -1791,8 +1792,7 @@ HTML;
     }
 
     // -------- User is uploading a file for import
-    if (isset($_SERVER["QUERY_STRING"]) && startswith($_SERVER["QUERY_STRING"],'do=upload'))
-    {
+    if (isset($_SERVER["QUERY_STRING"]) && startswith($_SERVER["QUERY_STRING"],'do=upload')) {
         // If file is too big, some form field may be missing.
         if (!isset($_POST['token']) || (!isset($_FILES)) || (isset($_FILES['filetoupload']['size']) && $_FILES['filetoupload']['size']==0))
         {
@@ -1800,8 +1800,10 @@ HTML;
             echo '<script>alert("The file you are trying to upload is probably bigger than what this webserver can accept ('.getMaxFileSize().' bytes). Please upload in smaller chunks.");document.location=\''.escape($returnurl).'\';</script>';
             exit;
         }
-        if (!tokenOk($_POST['token'])) die('Wrong token.');
-        importFile();
+        if (!tokenOk($_POST['token'])) {
+            die('Wrong token.');
+        }
+        import_bookmark_file($GLOBALS, $_POST, $_FILES);
         exit;
     }
 
@@ -1868,95 +1870,6 @@ HTML;
     exit;
 }
 
-// -----------------------------------------------------------------------------------------------
-// Process the import file form.
-function importFile()
-{
-    if (!isLoggedIn()) { die('Not allowed.'); }
-    $LINKSDB = new LinkDB(
-        $GLOBALS['config']['DATASTORE'],
-        isLoggedIn(),
-        $GLOBALS['config']['HIDE_PUBLIC_LINKS'],
-        $GLOBALS['redirector']
-    );
-    $filename=$_FILES['filetoupload']['name'];
-    $filesize=$_FILES['filetoupload']['size'];
-    $data=file_get_contents($_FILES['filetoupload']['tmp_name']);
-    $private = (empty($_POST['private']) ? 0 : 1); // Should the links be imported as private?
-    $overwrite = !empty($_POST['overwrite']) ; // Should the imported links overwrite existing ones?
-    $import_count=0;
-
-    // Sniff file type:
-    $type='unknown';
-    if (startsWith($data,'<!DOCTYPE NETSCAPE-Bookmark-file-1>')) $type='netscape'; // Netscape bookmark file (aka Firefox).
-
-    // Then import the bookmarks.
-    if ($type=='netscape')
-    {
-        // This is a standard Netscape-style bookmark file.
-        // This format is supported by all browsers (except IE, of course), also Delicious, Diigo and others.
-        foreach(explode('<DT>',$data) as $html) // explode is very fast
-        {
-            $link = array('linkdate'=>'','title'=>'','url'=>'','description'=>'','tags'=>'','private'=>0);
-            $d = explode('<DD>',$html);
-            if (startswith($d[0],'<A '))
-            {
-                $link['description'] = (isset($d[1]) ? html_entity_decode(trim($d[1]),ENT_QUOTES,'UTF-8') : '');  // Get description (optional)
-                preg_match('!<A .*?>(.*?)</A>!i',$d[0],$matches); $link['title'] = (isset($matches[1]) ? trim($matches[1]) : '');  // Get title
-                $link['title'] = html_entity_decode($link['title'],ENT_QUOTES,'UTF-8');
-                preg_match_all('! ([A-Z_]+)=\"(.*?)"!i',$html,$matches,PREG_SET_ORDER);  // Get all other attributes
-                $raw_add_date=0;
-                foreach($matches as $m)
-                {
-                    $attr=$m[1]; $value=$m[2];
-                    if ($attr=='HREF') $link['url']=html_entity_decode($value,ENT_QUOTES,'UTF-8');
-                    elseif ($attr=='ADD_DATE')
-                    {
-                        $raw_add_date=intval($value);
-                        if ($raw_add_date>30000000000) $raw_add_date/=1000;	//If larger than year 2920, then was likely stored in milliseconds instead of seconds
-                    }
-                    elseif ($attr=='PRIVATE') $link['private']=($value=='0'?0:1);
-                    elseif ($attr=='TAGS') $link['tags']=html_entity_decode(str_replace(',',' ',$value),ENT_QUOTES,'UTF-8');
-                }
-                if ($link['url']!='')
-                {
-                    if ($private==1) $link['private']=1;
-                    $dblink = $LINKSDB->getLinkFromUrl($link['url']); // See if the link is already in database.
-                    if ($dblink==false)
-                    {  // Link not in database, let's import it...
-                       if (empty($raw_add_date)) $raw_add_date=time(); // In case of shitty bookmark file with no ADD_DATE
-
-                       // Make sure date/time is not already used by another link.
-                       // (Some bookmark files have several different links with the same ADD_DATE)
-                       // We increment date by 1 second until we find a date which is not used in DB.
-                       // (so that links that have the same date/time are more or less kept grouped by date, but do not conflict.)
-                       while (!empty($LINKSDB[date('Ymd_His',$raw_add_date)])) { $raw_add_date++; }// Yes, I know it's ugly.
-                       $link['linkdate']=date('Ymd_His',$raw_add_date);
-                       $LINKSDB[$link['linkdate']] = $link;
-                       $import_count++;
-                    }
-                    else // Link already present in database.
-                    {
-                        if ($overwrite)
-                        {   // If overwrite is required, we import link data, except date/time.
-                            $link['linkdate']=$dblink['linkdate'];
-                            $LINKSDB[$link['linkdate']] = $link;
-                            $import_count++;
-                        }
-                    }
-
-                }
-            }
-        }
-        $LINKSDB->savedb($GLOBALS['config']['PAGECACHE']);
-
-        echo '<script>alert("File '.json_encode($filename).' ('.$filesize.' bytes) was successfully processed: '.$import_count.' links imported.");document.location=\'?\';</script>';
-    }
-    else
-    {
-        echo '<script>alert("File '.json_encode($filename).' ('.$filesize.' bytes) has an unknown file format. Nothing was imported.");document.location=\'?\';</script>';
-    }
-}
 
 // -----------------------------------------------------------------------------------------------
 // Template for the list of links (<div id="linklist">)

--- a/tests/BookmarkUtilsTest.php
+++ b/tests/BookmarkUtilsTest.php
@@ -1,0 +1,42 @@
+<?php
+require_once 'application/BookmarkUtils.php';
+
+/**
+ * Unitary tests for bookmark imports
+ */
+class BookmarkUtilsTest extends PHPUnit_Framework_TestCase
+{
+    /**
+     * Import success notification
+     */
+    public function test_generate_successful_import_notification()
+    {
+        $name = '/home/ringo/starrs.html';
+        $size = 1968;
+        $count = 312;
+        $this->assertEquals(
+            '<script>alert("File '.$name.' ('.$size.' bytes) was successfully processed: '
+            .$count.' links imported.");document.location=\'?\';</script>',
+            generate_import_notification($name, $size, $count)
+        );
+    }
+
+    /**
+     * Import failure notification
+     */
+    public function test_generate_failed_import_notification()
+    {
+        $name = 'D:\\Users\Ringo\My Documents\starrs.html';
+        $size = 9;
+        $this->assertEquals(
+            '<script>alert("File '.$name.' ('.$size.' bytes) has an unknown file format. '
+            .'Nothing was imported.");document.location=\'?\';</script>',
+            generate_import_notification($name, $size)
+        );
+        $this->assertEquals(
+            '<script>alert("File '.$name.' ('.$size.' bytes) has an unknown file format. '
+            .'Nothing was imported.");document.location=\'?\';</script>',
+            generate_import_notification($name, $size, 0)
+        );
+    }
+}


### PR DESCRIPTION
Relates to https://github.com/sebsauvage/Shaarli/issues/146

Modifications:
- [index.php] remove `importFile`
- [app] BookmarkImporter

WIP:
- split logic
- cleanup code
- apply coding conventions
- use a generic parser, see https://github.com/shaarli/netscape-bookmark-parser
    - iterate over the resulting array to fill the LinkDB

TODO:
- test coverage
- update https://github.com/shaarli/Shaarli/wiki/Backup%2C-restore%2C-import-and-export
    - mention the generic parser used
    - encourage users to submit faulty exports to serve as test reference (Mister Wang, SemanticScuttle, etc.)
  