### PR TITLE
Fixes #526: bad font size separator in tagcloud with some locale

### DIFF
--- a/index.php
+++ b/index.php
@@ -1015,11 +1015,16 @@ function renderPage()
             return strcasecmp($a, $b);
         });
 
-        $tagList=array();
-        foreach($tags as $key=>$value)
-        // Tag font size scaling: default 15 and 30 logarithm bases affect scaling, 22 and 6 are arbitrary font sizes for max and min sizes.
-        {
-            $tagList[$key] = array('count'=>$value,'size'=>log($value, 15) / log($maxcount, 30) * (22-6) + 6);
+        $tagList = array();
+        foreach($tags as $key => $value) {
+            // Tag font size scaling:
+            //   default 15 and 30 logarithm bases affect scaling,
+            //   22 and 6 are arbitrary font sizes for max and min sizes.
+            $size = log($value, 15) / log($maxcount, 30) * 2.2 + 0.8;
+            $tagList[$key] = array(
+                'count' => $value,
+                'size' => number_format($size, 2, '.', ''),
+            );
         }
 
         $data = array(

--- a/tpl/tagcloud.html
+++ b/tpl/tagcloud.html
@@ -12,8 +12,8 @@
 
     <div id="cloudtag">
         {loop="tags"}
-            <span class="count">{$value.count}</span>
-            <a href="?searchtags={$key|urlencode}" style="font-size:{$value.size}pt;">{$key}</a>
+            <span class="count">{$value.count}</span><a
+                href="?searchtags={$key|urlencode}" style="font-size:{$value.size}em;">{$key}</a>
             {loop="$value.tag_plugin"}
                 {$value}
             {/loop}


### PR DESCRIPTION
      * Force the number format with number_format().
      * Reduce the size deciment number to 2.