### PR TITLE
Export: allow prepending notes with the Shaarli instance's URL

### DIFF
--- a/application/NetscapeBookmarkUtils.php
+++ b/application/NetscapeBookmarkUtils.php
@@ -13,17 +13,19 @@ class NetscapeBookmarkUtils
      * - timestamp  link addition date, using the Unix epoch format
      * - taglist    comma-separated tag list
      *
-     * @param LinkDB $linkDb    The link datastore
-     * @param string $selection Which links to export: (all|private|public)
+     * @param LinkDB $linkDb         Link datastore
+     * @param string $selection      Which links to export: (all|private|public)
+     * @param bool   $prependNoteUrl Prepend note permalinks with the server's URL
+     * @param string $indexUrl       Absolute URL of the Shaarli index page
      *
      * @throws Exception Invalid export selection
      *
      * @return array The links to be exported, with additional fields
      */
-    public static function filterAndFormat($linkDb, $selection)
+    public static function filterAndFormat($linkDb, $selection, $prependNoteUrl, $indexUrl)
     {
         // see tpl/export.html for possible values
-        if (! in_array($selection, array('all','public','private'))) {
+        if (! in_array($selection, array('all', 'public', 'private'))) {
             throw new Exception('Invalid export selection: "'.$selection.'"');
         }
 
@@ -39,6 +41,11 @@ class NetscapeBookmarkUtils
             $date = DateTime::createFromFormat(LinkDB::LINK_DATE_FORMAT, $link['linkdate']);
             $link['timestamp'] = $date->getTimestamp();
             $link['taglist'] = str_replace(' ', ',', $link['tags']);
+
+            if (startsWith($link['url'], '?') && $prependNoteUrl) {
+                $link['url'] = $indexUrl . $link['url'];
+            }
+
             $bookmarkLinks[] = $link;
         }
 

--- a/index.php
+++ b/index.php
@@ -1590,8 +1590,9 @@ function renderPage()
         exit;
     }
 
