### PR TITLE
Reference netscape-bookmark-parser & allow generating custom release archives

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-# Ignore data/, tmp/, cache/ and pagecache/
+# Shaarli runtime resources
 data
 tmp
 cache
@@ -9,18 +9,22 @@ pagecache
 .buildpath
 .project
 
-# Ignore raintpl generated pages
+# Raintpl generated pages
 *.rtpl.php
 
-# Ignore test dependencies
+# 3rd-party dependencies
 composer.lock
-/vendor/
+vendor/
 
-# Ignore development and test resources
+# Release archives
+*.tar
+*.zip
+
+# Development and test resources
 coverage
 doxygen
 sandbox
 phpmd.html
 
-# Ignore user plugin configuration
+# User plugin configuration
 plugins/*/config.php

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 # The personal, minimalist, super-fast, database free, bookmarking service.
-# Makefile for PHP code analysis & testing
+# Makefile for PHP code analysis & testing, documentation and release generation
 
 # Prerequisites:
 # - install Composer, either:
@@ -126,6 +126,34 @@ test:
 	@echo "-------"
 	@mkdir -p sandbox
 	@$(BIN)/phpunit tests
+
+##
+# Custom release archive generation
+#
+# For each tagged revision, GitHub provides tar and zip archives that correspond
+# to the output of git-archive
+#
+# These targets produce similar archives, featuring 3rd-party dependencies
+# to ease deployment on shared hosting.
+##
+ARCHIVE_VERSION := shaarli-$$(git describe)-full
+
+release_archive: release_tar release_zip
+
+### download 3rd-party PHP libraries
+composer_dependencies: clean
+	composer update --no-dev
+	find vendor/ -name ".git" -type d -exec rm -rf {} +
+
+### generate a release tarball and include 3rd-party dependencies
+release_tar: composer_dependencies
+	git archive -o $(ARCHIVE_VERSION).tar HEAD
+	tar rvf $(ARCHIVE_VERSION).tar vendor/
+
+### generate a release zip and include 3rd-party dependencies
+release_zip: composer_dependencies
+	git archive -o $(ARCHIVE_VERSION).zip -9 HEAD
+	zip -r $(ARCHIVE_VERSION).zip vendor/
 
 ##
 # Targets for repository and documentation maintenance

--- a/composer.json
+++ b/composer.json
@@ -9,8 +9,15 @@
         "wiki": "https://github.com/shaarli/Shaarli/wiki"
     },
     "keywords": ["bookmark", "link", "share", "web"],
+    "repositories": [
+        {
+            "type": "vcs",
+            "url": "https://github.com/shaarli/netscape-bookmark-parser"
+        }
+    ],
     "require": {
-        "php": ">=5.3.4"
+        "php": ">=5.3.4",
+        "kafene/netscape-bookmark-parser": "dev-shaarli-stable"
     },
     "require-dev": {
         "phpmd/phpmd" : "@stable",


### PR DESCRIPTION
See #607

- reference https://github.com/shaarli/netscape-bookmark-parser as a Composer VCS repository
- allow generating custom release archives (tarball, zip) containing 3rd-party dependencies

TODO:
- check on a dummy fork that GitHub-generated release archives can be replaced/superseded by manually uploaded archives
- tweak `git describe` output (used to name archives)
- archiving commands are currently _quiet_ - set them to be _verbose_?