### PR TITLE
Fixes #600 - Shaarli's title is not set with the new config manager

### DIFF
--- a/application/PageBuilder.php
+++ b/application/PageBuilder.php
@@ -68,18 +68,12 @@ class PageBuilder
         $this->tpl->assign('source', index_url($_SERVER));
         $this->tpl->assign('version', shaarli_version);
         $this->tpl->assign('scripturl', index_url($_SERVER));
-        $this->tpl->assign('pagetitle', 'Shaarli');
         $this->tpl->assign('privateonly', !empty($_SESSION['privateonly'])); // Show only private links?
-        if ($this->conf->exists('general.title')) {
-            $this->tpl->assign('pagetitle', $this->conf->get('general.title'));
-        }
+        $this->tpl->assign('pagetitle', $this->conf->get('general.title', 'Shaarli'));
         if ($this->conf->exists('general.header_link')) {
             $this->tpl->assign('titleLink', $this->conf->get('general.header_link'));
         }
-        if ($this->conf->exists('pagetitle')) {
-            $this->tpl->assign('pagetitle', $this->conf->get('pagetitle'));
-        }
-        $this->tpl->assign('shaarlititle', $this->conf->get('title', 'Shaarli'));
+        $this->tpl->assign('shaarlititle', $this->conf->get('general.title', 'Shaarli'));
         $this->tpl->assign('openshaarli', $this->conf->get('security.open_shaarli', false));
         $this->tpl->assign('showatom', $this->conf->get('feed.show_atom', false));
         $this->tpl->assign('hide_timestamps', $this->conf->get('privacy.hide_timestamps', false));

--- a/index.php
+++ b/index.php
@@ -1675,10 +1675,7 @@ function buildLinkList($PAGE,$LINKSDB, $conf, $pluginManager)
         $keys[] = $key;
     }
 
-    // If there is only a single link, we change on-the-fly the title of the page.
-    if (count($linksToDisplay) == 1) {
-        $conf->set('pagetitle', $linksToDisplay[$keys[0]]['title'] .' - '. $conf->get('general.title'));
-    }
+
 
     // Select articles according to paging.
     $pagecount = ceil(count($keys) / $_SESSION['LINKS_PER_PAGE']);
@@ -1740,9 +1737,10 @@ function buildLinkList($PAGE,$LINKSDB, $conf, $pluginManager)
         'links' => $linkDisp,
         'tags' => $LINKSDB->allTags(),
     );
-    // FIXME! temporary fix - see #399.
-    if ($conf->exists('pagetitle') && count($linkDisp) == 1) {
-        $data['pagetitle'] = $conf->get('pagetitle');
+
+    // If there is only a single link, we change on-the-fly the title of the page.
+    if (count($linksToDisplay) == 1) {
+        $data['pagetitle'] = $linksToDisplay[$keys[0]]['title'] .' - '. $conf->get('general.title');
     }
 
     $pluginManager->executeHooks('render_linklist', $data, array('loggedin' => isLoggedIn()));


### PR DESCRIPTION
  - Fixed title config key
  - Page title (in head tag) is no longer set through the config manager