### PR TITLE
Refactor RSS feeds generation, and do it through templates

### DIFF
--- a/application/FeedBuilder.php
+++ b/application/FeedBuilder.php
@@ -103,23 +103,7 @@ class FeedBuilder
     public function buildData()
     {
         // Optionally filter the results:
-        $searchtags = !empty($this->userInput['searchtags']) ? escape($this->userInput['searchtags']) : '';
-        $searchterm = !empty($this->userInput['searchterm']) ? escape($this->userInput['searchterm']) : '';
-        if (! empty($searchtags) && ! empty($searchterm)) {
-            $linksToDisplay = $this->linkDB->filter(
-                LinkFilter::$FILTER_TAG | LinkFilter::$FILTER_TEXT,
-                array($searchtags, $searchterm)
-            );
-        }
-        elseif ($searchtags) {
-            $linksToDisplay = $this->linkDB->filter(LinkFilter::$FILTER_TAG, $searchtags);
-        }
-        elseif ($searchterm) {
-            $linksToDisplay = $this->linkDB->filter(LinkFilter::$FILTER_TEXT, $searchterm);
-        }
-        else {
-            $linksToDisplay = $this->linkDB;
-        }
+        $linksToDisplay = $this->linkDB->filterSearch($this->userInput);
 
         $nblinksToDisplay = $this->getNbLinks(count($linksToDisplay));
 

--- a/application/LinkFilter.php
+++ b/application/LinkFilter.php
@@ -44,7 +44,7 @@ class LinkFilter
      * Filter links according to parameters.
      *
      * @param string $type          Type of filter (eg. tags, permalink, etc.).
-     * @param string $request       Filter content.
+     * @param mixed  $request       Filter content.
      * @param bool   $casesensitive Optional: Perform case sensitive filter if true.
      * @param bool   $privateonly   Optional: Only returns private links if true.
      *
@@ -110,6 +110,8 @@ class LinkFilter
      * @param string $smallHash permalink hash.
      *
      * @return array $filtered array containing permalink data.
+     *
+     * @throws LinkNotFoundException if the smallhash doesn't match any link.
      */
     private function filterSmallHash($smallHash)
     {
@@ -121,6 +123,11 @@ class LinkFilter
                 return $filtered;
             }
         }
+
+        if (empty($filtered)) {
+            throw new LinkNotFoundException();
+        }
+
         return $filtered;
     }
 
@@ -317,4 +324,9 @@ class LinkFilter
 
         return array_filter(explode(' ', trim($tagsOut)), 'strlen');
     }
+}
+
+class LinkNotFoundException extends Exception
+{
+    protected $message = 'The link you are trying to reach does not exist or has been deleted.';
 }

--- a/application/Router.php
+++ b/application/Router.php
@@ -15,6 +15,10 @@ class Router
 
     public static $PAGE_DAILY = 'daily';
 
+    public static $PAGE_FEED_ATOM = 'atom';
+
+    public static $PAGE_FEED_RSS = 'rss';
+
     public static $PAGE_TOOLS = 'tools';
 
     public static $PAGE_CHANGEPASSWORD = 'changepasswd';
@@ -77,6 +81,14 @@ class Router
 
         if (startsWith($query, 'do='. self::$PAGE_DAILY)) {
             return self::$PAGE_DAILY;
+        }
+
+        if (startsWith($query, 'do='. self::$PAGE_FEED_ATOM)) {
+            return self::$PAGE_FEED_ATOM;
+        }
+
+        if (startsWith($query, 'do='. self::$PAGE_FEED_RSS)) {
+            return self::$PAGE_FEED_RSS;
         }
 
         // At this point, only loggedin pages.

--- a/application/Router.php
+++ b/application/Router.php
@@ -53,7 +53,7 @@ class Router
      * @param array  $get      $_SERVER['GET'].
      * @param bool   $loggedIn true if authenticated user.
      *
