### PR TITLE
Markdown: inline code background color

### DIFF
--- a/plugins/markdown/markdown.css
+++ b/plugins/markdown/markdown.css
@@ -143,6 +143,13 @@
     hyphens: none;  
 }
 
+.markdown :not(pre) code {
+    background-color: #eee;
+    padding: 1px 3px;
+    border-radius: 1px;
+    box-shadow: 0 -1px 0 #e5e5e5,0 0 1px rgba(0,0,0,0.12),0 1px 1px rgba(0,0,0,0.24);
+}
+
 .md_help {
     color: white;
 }


### PR DESCRIPTION
To make it more visible. Fixes #511 