### PR TITLE
Url.php: remove unwanted ?PHPSESSID= URL parameters

### DIFF
--- a/application/Url.php
+++ b/application/Url.php
@@ -99,6 +99,7 @@ class Url
         'action_type_map=',
         'fb_',
         'fb=',
+        'PHPSESSID=',
 
         // Scoop.it
         '__scoop',

--- a/tests/Url/UrlTest.php
+++ b/tests/Url/UrlTest.php
@@ -85,6 +85,7 @@ class UrlTest extends PHPUnit_Framework_TestCase
         $this->assertUrlIsCleaned('?utm_term=1n4l');
 
         $this->assertUrlIsCleaned('?xtor=some-url');
+        $this->assertUrlIsCleaned('?PHPSESSID=012345678910111213');
     }
 
     /**


### PR DESCRIPTION
As seen on https://lafibre.info/online/datacenter-dc3-diliad/ and many other websites.