-     * @return self::page found.
+     * @return string page found.
      */
     public static function findPage($query, $get, $loggedIn)
     {

--- a/application/Updater.php
+++ b/application/Updater.php
@@ -137,7 +137,7 @@ class Updater
      */
     public function updateMethodRenameDashTags()
     {
-        $linklist = $this->linkDB->filter();
+        $linklist = $this->linkDB->filterSearch();
         foreach ($linklist as $link) {
             $link['tags'] = preg_replace('/(^| )\-/', '$1', $link['tags']);
             $link['tags'] = implode(' ', array_unique(LinkFilter::tagsStrToArray($link['tags'], true)));

--- a/application/Utils.php
+++ b/application/Utils.php
@@ -63,14 +63,22 @@ function endsWith($haystack, $needle, $case=true)
 
 /**
  * Htmlspecialchars wrapper
+ * Support multidimensional array of strings.
  *
- * @param string $str the string to escape.
+ * @param mixed $input Data to escape: a single string or an array of strings.
  *
  * @return string escaped.
  */
-function escape($str)
+function escape($input)
 {
-    return htmlspecialchars($str, ENT_COMPAT, 'UTF-8', false);
+    if (is_array($input)) {
+        $out = array();
+        foreach($input as $key => $value) {
+            $out[$key] = escape($value);
+        }
+        return $out;
+    }
+    return htmlspecialchars($input, ENT_COMPAT, 'UTF-8', false);
 }
 
 /**

--- a/application/Utils.php
+++ b/application/Utils.php
@@ -226,7 +226,7 @@ function space2nbsp($text)
  *
  * @return string formatted description.
  */
-function format_description($description, $redirector) {
+function format_description($description, $redirector = false) {
     return nl2br(space2nbsp(text2clickable($description, $redirector)));
 }
 

--- a/index.php
+++ b/index.php
@@ -637,6 +637,29 @@ class pageBuilder
         $this->tpl->assign($what,$where);
     }
 
+    /**
+     * Assign an array of data to the template builder.
+     *
+     * @param array $data Data to assign.
+     *
+     * @return false if invalid data.
+     */
+    public function assignAll($data)
+    {
+        // Lazy initialization
+        if ($this->tpl === false) {
+            $this->initialize();
+        }
+
+        if (empty($data) || !is_array($data)){
+            return false;
+        }
+
+        foreach ($data as $key => $value) {
+            $this->assign($key, $value);
+        }
+    }
+
     // Render a specific page (using a template).
     // e.g. pb.renderPage('picwall')
     public function renderPage($page)

--- a/index.php
+++ b/index.php
@@ -785,6 +785,12 @@ function showRSS($pageBuilder, $linkDB)
     $data['usepermalinks'] = $usepermalinks;
     $data['links'] = $linkDisp;
 
+    $pluginManager = PluginManager::getInstance();
+    $pluginManager->executeHooks('render_feed', $data, array(
+        'loggedin' => isLoggedIn(),
+        'target' => Router::$PAGE_RSS,
+    ));
+
     $pageBuilder->assignAll($data);
     $pageBuilder->renderPage('feed.rss', false);
     $cache->cache(ob_get_contents());

--- a/plugins/demo_plugin/demo_plugin.php
+++ b/plugins/demo_plugin/demo_plugin.php
@@ -323,3 +323,28 @@ function hook_demo_plugin_delete_link($data)
         exit('You can not delete a YouTube link. Don\'t ask.');
     }
 }
+
+/**
+ * Execute render_feed hook.
+ * Called with ATOM and RSS feed.
+ *
+ * Special data keys:
+ *   - _PAGE_: current page
+ *   - _LOGGEDIN_: true/false
+ *
+ * @param array $data data passed to plugin
+ *
+ * @return array altered $data.
+ */
+function hook_demo_plugin_render_feed($data)
+{
+    foreach ($data['links'] as &$link) {
+        if ($data['_PAGE_'] == Router::$PAGE_FEED_ATOM) {
+            $link['description'] .= ' - ATOM Feed' ;
+        }
+        elseif ($data['_PAGE_'] == Router::$PAGE_FEED_RSS) {
+            $link['description'] .= ' - RSS Feed';
+        }
+    }
+    return $data;
+}

--- a/tests/FeedBuilderTest.php
+++ b/tests/FeedBuilderTest.php
@@ -1,0 +1,212 @@
+<?php
+
+require_once 'application/FeedBuilder.php';
+require_once 'application/LinkDB.php';
+
+/**
+ * FeedBuilderTest class.
+ *
+ * Unit tests for FeedBuilder.
+ */
+class FeedBuilderTest extends PHPUnit_Framework_TestCase
+{
+    /**
+     * @var string locale Basque (Spain).
+     */
+    public static $LOCALE = 'eu_ES';
+
+    /**
+     * @var string language in RSS format.
+     */
+    public static $RSS_LANGUAGE = 'eu-es';
+
+    /**
+     * @var string language in ATOM format.
+     */
+    public static $ATOM_LANGUAGUE = 'eu';
+
+    protected static $testDatastore = 'sandbox/datastore.php';
+
+    public static $linkDB;
+
+    public static $serverInfo;
+
+    /**
+     * Called before every test method.
+     */
+    public static function setUpBeforeClass()
+    {
+        $refLinkDB = new ReferenceLinkDB();
+        $refLinkDB->write(self::$testDatastore);
+        self::$linkDB = new LinkDB(self::$testDatastore, true, false);
+        self::$serverInfo = array(
+            'HTTPS' => 'Off',
+            'SERVER_NAME' => 'host.tld',
+            'SERVER_PORT' => '80',
+            'SCRIPT_NAME' => '/index.php',
+            'REQUEST_URI' => '/index.php?do=feed',
+        );
+    }
+
+    /**
+     * Test GetTypeLanguage().
+     */
+    public function testGetTypeLanguage()
+    {
+        $feedBuilder = new FeedBuilder(null, FeedBuilder::$FEED_ATOM, null, null, false);
+        $feedBuilder->setLocale(self::$LOCALE);
+        $this->assertEquals(self::$ATOM_LANGUAGUE, $feedBuilder->getTypeLanguage());
+        $feedBuilder = new FeedBuilder(null, FeedBuilder::$FEED_RSS, null, null, false);
+        $feedBuilder->setLocale(self::$LOCALE);
+        $this->assertEquals(self::$RSS_LANGUAGE, $feedBuilder->getTypeLanguage());
+        $feedBuilder = new FeedBuilder(null, FeedBuilder::$FEED_ATOM, null, null, false);
+        $this->assertEquals('en', $feedBuilder->getTypeLanguage());
+        $feedBuilder = new FeedBuilder(null, FeedBuilder::$FEED_RSS, null, null, false);
+        $this->assertEquals('en-en', $feedBuilder->getTypeLanguage());
+    }
+
+    /**
+     * Test buildData with RSS feed.
+     */
+    public function testRSSBuildData()
+    {
+        $feedBuilder = new FeedBuilder(self::$linkDB, FeedBuilder::$FEED_RSS, self::$serverInfo, null, false);
+        $feedBuilder->setLocale(self::$LOCALE);
+        $data = $feedBuilder->buildData();
+        // Test headers (RSS)
+        $this->assertEquals(self::$RSS_LANGUAGE, $data['language']);
+        $this->assertEmpty($data['pubsubhub_url']);
+        $this->assertEquals('Tue, 10 Mar 2015 11:46:51 +0100', $data['last_update']);
+        $this->assertEquals(true, $data['show_dates']);
+        $this->assertEquals('http://host.tld/index.php?do=feed', $data['self_link']);
+        $this->assertEquals('http://host.tld/', $data['index_url']);
+        $this->assertFalse($data['usepermalinks']);
+        $this->assertEquals(ReferenceLinkDB::$NB_LINKS_TOTAL, count($data['links']));
+
+        // Test first link (note link)
+        $link = array_shift($data['links']);
+        $this->assertEquals('20150310_114651', $link['linkdate']);
+        $this->assertEquals('http://host.tld/?WDWyig', $link['guid']);
+        $this->assertEquals('http://host.tld/?WDWyig', $link['url']);
+        $this->assertEquals('Tue, 10 Mar 2015 11:46:51 +0100', $link['iso_date']);
+        $this->assertContains('Stallman has a beard', $link['description']);
+        $this->assertContains('Permalink', $link['description']);
+        $this->assertContains('http://host.tld/?WDWyig', $link['description']);
+        $this->assertEquals(1, count($link['taglist']));
+        $this->assertEquals('stuff', $link['taglist'][0]);
+
+        // Test URL with external link.
+        $this->assertEquals('https://static.fsf.org/nosvn/faif-2.0.pdf', $data['links']['20150310_114633']['url']);
+
+        // Test multitags.
+        $this->assertEquals(5, count($data['links']['20141125_084734']['taglist']));
+        $this->assertEquals('css', $data['links']['20141125_084734']['taglist'][0]);
+    }
+
+    /**
+     * Test buildData with ATOM feed (test only specific to ATOM).
+     */
+    public function testAtomBuildData()
+    {
+        $feedBuilder = new FeedBuilder(self::$linkDB, FeedBuilder::$FEED_ATOM, self::$serverInfo, null, false);
+        $feedBuilder->setLocale(self::$LOCALE);
+        $data = $feedBuilder->buildData();
+        $this->assertEquals(ReferenceLinkDB::$NB_LINKS_TOTAL, count($data['links']));
+        $link = array_shift($data['links']);
+        $this->assertEquals('2015-03-10T11:46:51+01:00', $link['iso_date']);
+    }
+
+    /**
+     * Test buildData with search criteria.
+     */
+    public function testBuildDataFiltered()
+    {
+        $criteria = array(
+            'searchtags' => 'stuff',
+            'searchterm' => 'beard',
+        );
+        $feedBuilder = new FeedBuilder(self::$linkDB, FeedBuilder::$FEED_ATOM, self::$serverInfo, $criteria, false);
+        $feedBuilder->setLocale(self::$LOCALE);
+        $data = $feedBuilder->buildData();
+        $this->assertEquals(1, count($data['links']));
+        $link = array_shift($data['links']);
+        $this->assertEquals('20150310_114651', $link['linkdate']);
+    }
+
+    /**
+     * Test buildData with nb limit.
+     */
+    public function testBuildDataCount()
+    {
+        $criteria = array(
+            'nb' => '1',
+        );
+        $feedBuilder = new FeedBuilder(self::$linkDB, FeedBuilder::$FEED_ATOM, self::$serverInfo, $criteria, false);
+        $feedBuilder->setLocale(self::$LOCALE);
+        $data = $feedBuilder->buildData();
+        $this->assertEquals(1, count($data['links']));
+        $link = array_shift($data['links']);
+        $this->assertEquals('20150310_114651', $link['linkdate']);
+    }
+
+    /**
+     * Test buildData with permalinks on.
+     */
+    public function testBuildDataPermalinks()
+    {
+        $feedBuilder = new FeedBuilder(self::$linkDB, FeedBuilder::$FEED_ATOM, self::$serverInfo, null, false);
+        $feedBuilder->setLocale(self::$LOCALE);
+        $feedBuilder->setUsePermalinks(true);
+        $data = $feedBuilder->buildData();
+        $this->assertEquals(ReferenceLinkDB::$NB_LINKS_TOTAL, count($data['links']));
+        $this->assertTrue($data['usepermalinks']);
+        // First link is a permalink
+        $link = array_shift($data['links']);
+        $this->assertEquals('20150310_114651', $link['linkdate']);
+        $this->assertEquals('http://host.tld/?WDWyig', $link['guid']);
+        $this->assertEquals('http://host.tld/?WDWyig', $link['url']);
+        $this->assertContains('Direct link', $link['description']);
+        $this->assertContains('http://host.tld/?WDWyig', $link['description']);
+        // Second link is a direct link
+        $link = array_shift($data['links']);
+        $this->assertEquals('20150310_114633', $link['linkdate']);
+        $this->assertEquals('http://host.tld/?kLHmZg', $link['guid']);
+        $this->assertEquals('https://static.fsf.org/nosvn/faif-2.0.pdf', $link['url']);
+        $this->assertContains('Direct link', $link['description']);
+        $this->assertContains('https://static.fsf.org/nosvn/faif-2.0.pdf', $link['description']);
+    }
+
+    /**
+     * Test buildData with hide dates settings.
+     */
+    public function testBuildDataHideDates()
+    {
+        $feedBuilder = new FeedBuilder(self::$linkDB, FeedBuilder::$FEED_ATOM, self::$serverInfo, null, false);
+        $feedBuilder->setLocale(self::$LOCALE);
+        $feedBuilder->setHideDates(true);
+        $data = $feedBuilder->buildData();
+        $this->assertEquals(ReferenceLinkDB::$NB_LINKS_TOTAL, count($data['links']));
+        $this->assertFalse($data['show_dates']);
+
+        // Show dates while logged in
+        $feedBuilder = new FeedBuilder(self::$linkDB, FeedBuilder::$FEED_ATOM, self::$serverInfo, null, true);
+        $feedBuilder->setLocale(self::$LOCALE);
+        $feedBuilder->setHideDates(true);
+        $data = $feedBuilder->buildData();
+        $this->assertEquals(ReferenceLinkDB::$NB_LINKS_TOTAL, count($data['links']));
+        $this->assertTrue($data['show_dates']);
+    }
+
+    /**
+     * Test buildData with hide dates settings.
+     */
+    public function testBuildDataPubsubhub()
+    {
+        $feedBuilder = new FeedBuilder(self::$linkDB, FeedBuilder::$FEED_ATOM, self::$serverInfo, null, false);
+        $feedBuilder->setLocale(self::$LOCALE);
+        $feedBuilder->setPubsubhubUrl('http://pubsubhub.io');
+        $data = $feedBuilder->buildData();
+        $this->assertEquals(ReferenceLinkDB::$NB_LINKS_TOTAL, count($data['links']));
+        $this->assertEquals('http://pubsubhub.io', $data['pubsubhub_url']);
+    }
+}

--- a/tests/LinkDBTest.php
+++ b/tests/LinkDBTest.php
@@ -17,8 +17,20 @@ class LinkDBTest extends PHPUnit_Framework_TestCase
 {
     // datastore to test write operations
     protected static $testDatastore = 'sandbox/datastore.php';
+
+    /**
+     * @var ReferenceLinkDB instance.
+     */
     protected static $refDB = null;
+
+    /**
+     * @var LinkDB public LinkDB instance.
+     */
     protected static $publicLinkDB = null;
+
+    /**
+     * @var LinkDB private LinkDB instance.
+     */
     protected static $privateLinkDB = null;
 
     /**
@@ -335,9 +347,10 @@ class LinkDBTest extends PHPUnit_Framework_TestCase
     public function testFilterString()
     {
         $tags = 'dev cartoon';
+        $request = array('searchtags' => $tags);
         $this->assertEquals(
             2,
-            count(self::$privateLinkDB->filter(LinkFilter::$FILTER_TAG, $tags, true, false))
+            count(self::$privateLinkDB->filterSearch($request, true, false))
         );
     }
 
@@ -347,9 +360,10 @@ class LinkDBTest extends PHPUnit_Framework_TestCase
     public function testFilterArray()
     {
         $tags = array('dev', 'cartoon');
+        $request = array('searchtags' => $tags);
         $this->assertEquals(
             2,
-            count(self::$privateLinkDB->filter(LinkFilter::$FILTER_TAG, $tags, true, false))
+            count(self::$privateLinkDB->filterSearch($request, true, false))
         );
     }
 
@@ -360,14 +374,48 @@ class LinkDBTest extends PHPUnit_Framework_TestCase
     public function testHiddenTags()
     {
         $tags = '.hidden';
+        $request = array('searchtags' => $tags);
         $this->assertEquals(
             1,
-            count(self::$privateLinkDB->filter(LinkFilter::$FILTER_TAG, $tags, true, false))
+            count(self::$privateLinkDB->filterSearch($request, true, false))
         );
 
         $this->assertEquals(
             0,
-            count(self::$publicLinkDB->filter(LinkFilter::$FILTER_TAG, $tags, true, false))
+            count(self::$publicLinkDB->filterSearch($request, true, false))
         );
+    }
+
+    /**
+     * Test filterHash() with a valid smallhash.
+     */
+    public function testFilterHashValid()
+    {
+        $request = smallHash('20150310_114651');
+        $this->assertEquals(
+            1,
+            count(self::$publicLinkDB->filterHash($request))
+        );
+    }
+
+    /**
+     * Test filterHash() with an invalid smallhash.
+     *
+     * @expectedException LinkNotFoundException
+     */
+    public function testFilterHashInValid1()
+    {
+        $request = 'blabla';
+        self::$publicLinkDB->filterHash($request);
+    }
+
+    /**
+     * Test filterHash() with an empty smallhash.
+     *
+     * @expectedException LinkNotFoundException
+     */
+    public function testFilterHashInValid()
+    {
+        self::$publicLinkDB->filterHash('');
     }
 }

--- a/tests/LinkFilterTest.php
+++ b/tests/LinkFilterTest.php
@@ -12,8 +12,6 @@ class LinkFilterTest extends PHPUnit_Framework_TestCase
      */
     protected static $linkFilter;
 
-    protected static $NB_LINKS_REFDB = 7;
-
     /**
      * Instanciate linkFilter with ReferenceLinkDB data.
      */
@@ -29,7 +27,7 @@ class LinkFilterTest extends PHPUnit_Framework_TestCase
     public function testFilter()
     {
         $this->assertEquals(
-            self::$NB_LINKS_REFDB,
+            ReferenceLinkDB::$NB_LINKS_TOTAL,
             count(self::$linkFilter->filter('', ''))
         );
 
@@ -40,12 +38,12 @@ class LinkFilterTest extends PHPUnit_Framework_TestCase
         );
 
         $this->assertEquals(
-            self::$NB_LINKS_REFDB,
+            ReferenceLinkDB::$NB_LINKS_TOTAL,
             count(self::$linkFilter->filter(LinkFilter::$FILTER_TAG, ''))
         );
 
         $this->assertEquals(
-            self::$NB_LINKS_REFDB,
+            ReferenceLinkDB::$NB_LINKS_TOTAL,
             count(self::$linkFilter->filter(LinkFilter::$FILTER_TEXT, ''))
         );
     }
