### PR TITLE
Fix error when filtering search tags

### DIFF
--- a/application/LinkFilter.php
+++ b/application/LinkFilter.php
@@ -322,7 +322,7 @@ class LinkFilter
         $tagsOut = $casesensitive ? $tags : mb_convert_case($tags, MB_CASE_LOWER, 'UTF-8');
         $tagsOut = str_replace(',', ' ', $tagsOut);
 
-        return array_filter(explode(' ', trim($tagsOut)), 'strlen');
+        return array_values(array_filter(explode(' ', trim($tagsOut)), 'strlen'));
     }
 }
 


### PR DESCRIPTION
Arrays are key-value maps. We should reindex the array after a filter
since we are using the key and count to do array access in filterTags.
An example would be searching for "foo, bar", after the array filter,
our array is actually (0 -> foo, 2 -> bar) which will cause an error
when trying to access $searchtags[1].