### PR TITLE
privacy: tell robots not to index content

### DIFF
--- a/robots.txt
+++ b/robots.txt
@@ -1,0 +1,2 @@
+User-agent: *
+Disallow: /

--- a/tpl/includes.html
+++ b/tpl/includes.html
@@ -2,6 +2,7 @@
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 <meta name="format-detection" content="telephone=no" />
 <meta name="viewport" content="width=device-width,initial-scale=1.0" />
+<meta name="robots" content="noindex, nofollow" />
 <link rel="alternate" type="application/rss+xml" href="{$feedurl}?do=rss{$searchcrits}#" title="RSS Feed" />
 <link rel="alternate" type="application/atom+xml" href="{$feedurl}?do=atom{$searchcrits}#" title="ATOM Feed" />
 <link href="images/favicon.ico#" rel="shortcut icon" type="image/x-icon" />


### PR DESCRIPTION
This will prevent "honest" web crawlers from indexing each and every link
and Daily page from a Shaarli instance, thus getting rid of a certain
amount of unsollicited network traffic.
Please note that the"robots" tags is merely an indication for web robots
(crawlers, indexers) and may not be enforced by malicious bots.

See:
- http://www.robotstxt.org/
- http://www.robotstxt.org/robotstxt.html
- http://www.robotstxt.org/meta.html