@@ -383,7 +381,7 @@ class LinkFilterTest extends PHPUnit_Framework_TestCase
             ))
         );
         $this->assertEquals(
-            self::$NB_LINKS_REFDB,
+            ReferenceLinkDB::$NB_LINKS_TOTAL,
             count(self::$linkFilter->filter(
                 LinkFilter::$FILTER_TAG | LinkFilter::$FILTER_TEXT,
                 ''

--- a/tests/LinkFilterTest.php
+++ b/tests/LinkFilterTest.php
@@ -165,13 +165,12 @@ class LinkFilterTest extends PHPUnit_Framework_TestCase
 
     /**
      * No link for this hash
+     *
+     * @expectedException LinkNotFoundException
      */
     public function testFilterUnknownSmallHash()
     {
-        $this->assertEquals(
-            0,
-            count(self::$linkFilter->filter(LinkFilter::$FILTER_HASH, 'Iblaah'))
-        );
+        self::$linkFilter->filter(LinkFilter::$FILTER_HASH, 'Iblaah');
     }
 
     /**

--- a/tests/Updater/UpdaterTest.php
+++ b/tests/Updater/UpdaterTest.php
@@ -236,9 +236,9 @@ class UpdaterTest extends PHPUnit_Framework_TestCase
         $refDB = new ReferenceLinkDB();
         $refDB->write(self::$testDatastore);
         $linkDB = new LinkDB(self::$testDatastore, true, false);
-        $this->assertEmpty($linkDB->filter(LinkFilter::$FILTER_TAG, 'exclude'));
+        $this->assertEmpty($linkDB->filterSearch(array('searchtags' => 'exclude')));
         $updater = new Updater(array(), self::$configFields, $linkDB, true);
         $updater->updateMethodRenameDashTags();
-        $this->assertNotEmpty($linkDB->filter(LinkFilter::$FILTER_TAG, 'exclude'));
+        $this->assertNotEmpty($linkDB->filterSearch(array('searchtags' =>  'exclude')));
     }
 }

--- a/tests/utils/ReferenceLinkDB.php
+++ b/tests/utils/ReferenceLinkDB.php
@@ -4,6 +4,8 @@
  */
 class ReferenceLinkDB
 {
+    public static $NB_LINKS_TOTAL = 7;
+
     private $_links = array();
     private $_publicCount = 0;
     private $_privateCount = 0;
@@ -14,21 +16,21 @@ class ReferenceLinkDB
     function __construct()
     {
         $this->addLink(
+            'Link title: @website',
+            '?WDWyig',
+            'Stallman has a beard and is part of the Free Software Foundation (or not). Seriously, read this.',
+            0,
+            '20150310_114651',
+            'stuff'
+        );
+
+        $this->addLink(
             'Free as in Freedom 2.0 @website',
             'https://static.fsf.org/nosvn/faif-2.0.pdf',
             'Richard Stallman and the Free Software Revolution. Read this.',
             0,
             '20150310_114633',
             'free gnu software stallman -exclude stuff'
-        );
-
-        $this->addLink(
-            'Link title: @website',
-            'local',
-            'Stallman has a beard and is part of the Free Software Foundation (or not). Seriously, read this.',
-            0,
-            '20150310_114651',
-            'stuff'
         );
 
         $this->addLink(

--- a/tpl/configure.html
+++ b/tpl/configure.html
@@ -22,9 +22,12 @@
         	<input type="checkbox" name="privateLinkByDefault" id="privateLinkByDefault" {if="!empty($GLOBALS['privateLinkByDefault'])"}checked{/if}/><label for="privateLinkByDefault">&nbsp;All new links are private by default</label></td>
         </tr>
         <tr>
-        	<td valign="top"><b>Enable RSS Permalinks</b></td>
+        	<td valign="top"><b>RSS direct links</b></td>
         	<td>
-        		<input type="checkbox" name="enableRssPermalinks" id="enableRssPermalinks" {if="!empty($GLOBALS['config']['ENABLE_RSS_PERMALINKS'])"}checked{/if}/><label for="enableRssPermalinks">&nbsp;Switches the RSS feed URLs between full URLs and shortlinks. Enabling it will show a permalink in the description, and the feed item will be linked to the absolute URL. Disabling it swaps this behaviour around (permalink in title and link in description). RSS Permalinks are currently <b>{if="$GLOBALS['config']['ENABLE_RSS_PERMALINKS']"}enabled{else}disabled{/if}</b></label>
+        		<input type="checkbox" name="enableRssPermalinks" id="enableRssPermalinks" {if="!empty($GLOBALS['config']['ENABLE_RSS_PERMALINKS'])"}checked{/if}/>
+              <label for="enableRssPermalinks">
+                  &nbsp;Disable it to use permalinks in RSS feed instead of direct links to your shaared links. Currently <b>{if="$GLOBALS['config']['ENABLE_RSS_PERMALINKS']"}enabled{else}disabled{/if}.</b>
+              </label>
         	</td>
         </tr>
         <tr>

--- a/tpl/feed.atom.html
+++ b/tpl/feed.atom.html
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<feed xmlns="http://www.w3.org/2005/Atom">
+  <title>{$pagetitle}</title>
+  <subtitle>Shaared links</subtitle>
+  {if="$show_dates"}
+    <updated>{$last_update}</updated>
+  {/if}
+  <link rel="self" href="{$self_link}#" />
+  {if="!empty($pubsubhub_url)"}
+    <!-- PubSubHubbub Discovery -->
+    <link rel="hub" href="{$pubsubhub_url}#" />
+    <!-- End Of PubSubHubbub Discovery -->
+  {/if}
+  <author>
+    <name>{$index_url}</name>
+    <uri>{$index_url}</uri>
+  </author>
+  <id>{$index_url}</id>
+  <generator>Shaarli</generator>
+  {loop="links"}
+    <entry>
+      <title>{$value.title}</title>
+      {if="$usepermalinks"}
+        <link href="{$value.guid}#" />
+      {else}
+        <link href="{$value.url}#" />
+      {/if}
+      <id>{$value.guid}</id>
+      {if="$show_dates"}
+        <updated>{$value.iso_date}</updated>
+      {/if}
+      <content type="html" xml:lang="{$language}">
+        <![CDATA[{$value.description}]]>
+      </content>
+      {loop="$value.taglist"}
+        <category scheme="{$index_url}?searchtags=" term="{$value|strtolower}" label="{$value}" />
+      {/loop}
+    </entry>
+  {/loop}
+</feed>

--- a/tpl/feed.rss.html
+++ b/tpl/feed.rss.html
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0" xmlns:content="http://purl.org/rss/1.0/modules/content/" xmlns:atom="http://www.w3.org/2005/Atom">
+  <channel>
+    <title>{$pagetitle}</title>
+    <link>{$index_url}</link>
+    <description>Shaared links</description>
+    <language>{$language}</language>
+    <copyright>{$index_url}</copyright>
+    <generator>Shaarli</generator>
+    <atom:link rel="self" href="{$self_link}"  />
+    {if="!empty($pubsubhub_url)"}
+      <!-- PubSubHubbub Discovery -->
+      <atom:link rel="hub" href="{$pubsubhub_url}" />
+    {/if}
+    {loop="links"}
+      <item>
+        <title>{$value.title}</title>
+        <guid isPermaLink="{if="$usepermalinks"}true{else}false{/if}">{$value.guid}</guid>
+        {if="$usepermalinks"}
+          <link>{$value.guid}</link>
+        {else}
+          <link>{$value.url}</link>
+        {/if}
+        {if="$show_dates"}
+          <pubDate>{$value.iso_date}</pubDate>
+        {/if}
+        <description><![CDATA[{$value.description}]]></description>
+        {loop="$value.taglist"}
+          <category domain="{$index_url}?searchtags=">{$value}</category>
+        {/loop}
+      </item>
+    {/loop}
+  </channel>
+</rss>


### PR DESCRIPTION
This PR is a bit huge, please look at the commit log to review it. I've tried to split everything in different commits to make it understandable.

To sum it up:

  * RSS and Atom feeds are now sharing the same code, in FeedBuilder.
  * They're generated through RainTPL templates. 
  * It's now covered by unit tests.
  * There is a new plugin hook called before rendering feeds.
  * The `ENABLE_RSS_PERMALINKS` setting in administration has been reworded.

Fixes #273 

Note that this doesn't concern Daily RSS feed.

PS: [tig](https://github.com/jonas/tig) is awesome.