### PR TITLE
Use correct 'UTC' timezone

### DIFF
--- a/application/TimeZone.php
+++ b/application/TimeZone.php
@@ -101,10 +101,6 @@ function generateTimeZoneForm($preselectedTimezone='')
  */
 function isTimeZoneValid($continent, $city)
 {
-    if ($continent == 'UTC' && $city == 'UTC') {
-        return true;
-    }
-
     return in_array(
         $continent.'/'.$city,
         timezone_identifiers_list()

--- a/index.php
+++ b/index.php
@@ -1276,11 +1276,15 @@ function renderPage()
     {
         if (!empty($_POST['title']) )
         {
-            if (!tokenOk($_POST['token'])) die('Wrong token.'); // Go away!
+            if (!tokenOk($_POST['token'])) {
+                die('Wrong token.'); // Go away!
+            }
             $tz = 'UTC';
-            if (!empty($_POST['continent']) && !empty($_POST['city']))
-                if (isTimeZoneValid($_POST['continent'],$_POST['city']))
-                    $tz = $_POST['continent'].'/'.$_POST['city'];
+            if (!empty($_POST['continent']) && !empty($_POST['city'])
+                && isTimeZoneValid($_POST['continent'], $_POST['city'])
+            ) {
+                $tz = $_POST['continent'] . '/' . $_POST['city'];
+            }
             $GLOBALS['timezone'] = $tz;
             $GLOBALS['title']=$_POST['title'];
             $GLOBALS['titleLink']=$_POST['titleLink'];
@@ -2113,10 +2117,10 @@ function install()
     if (!empty($_POST['setlogin']) && !empty($_POST['setpassword']))
     {
         $tz = 'UTC';
-        if (!empty($_POST['continent']) && !empty($_POST['city'])) {
-            if (isTimeZoneValid($_POST['continent'], $_POST['city'])) {
-                $tz = $_POST['continent'].'/'.$_POST['city'];
-            }
+        if (!empty($_POST['continent']) && !empty($_POST['city'])
+            && isTimeZoneValid($_POST['continent'], $_POST['city'])
+        ) {
+            $tz = $_POST['continent'].'/'.$_POST['city'];
         }
         $GLOBALS['timezone'] = $tz;
         // Everything is ok, let's create config file.

--- a/tests/TimeZoneTest.php
+++ b/tests/TimeZoneTest.php
@@ -67,7 +67,6 @@ class TimeZoneTest extends PHPUnit_Framework_TestCase
     {
         $this->assertTrue(isTimeZoneValid('America', 'Argentina/Ushuaia'));
         $this->assertTrue(isTimeZoneValid('Europe', 'Oslo'));
-        $this->assertTrue(isTimeZoneValid('UTC', 'UTC'));
     }
 
     /**
@@ -78,5 +77,6 @@ class TimeZoneTest extends PHPUnit_Framework_TestCase
         $this->assertFalse(isTimeZoneValid('CEST', 'CEST'));
         $this->assertFalse(isTimeZoneValid('Europe', 'Atlantis'));
         $this->assertFalse(isTimeZoneValid('Middle_Earth', 'Moria'));
+        $this->assertFalse(isTimeZoneValid('UTC', 'UTC'));
     }
 }


### PR DESCRIPTION
During install or configuration, if `UTC/UTC` is selected, use the fallback value, `UTC`, which is a valid timezone.

Fixes #547 