### PR TITLE
The "nomarkdown" tag is no longer private

### DIFF
--- a/plugins/markdown/markdown.php
+++ b/plugins/markdown/markdown.php
@@ -10,9 +10,8 @@ require_once 'Parsedown.php';
 
 /*
  * If this tag is used on a shaare, the description won't be processed by Parsedown.
- * Using a private tag so it won't appear for visitors.
  */
-define('NO_MD_TAG', '.nomarkdown');
+define('NO_MD_TAG', 'nomarkdown');
 
 /**
  * Parse linklist descriptions.
@@ -25,11 +24,11 @@ function hook_markdown_render_linklist($data)
 {
     foreach ($data['links'] as &$value) {
         if (!empty($value['tags']) && noMarkdownTag($value['tags'])) {
+            $value['taglist'] = stripNoMarkdownTag($value['taglist']);
             continue;
         }
         $value['description'] = process_markdown($value['description']);
     }
-
     return $data;
 }
 
@@ -44,6 +43,7 @@ function hook_markdown_render_feed($data)
 {
     foreach ($data['links'] as &$value) {
         if (!empty($value['tags']) && noMarkdownTag($value['tags'])) {
+            $value['tags'] = stripNoMarkdownTag($value['tags']);
             continue;
         }
         $value['description'] = process_markdown($value['description']);
@@ -84,6 +84,19 @@ function hook_markdown_render_daily($data)
 function noMarkdownTag($tags)
 {
     return strpos($tags, NO_MD_TAG) !== false;
+}
+
+/**
+ * Remove the no-markdown meta tag so it won't be displayed.
+ *
+ * @param string $tags Tag list.
+ *
+ * @return string tag list without no markdown tag.
+ */
+function stripNoMarkdownTag($tags)
+{
+    unset($tags[array_search(NO_MD_TAG, $tags)]);
+    return array_values($tags);
 }
 
 /**

--- a/tests/plugins/PluginMarkdownTest.php
+++ b/tests/plugins/PluginMarkdownTest.php
@@ -125,7 +125,8 @@ class PluginMarkdownTest extends PHPUnit_Framework_TestCase
         $data = array(
             'links' => array(array(
                 'description' => $str,
-                'tags' => NO_MD_TAG
+                'tags' => NO_MD_TAG,
+                'taglist' => array(NO_MD_TAG),
             ))
         );
 
@@ -140,7 +141,8 @@ class PluginMarkdownTest extends PHPUnit_Framework_TestCase
                     // nth link
                     0 => array(
                         'formatedDescription' => $str,
-                        'tags' => NO_MD_TAG
+                        'tags' => NO_MD_TAG,
+                        'taglist' => array(),
                     ),
                 ),
             ),


### PR DESCRIPTION
A private tag is never loaded for visitor, making this feature useless. 

This tag is no longer private, *but* always hidden in linklist.

From Gitter:
> **@nodiscc**: I've read about a possible bug in the markdown plugin, just a reminder to check for this http://shaarli.guiguishow.info/?PAenmg
> **@ArthurHoaro**: Oh. That was stupid. The .nomarkdown tag is private, so it's never loaded for visitors.

EDIT: backquotes in the commit message didn't work very well.