-    // -------- Export as Netscape Bookmarks HTML file.
     if ($targetPage == Router::$PAGE_EXPORT) {
+        // Export links as a Netscape Bookmarks file
+
         if (empty($_GET['selection'])) {
             $PAGE->assign('linkcount',count($LINKSDB));
             $PAGE->renderPage('export');
@@ -1600,10 +1601,21 @@ function renderPage()
 
         // export as bookmarks_(all|private|public)_YYYYmmdd_HHMMSS.html
         $selection = $_GET['selection'];
+        if (isset($_GET['prepend_note_url'])) {
+            $prependNoteUrl = $_GET['prepend_note_url'];
+        } else {
+            $prependNoteUrl = false;
+        }
+
         try {
             $PAGE->assign(
                 'links',
-                NetscapeBookmarkUtils::filterAndFormat($LINKSDB, $selection)
+                NetscapeBookmarkUtils::filterAndFormat(
+                    $LINKSDB,
+                    $selection,
+                    $prependNoteUrl,
+                    index_url($_SERVER)
+                )
             );
         } catch (Exception $exc) {
             header('Content-Type: text/plain; charset=utf-8');

--- a/tests/NetscapeBookmarkUtilsTest.php
+++ b/tests/NetscapeBookmarkUtilsTest.php
@@ -39,7 +39,7 @@ class NetscapeBookmarkUtilsTest extends PHPUnit_Framework_TestCase
      */
     public function testFilterAndFormatInvalid()
     {
-        NetscapeBookmarkUtils::filterAndFormat(self::$linkDb, 'derp');
+        NetscapeBookmarkUtils::filterAndFormat(self::$linkDb, 'derp', false, '');
     }
 
     /**
@@ -47,7 +47,7 @@ class NetscapeBookmarkUtilsTest extends PHPUnit_Framework_TestCase
      */
     public function testFilterAndFormatAll()
     {
-        $links = NetscapeBookmarkUtils::filterAndFormat(self::$linkDb, 'all');
+        $links = NetscapeBookmarkUtils::filterAndFormat(self::$linkDb, 'all', false, '');
         $this->assertEquals(self::$refDb->countLinks(), sizeof($links));
         foreach ($links as $link) {
             $date = DateTime::createFromFormat(LinkDB::LINK_DATE_FORMAT, $link['linkdate']);
@@ -67,7 +67,7 @@ class NetscapeBookmarkUtilsTest extends PHPUnit_Framework_TestCase
      */
     public function testFilterAndFormatPrivate()
     {
-        $links = NetscapeBookmarkUtils::filterAndFormat(self::$linkDb, 'private');
+        $links = NetscapeBookmarkUtils::filterAndFormat(self::$linkDb, 'private', false, '');
         $this->assertEquals(self::$refDb->countPrivateLinks(), sizeof($links));
         foreach ($links as $link) {
             $date = DateTime::createFromFormat(LinkDB::LINK_DATE_FORMAT, $link['linkdate']);
@@ -87,7 +87,7 @@ class NetscapeBookmarkUtilsTest extends PHPUnit_Framework_TestCase
      */
     public function testFilterAndFormatPublic()
     {
-        $links = NetscapeBookmarkUtils::filterAndFormat(self::$linkDb, 'public');
+        $links = NetscapeBookmarkUtils::filterAndFormat(self::$linkDb, 'public', false, '');
         $this->assertEquals(self::$refDb->countPublicLinks(), sizeof($links));
         foreach ($links as $link) {
             $date = DateTime::createFromFormat(LinkDB::LINK_DATE_FORMAT, $link['linkdate']);
@@ -100,5 +100,35 @@ class NetscapeBookmarkUtilsTest extends PHPUnit_Framework_TestCase
                 $link['taglist']
             );
         }
+    }
+
+    /**
+     * Do not prepend notes with the Shaarli index's URL
+     */
+    public function testFilterAndFormatDoNotPrependNoteUrl()
+    {
+        $links = NetscapeBookmarkUtils::filterAndFormat(self::$linkDb, 'public', false, '');
+        $this->assertEquals(
+            '?WDWyig',
+            $links[0]['url']
+        );
+    }
+
+    /**
+     * Prepend notes with the Shaarli index's URL
+     */
+    public function testFilterAndFormatPrependNoteUrl()
+    {
+        $indexUrl = 'http://localhost:7469/shaarli/';
+        $links = NetscapeBookmarkUtils::filterAndFormat(
+            self::$linkDb,
+            'public',
+            true,
+            $indexUrl
+        );
+        $this->assertEquals(
+            $indexUrl . '?WDWyig',
+            $links[0]['url']
+        );
     }
 }

--- a/tpl/export.html
+++ b/tpl/export.html
@@ -5,15 +5,21 @@
   <div id="pageheader">
     {include="page.header"}
     <div id="toolsdiv">
-      <a href="?do=export&amp;selection=all">
-        <b>Export all</b><span>: Export all links</span>
-      </a><br>
-      <a href="?do=export&amp;selection=public">
-        <b>Export public</b><span>: Only export public links</span>
-      </a><br>
-      <a href="?do=export&amp;selection=private">
-        <b>Export private</b><span>: Only export private links</span>
-      </a>
+      <form method="GET">
+        <input type="hidden" name="do" value="export">
+        Selection:<br>
+        <input type="radio" name="selection" value="all" checked="true"> All<br>
+        <input type="radio" name="selection" value="private"> Private<br>
+        <input type="radio" name="selection" value="public"> Public<br>
+        <br>
+        <input type="checkbox" name="prepend_note_url" id="prepend_note_url">
+        <label for="prepend_note_url">
+          Prepend note permalinks with this Shaarli instance's URL
+          <em>(useful to import bookmarks in a web browser)</em>
+        </label>
+        <br><br>
+        <input class="bigbutton" type="submit" value="Export">
+      </form>
       <div class="clear"></div>
     </div>
   </div>


### PR DESCRIPTION
Relates to #102

Additions:
- application:
  - export: allow prepending note permalinks with the instance's URL
  - test coverage

Modifications:
- export template: switch to an HTML form
  - link selection (all/private/public)
  - prepend note permalinks with the instance's URL