### PR TITLE
Fixes #497: ignore case difference between tags

### DIFF
--- a/application/LinkDB.php
+++ b/application/LinkDB.php
@@ -417,11 +417,18 @@ You use the community supported version of the original Shaarli project, by Seba
     public function allTags()
     {
         $tags = array();
+        $caseMapping = array();
         foreach ($this->_links as $link) {
             foreach (explode(' ', $link['tags']) as $tag) {
-                if (!empty($tag)) {
-                    $tags[$tag] = (empty($tags[$tag]) ? 1 : $tags[$tag] + 1);
+                if (empty($tag)) {
+                    continue;
                 }
+                // The first case found will be displayed.
+                if (!isset($caseMapping[strtolower($tag)])) {
+                    $caseMapping[strtolower($tag)] = $tag;
+                    $tags[$caseMapping[strtolower($tag)]] = 0;
+                }
+                $tags[$caseMapping[strtolower($tag)]]++;
             }
         }
         // Sort tags by usage (most used tag first)

--- a/tests/FeedBuilderTest.php
+++ b/tests/FeedBuilderTest.php
@@ -93,7 +93,7 @@ class FeedBuilderTest extends PHPUnit_Framework_TestCase
         $this->assertContains('Permalink', $link['description']);
         $this->assertContains('http://host.tld/?WDWyig', $link['description']);
         $this->assertEquals(1, count($link['taglist']));
-        $this->assertEquals('stuff', $link['taglist'][0]);
+        $this->assertEquals('sTuff', $link['taglist'][0]);
 
         // Test URL with external link.
         $this->assertEquals('https://static.fsf.org/nosvn/faif-2.0.pdf', $data['links']['20150310_114633']['url']);

--- a/tests/LinkDBTest.php
+++ b/tests/LinkDBTest.php
@@ -290,7 +290,9 @@ class LinkDBTest extends PHPUnit_Framework_TestCase
                 'stallman' => 1,
                 'free' => 1,
                 '-exclude' => 1,
-                'stuff' => 2,
+                // The DB contains a link with `sTuff` and another one with `stuff` tag.
+                // They need to be grouped with the first case found (`sTuff`).
+                'sTuff' => 2,
             ),
             self::$publicLinkDB->allTags()
         );
@@ -310,7 +312,7 @@ class LinkDBTest extends PHPUnit_Framework_TestCase
                 'w3c' => 1,
                 'css' => 1,
                 'Mercurial' => 1,
-                'stuff' => 2,
+                'sTuff' => 2,
                 '-exclude' => 1,
                 '.hidden' => 1,
             ),

--- a/tests/utils/ReferenceLinkDB.php
+++ b/tests/utils/ReferenceLinkDB.php
@@ -21,7 +21,7 @@ class ReferenceLinkDB
             'Stallman has a beard and is part of the Free Software Foundation (or not). Seriously, read this.',
             0,
             '20150310_114651',
-            'stuff'
+            'sTuff'
         );
 
         $this->addLink(


### PR DESCRIPTION
When retrieving all tags, case differences will be ignored.
This affects:

  * tag cloud
  * tag autocompletion