### PR TITLE
Remove delicious from Shaarli description

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ![Shaarli logo](doc/images/doc-logo.png)
 
-The personal, minimalist, super-fast, no-database delicious clone.
+The personal, minimalist, super-fast, database free, bookmarking service.
 
 _Do you want to share the links you discover?_
 _Shaarli is a minimalist delicious clone that you can install on your own server._

--- a/tpl/page.footer.html
+++ b/tpl/page.footer.html
@@ -1,5 +1,7 @@
 <div id="footer">
-    <b><a href="https://github.com/shaarli/Shaarli">Shaarli</a></b> - The personal, minimalist, super-fast, no-database delicious clone by the <a href="https://github.com/shaarli/Shaarli">Shaarli</a> community - <a href="doc/Home.html">Help/documentation</a>
+  <strong><a href="https://github.com/shaarli/Shaarli">Shaarli</a></strong>
+  - The personal, minimalist, super-fast, database free, bookmarking service by the Shaarli community
+  - <a href="doc/Home.html" rel="nofollow">Help/documentation</a>
     {loop="$plugins_footer.text"}
         {$value}
     {/loop}


### PR DESCRIPTION
Because Shaarli isn't a delicious clone. Also it's 2016 and delicious is more or less dead.

I've also added a 'nofollow' instruction to the docs, because if you search Shaarli inyour favorite search engine you might notice a bunch of links to the documentation from random Shaarli's instances.