### PR TITLE
Avoids populating a markdown empty container if there's no description.

### DIFF
--- a/plugins/markdown/markdown.php
+++ b/plugins/markdown/markdown.php
@@ -173,7 +173,10 @@ function process_markdown($description)
         ->setBreaksEnabled(true)
         ->text($processedDescription);
     $processedDescription = sanitize_html($processedDescription);
-    $processedDescription = '<div class="markdown">'. $processedDescription . '</div>';
+
+    if(!empty($processedDescription)){
+        $processedDescription = '<div class="markdown">'. $processedDescription . '</div>';
+    }
 
     return $processedDescription;
 }


### PR DESCRIPTION
It allows to respect the choice that has been made to not populate the link-description div when there's no content. And it makes things easier in terms of design to avoid unnecessary padding and margin when there is nothing to display.