### PR TITLE
Shaarli API first step

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -1,0 +1,2 @@
+RewriteEngine on
+RewriteRule ^(.*/?)api/v(\d+)(/.*)$ $1index.php?do=api&version=$2&q=$3&%{QUERY_STRING} [L]

--- a/application/LinkDB.php
+++ b/application/LinkDB.php
@@ -474,4 +474,22 @@ You use the community supported version of the original Shaarli project, by Seba
 
         return $linkDays;
     }
+
+    /**
+     * Reload all links from the datastore.
+     */
+    public function refresh()
+    {
+        $this->_readDB();
+    }
+
+    /**
+     * Force the user login state.
+     *
+     * @param boolean $loggedIn true logged in user (can load private links).
+     */
+    public function setLoggedIn($loggedIn)
+    {
+        $this->_loggedIn = $loggedIn;
+    }
 }

--- a/application/LinkUtils.php
+++ b/application/LinkUtils.php
@@ -81,7 +81,7 @@ function html_extract_charset($html)
 /**
  * Count private links in given linklist.
  *
- * @param array $links Linklist.
+ * @param array|Countable $links Linklist.
  *
  * @return int Number of private links.
  */

--- a/application/Router.php
+++ b/application/Router.php
@@ -43,6 +43,8 @@ class Router
 
     public static $PAGE_SAVE_PLUGINSADMIN = 'save_pluginadmin';
 
+    public static $API = 'api';
+
     /**
      * Reproducing renderPage() if hell, to avoid regression.
      *
@@ -89,6 +91,10 @@ class Router
 
         if (startsWith($query, 'do='. self::$PAGE_FEED_RSS)) {
             return self::$PAGE_FEED_RSS;
+        }
+
+        if (startsWith($query, 'do='. self::$API)) {
+            return self::$API;
         }
 
         // At this point, only loggedin pages.

--- a/application/Updater.php
+++ b/application/Updater.php
@@ -215,6 +215,29 @@ class Updater
         }
         return true;
     }
+
+    /**
+     * Initialize API settings:
+     *   - api.enabled: true
+     *   - api.secret: generated secret
+     */
+    public function updateMethodApiSettings()
+    {
+        if ($this->conf->exists('api.secret')) {
+            return true;
+        }
+
+        $this->conf->set('api.enabled', true);
+        $this->conf->set(
+            'api.secret',
+            generate_api_secret(
+                $this->conf->get('credentials.login'),
+                $this->conf->get('credentials.salt')
+            )
+        );
+        $this->conf->write($this->isLoggedIn);
+        return true;
+    }
 }
 
 /**

--- a/application/Utils.php
+++ b/application/Utils.php
@@ -221,3 +221,29 @@ function autoLocale($headerLocale)
     }
     setlocale(LC_ALL, $attempts);
 }
+
+/**
+ * Generates a default API secret.
+ *
+ * Note that the random-ish methods used in this function are predictable,
+ * which makes them NOT suitable for crypto.
+ * BUT the random string is salted with the salt and hashed with the username.
+ * It makes the generated API secret secured enough for Shaarli.
+ *
+ * PHP 7 provides random_int(), designed for cryptography.
+ * More info: http://stackoverflow.com/questions/4356289/php-random-string-generator
+
+ * @param string $username Shaarli login username
+ * @param string $salt     Shaarli password hash salt
+ *
+ * @return string|bool Generated API secret, 12 char length.
+ *                     Or false if invalid parameters are provided (which will make the API unusable).
+ */
+function generate_api_secret($username, $salt)
+{
+    if (empty($username) || empty($salt)) {
+        return false;
+    }
+
+    return str_shuffle(substr(hash_hmac('sha512', uniqid($salt), $username), 10, 12));
+}

--- a/application/api/Api.php
+++ b/application/api/Api.php
@@ -1,0 +1,180 @@
+<?php
+
+require_once 'ApiResponse.php';
+require_once 'ApiException.php';
+
+/**
+ * Class Api
+ *
+ * Shaarli's API V1. This class validates and processes API request, and returns an ApiResponse.
+ */
+class Api
+{
+    /**
+     * @var int Number of item returned by default.
+     */
+    public static $DEFAULT_LIMIT = 20;
+
+    /**
+     * @var int JWT token validity in seconds.
+     */
+    public static $TOKEN_DURATION = 540;
+
+    /**
+     * @var ConfigManager instance.
+     */
+    protected $conf;
+
+    /**
+     * @var LinkDB instance.
+     */
+    protected $linkDB;
+
+    /**
+     * @var PluginManager instance.
+     */
+    protected $pluginManager;
+
+    /**
+     * @var array List of allowed service methods.
+     */
+    protected static $allowedMethod = array(
+        'getInfo',
+    );
+
+    /**
+     * Api constructor.
+     *
+     * @param $conf          ConfigManager instance.
+     * @param $linkDB        LinkDB        instance.
+     * @param $pluginManager PluginManager instnace.
+     */
+    public function __construct(&$conf, $linkDB, $pluginManager)
+    {
+        $this->conf = $conf;
+        $this->linkDB = $linkDB;
+        /*
+           FIXME!
+           This is a workaround to load private links even though the user is not logged in Shaarli.
+           We need to refactor how links are loaded and rendered (also needed for other features).
+        */
+        $this->linkDB->setLoggedIn(true);
+        $this->linkDB->refresh();
+        $this->pluginManager = $pluginManager;
+    }
+
+    /**
+     * Service request processor:
+     *   - Validates the request (token, generic parameters, etc.)
+     *   - Calls the appropriate service with formatted parameters.
+     *   - Returns the ApiResponse processed by the service, created due to an error.
+     *
+     * @param $server  array  $_SERVER.
+     * @param $headers array  List of all request headers (must include `jwt`).
+     * @param $get     array  $_GET.
+     * @param $body    string Request body content as a string.
+     *
+     * @return ApiResponse
+     */
+    public function call($server, $headers, $get, $body)
+    {
+        try {
+            $this->checkRequest($server, $headers, $get);
+            $pathParams = ApiUtils::getPathParameters($get['q']);
+            $method = ApiUtils::getMethod($server['REQUEST_METHOD'], $get['q']);
+            if (! in_array($method, static::$allowedMethod)) {
+                throw new ApiAuthorizationException('Method "'. $method .'"" is not allowed');
+            }
+
+            $body = ApiUtils::parseRequestBody($body);
+            $response = $this->$method($get, $pathParams, $body);
+            if (! $response instanceof ApiResponse) {
+                throw new ApiInternalException('Couldn\'t build the response');
+            }
+            return $response;
+        } catch (Exception $e) {
+            if (! $e instanceof ApiException) {
+                $e = new ApiInternalException($e->getMessage(), 500, $e);
+            }
+
+            $e->setDebug($this->conf->get('dev.debug'));
+            $e->setServer($server);
+            $e->setHeaders($headers);
+            $e->setGet($get);
+            $e->setBody($body);
+            return $e->getApiResponse();
+        }
+    }
+
+    /**
+     * Produces link counters and a few useful settings.
+     *
+     * @return array Information about Shaarli's instance.
+     */
+    public function getInfo()
+    {
+        $info = array(
+            'global_counter' => count($this->linkDB),
+            'private_counter' => count_private($this->linkDB),
+            'settings' => array(
+                'title' => $this->conf->get('general.title', 'Shaarli'),
+                'header_link' => $this->conf->get('general.header_link', '?'),
+                'timezone' => $this->conf->get('general.timezone', 'UTC'),
+                'enabled_plugins' => $this->conf->get('general.enabled_plugins', array()),
+                'default_private_links' => $this->conf->get('privacy.default_private_links', false),
+            ),
+        );
+        return new ApiResponse(200, array(), $info);
+    }
+
+    /**
+     * Check the request validity (HTTP method, request value, etc.),
+     * that the API is enabled, and the JWT token validity.
+     *
+     * @param array $server  $_SERVER array.
+     * @param array $headers All request headers.
+     * @param array $get     Request parameters.
+     *
+     * @throws ApiAuthorizationException The API is disabled or the token is invalid.
+     * @throws ApiBadParametersException Invalid request.
+     */
+    protected function checkRequest($server, $headers, $get)
+    {
+        if (! $this->conf->get('api.enabled', true)) {
+            throw new ApiAuthorizationException('API is disabled');
+        }
+        if (empty($get['q']) || empty($server['REQUEST_METHOD'])) {
+            throw new ApiBadParametersException('Invalid API call');
+        }
+        $this->checkToken($headers);
+    }
+
+    /**
+     * Check that the JWT token is set and valid.
+     * The API secret setting must be set.
+     *
+     * @param array $headers HTTP headers.
+     *
+     * @throws ApiAuthorizationException The token couldn't be validated.
+     */
+    protected function checkToken($headers) {
+        if (empty($headers['jwt'])) {
+            throw new ApiAuthorizationException('JWT token not provided');
+        }
+
+        $secret = $this->conf->get('api.secret');
+        if (empty($secret)) {
+            throw new ApiAuthorizationException('Token secret must be set in Shaarli\'s administration');
+        }
+
+        ApiUtils::validateJwtToken($headers['jwt'], $this->conf->get('api.secret'));
+    }
+
+    /**
+     * @param ConfigManager $conf
+     */
+    public function setConf($conf)
+    {
+        $this->conf = $conf;
+    }
+}

--- a/application/api/ApiException.php
+++ b/application/api/ApiException.php
@@ -1,0 +1,168 @@
+<?php
+
+/**
+ * Class ApiException
+ *
+ * Parent Exception related to the API, able to generate a valid ApiResponse.
+ * Also can include various information in debug mode.
+ */
+abstract class ApiException extends Exception {
+    /**
+     * @var bool Debug mode enabled/disabled.
+     */
+    protected $debug;
+
+    /**
+     * @var array $_SERVER
+     */
+    protected $server;
+
+    /**
+     * @var array List of request parameters
+     */
+    protected $get;
+
+    /**
+     * @var array List of request headers
+     */
+    protected $headers;
+
+    /**
+     * @var string Body content.
+     */
+    protected $body;
+
+    /**
+     * Generate a valid ApiResponse for the exception.
+     *
+     * @return ApiResponse
+     */
+    public abstract function getApiResponse();
+
+    /**
+     * Creates ApiResponse body.
+     * In production mode, it will only return the exception message,
+     * but in dev mode, it includes additional information in an array.
+     *
+     * @return array|string response body
+     */
+    protected function getApiResponseBody() {
+        if ($this->debug !== true) {
+            return $this->getMessage();
+        }
+        return array(
+            $this->getMessage(),
+            $this->server,
+            $this->headers,
+            $this->get,
+            $this->body,
+            $this->getTraceAsString()
+        );
+    }
+
+    /**
+     * @param bool $debug
+     */
+    public function setDebug($debug)
+    {
+        $this->debug = $debug;
+    }
+
+    /**
+     * @param array $server
+     */
+    public function setServer($server)
+    {
+        $this->server = $server;
+    }
+
+    /**
+     * @param array $get
+     */
+    public function setGet($get)
+    {
+        $this->get = $get;
+    }
+
+    /**
+     * @param array $headers
+     */
+    public function setHeaders($headers)
+    {
+        $this->headers = $headers;
+    }
+
+    /**
+     * @param string $body
+     */
+    public function setBody($body)
+    {
+        $this->body = $body;
+    }
+}
+
+/**
+ * Class ApiInternalException
+ *
+ * Generic exception, return a 500 HTTP code.
+ */
+class ApiInternalException extends ApiException
+{
+    /**
+     * @inheritdoc
+     */
+    public function getApiResponse()
+    {
+        $error = ApiUtils::formatError(500, $this->getApiResponseBody());
+        return new ApiResponse(500, array(), $error);
+    }
+}
+
+/**
+ * Class ApiAuthorizationException
+ *
+ * Request not authorized, return a 401 HTTP code.
+ */
+class ApiAuthorizationException extends ApiException
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function getApiResponse()
+    {
+        $this->setMessage('Not authorized');
+        $error = ApiUtils::formatError(401, $this->getApiResponseBody());
+        return new ApiResponse(401, array(), $error);
+    }
+
+    /**
+     * Set the exception message.
+     *
+     * We only return a generic error message in production mode to avoid giving
+     * to much security information.
+     *
+     * @param $message string the exception message.
+     */
+    public function setMessage($message)
+    {
+        $original = $this->debug === true ? ': '. $this->getMessage() : '';
+        $this->message = $message . $original;
+    }
+}
+
+/**
+ * Class ApiBadParametersException
+ *
+ * Invalid request exception, return a 400 HTTP code.
+ */
+class ApiBadParametersException extends ApiException
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function getApiResponse()
+    {
+        $error = ApiUtils::formatError(400, $this->getApiResponseBody());
+        return new ApiResponse(400, array(), $error);
+    }
+}

--- a/application/api/ApiResponse.php
+++ b/application/api/ApiResponse.php
@@ -1,0 +1,86 @@
+<?php
+
+/**
+ * Class ApiResponse
+ *
+ * Bean containing the elements of an HTTP response.
+ */
+class ApiResponse
+{
+    /**
+     * @var int HTTP code.
+     */
+    protected $code;
+
+    /**
+     * @var array List of HTTP headers.
+     */
+    protected $headers;
+
+    /**
+     * @var mixed Body content in its PHP form (will be serialized to readable data, such as JSON).
+     */
+    protected $body;
+
+    /**
+     * ApiResponse constructor.
+     *
+     * @param $code
+     * @param $headers
+     * @param $body
+     */
+    public function __construct($code, $headers, $body)
+    {
+        $this->code = $code;
+        $this->headers = $headers;
+        $this->body = $body;
+    }
+
+    /**
+     * @return int
+     */
+    public function getCode()
+    {
+        return $this->code;
+    }
+
+    /**
+     * @param int $code
+     */
+    public function setCode($code)
+    {
+        $this->code = $code;
+    }
+
+    /**
+     * @return array
+     */
+    public function getHeaders()
+    {
+        return $this->headers;
+    }
+
+    /**
+     * @param array $headers
+     */
+    public function setHeaders($headers)
+    {
+        $this->headers = $headers;
+    }
+
+    /**
+     * @return mixed
+     */
+    public function getBody()
+    {
+        return $this->body;
+    }
+
+    /**
+     * @param mixed $body
+     */
+    public function setBody($body)
+    {
+        $this->body = $body;
+    }
+}

--- a/application/api/ApiUtils.php
+++ b/application/api/ApiUtils.php
@@ -1,0 +1,213 @@
+<?php
+
+/**
+ * Class ApiUtils
+ *
+ * Utility functions for the API.
+ */
+class ApiUtils
+{
+    /**
+     * Extract the service method name in Api from the request.
+     *
+     * FixMe! The current system (httpmethodServicename) isn't enough (e.g. getLinks).
+     *
+     * @param string $requestType HTTP Method name.
+     * @param string $query       API query parameter in $_GET.
+     *
+     * @return string Service method name.
+     */
+    public static function getMethod($requestType, $query)
+    {
+        $parts = explode('/', $query);
+        $request = ! empty($parts[1]) ? $parts[1] : '';
+        return strtolower($requestType) . ucfirst($request);
+    }
+
+    /**
+     * Extract the path parameters from the API query.
+     * Anything after the service name is a path parameter.
+     *
+     * @param string $query API query parameter in $_GET.
+     *
+     * @return array List of path parameters, or an empty array if none is provided.
+     */
+    public static function getPathParameters($query)
+    {
+        $parts = explode('/', $query);
+        $request = ! empty($parts[1]) ? $parts[1] : '';
+        return array_slice($parts, 2);
+    }
+
+    /**
+     * Create an API formatted link object from an internal link object.
+     *
+     * @param array $link Link in LinkDB format.
+     *
+     * @return array API formatted link.
+     */
+    public static function formatLink($link) {
+        if (empty($link['linkdate'])) {
+            return array();
+        }
+        if (! empty($link['tags'])) {
+            $tags = preg_split('/\s+/', $link['tags'], 0, PREG_SPLIT_NO_EMPTY);
+        }
+        $created = DateTime::createFromFormat(LinkDB::LINK_DATE_FORMAT, $link['linkdate']);
+
+        return array(
+            'id' => $link['linkdate'],
+            'url' => !empty($link['url']) ? $link['url'] : '',
+            'title' => !empty($link['title']) ? $link['title'] : '',
+            'description' => !empty($link['description']) ? $link['description'] : '',
+            'tags' => ! empty($tags) ? $tags : array(),
+            'private' => !empty($link['private']) ? $link['private'] : false,
+            'created' => $created->format(DateTime::ISO8601),
+            'updated' => '',
+        );
+    }
+
+    /**
+     * Convert a link given through a request, to a valid link for LinkDB.
+     *
+     * If no URL is provided, it will generate a local note URL.
+     * If no title is provided, it will use the URL as title.
+     *
+     * @param string $linkdate       Link identifier (link date).
+     * @param array  $input          Request Link.
+     * @param bool   $defaultPrivate Request Link.
+     *
+     * @return array Formatted link.
+     */
+    public static function buildLinkFromRequest($linkdate, $input, $defaultPrivate)
+    {
+        if (empty($input['url'])) {
+            $input['url'] = '?' . smallHash($linkdate);;
+        }
+
+        $link = array(
+            'linkdate'      => $linkdate,
+            'title'         => !empty($input['title']) ? $input['title'] : $input['url'],
+            'url'           => $input['url'],
+            'description'   => !empty($input['description']) ? $input['description'] : '',
+            'tags'          => !empty($input['tags']) ? implode(' ', $input['tags']) : '',
+            'private'       => isset($input['private']) ? $input['private'] === true : $defaultPrivate,
+        );
+
+        return $link;
+    }
+
+    /**
+     * Create a default error array for the API.
+     *
+     * @param int    $code    Error code, usually the HTTP code.
+     * @param string $message Error message.
+     *
+     * @return array Formatted error.
+     */
+    public static function formatError($code, $message)
+    {
+        return array(
+            'code' => $code,
+            'message' => $message,
+        );
+    }
+
+    /**
+     * Set response HTTP code.
+     * Uses a different method for PHP 5.3 because `http_response_code()` isn't available.
+     *
+     * @param int $code HTTP code.
+     */
+    public static function setHttpCode($code) {
+        if (function_exists('http_response_code')) {
+            http_response_code($code);
+        } else {
+            // PHP 5.3 fallback
+            header('X-PHP-Response-Code: '. $code, true, $code);
+        }
+    }
+
+    /**
+     * Validates a JWT token authenticity.
+     *
+     * @param string $token  JWT token extracted from the headers.
+     * @param string $secret API secret set in the settings.
+     *
+     * @throws ApiAuthorizationException the token is not valid.
+     */
+    public static function validateJwtToken($token, $secret)
+    {
+        $parts = explode('.', $token);
+        if (count($parts) != 3 || strlen($parts[0]) == 0 || strlen($parts[1]) == 0) {
+            throw new ApiAuthorizationException('Malformed JWT token');
+        }
+
+        $genSign = hash_hmac('sha512', $parts[0] .'.'. $parts[1], $secret);
+        if ($parts[2] != $genSign) {
+            throw new ApiAuthorizationException('Invalid JWT signature');
+        }
+
+        $header = json_decode(base64_decode($parts[0]));
+        if ($header === null) {
+            throw new ApiAuthorizationException('Invalid JWT header');
+        }
+
+        $payload = json_decode(base64_decode($parts[1]));
+        if ($payload === null) {
+            throw new ApiAuthorizationException('Invalid JWT payload');
+        }
+
+        if (empty($payload->iat)
+            || $payload->iat > time()
+            || time() - $payload->iat > Api::$TOKEN_DURATION
+        ) {
+            throw new ApiAuthorizationException('Invalid JWT issued time');
+        }
+    }
+
+    /**
+     * Display an API response in JSON format.
+     *
+     * @param ApiResponse $response API Response to be displayed.
+     */
+    public static function render($response)
+    {
+        ApiUtils::setHttpCode($response->getCode());
+        foreach ($response->getHeaders() as $header) {
+            header($header);
+        }
+        header('Content-Type: application/json');
+        $body = $response->getBody();
+        if (!empty($body)) {
+            echo json_encode($body);
+        }
+    }
+
+    /**
+     * Parse the JSON request body into an array.
+     *
+     * @param string $body HTTP request body as a string.
+     *
+     * @return array|null Parsed JSON array or null if the body is empty.
+     *
+     * @throws ApiBadParametersException An error occurred while trying to parse the JSON.
+     */
+    public static function parseRequestBody($body)
+    {
+        if (empty($body)) {
+            return null;
+        }
+        $body = json_decode($body, true);
+        if (json_last_error() != JSON_ERROR_NONE) {
+            // PHP 5.5
+            if (function_exists('json_last_error_msg')) {
+                $error = json_last_error_msg();
+            } else {
+                $error = 'JSON error #' . json_last_error();
+            }
+            throw new ApiBadParametersException('Invalid request content: ' . $error);
+        }
+        return $body;
+    }
+}

--- a/application/config/ConfigManager.php
+++ b/application/config/ConfigManager.php
@@ -20,6 +20,8 @@ class ConfigManager
      */
     protected static $NOT_FOUND = 'NOT_FOUND';
 
+    public static $DEFAULT_PLUGINS = array('qrcode');
+
     /**
      * @var string Config folder.
      */
@@ -306,7 +308,7 @@ class ConfigManager
 
         $this->setEmpty('general.header_link', '?');
         $this->setEmpty('general.links_per_page', 20);
-        $this->setEmpty('general.enabled_plugins', array('qrcode'));
+        $this->setEmpty('general.enabled_plugins', self::$DEFAULT_PLUGINS);
 
         $this->setEmpty('updates.check_updates', false);
         $this->setEmpty('updates.check_updates_branch', 'stable');

--- a/index.php
+++ b/index.php
@@ -1134,6 +1134,8 @@ function renderPage($conf, $pluginManager)
             $conf->set('feed.rss_permalinks', !empty($_POST['enableRssPermalinks']));
             $conf->set('updates.check_updates', !empty($_POST['updateCheck']));
             $conf->set('privacy.hide_public_links', !empty($_POST['hidePublicLinks']));
+            $conf->set('api.enabled', !empty($_POST['apiEnabled']));
+            $conf->set('api.secret', escape($_POST['apiSecret']));
             try {
                 $conf->write(isLoggedIn());
             }
@@ -1163,6 +1165,8 @@ function renderPage($conf, $pluginManager)
             $PAGE->assign('enable_rss_permalinks', $conf->get('feed.rss_permalinks', false));
             $PAGE->assign('enable_update_check', $conf->get('updates.check_updates', true));
             $PAGE->assign('hide_public_links', $conf->get('privacy.hide_public_links', false));
+            $PAGE->assign('api_enabled', $conf->get('api.enabled', true));
+            $PAGE->assign('api_secret', $conf->get('api.secret'));
             $PAGE->renderPage('configure');
             exit;
         }
@@ -1996,6 +2000,14 @@ function install($conf)
             $conf->set('general.title', 'Shared links on '.escape(index_url($_SERVER)));
         }
         $conf->set('updates.check_updates', !empty($_POST['updateCheck']));
+        $conf->set('api.enabled', !empty($_POST['enableApi']));
+        $conf->set(
+            'api.secret',
+            generate_api_secret(
+                $this->conf->get('credentials.login'),
+                $this->conf->get('credentials.salt')
+            )
+        );
         try {
             // Everything is ok, let's create config file.
             $conf->write(isLoggedIn());

--- a/index.php
+++ b/index.php
@@ -930,11 +930,29 @@ function renderPage($conf, $pluginManager)
         exit;
     }
 
-    // Display openseach plugin (XML)
+    // Display opensearch plugin (XML)
     if ($targetPage == Router::$PAGE_OPENSEARCH) {
         header('Content-Type: application/xml; charset=utf-8');
         $PAGE->assign('serverurl', index_url($_SERVER));
         $PAGE->renderPage('opensearch');
+        exit;
+    }
+
+    // API Call
+    if ($targetPage == Router::$API) {
+        require_once 'application/api/Api.php';
+        require_once 'application/api/ApiUtils.php';
+        require_once 'application/api/ApiResponse.php';
+
+        if (empty($_GET['version']) || $_GET['version'] != '1') {
+            $error = new ApiResponse(400, array(), ApiUtils::formatError(400, 'Unsupported version'));
+            ApiUtils::render($error);
+            exit;
+        }
+
+        $api = new Api($conf, $LINKSDB, $pluginManager);
+        $body = file_get_contents('php://input');
+        ApiUtils::render($api->call($_SERVER, getallheaders(), $_GET, $body));
         exit;
     }
 

--- a/plugins/markdown/markdown.php
+++ b/plugins/markdown/markdown.php
@@ -11,7 +11,9 @@ require_once 'Parsedown.php';
 /*
  * If this tag is used on a shaare, the description won't be processed by Parsedown.
  */
-define('NO_MD_TAG', 'nomarkdown');
+if (! defined('NO_MD_TAG')) {
+    define('NO_MD_TAG', 'nomarkdown');
+}
 
 /**
  * Parse linklist descriptions.

--- a/tests/Updater/UpdaterTest.php
+++ b/tests/Updater/UpdaterTest.php
@@ -270,7 +270,7 @@ $GLOBALS[\'privateLinkByDefault\'] = true;';
     public function testEscapeConfig()
     {
         $sandbox = 'sandbox/config';
-        copy(self::$configFile .'.json.php', $sandbox .'.json.php');
+        copy(self::$configFile . '.json.php', $sandbox . '.json.php');
         $this->conf = new ConfigManager($sandbox);
         $title = '<script>alert("title");</script>';
         $headerLink = '<script>alert("header_link");</script>';
@@ -285,6 +285,42 @@ $GLOBALS[\'privateLinkByDefault\'] = true;';
         $this->assertEquals(escape($title), $this->conf->get('general.title'));
         $this->assertEquals(escape($headerLink), $this->conf->get('general.header_link'));
         $this->assertEquals(escape($redirectorUrl), $this->conf->get('redirector.url'));
-        unlink($sandbox .'.json.php');
+        unlink($sandbox . '.json.php');
+    }
+
+    /**
+     * Test updateMethodApiSettings(): create default settings for the API (enabled + secret).
+     */
+    public function testUpdateApiSettings()
+    {
+        $confFile = 'sandbox/config';
+        copy(self::$configFile .'.json.php', $confFile .'.json.php');
+        $conf = new ConfigManager($confFile);
+        $updater = new Updater(array(), array(), $conf, true);
+
+        $this->assertFalse($conf->exists('api.enabled'));
+        $this->assertFalse($conf->exists('api.secret'));
+        $updater->updateMethodApiSettings();
+        $conf->reload();
+        $this->assertTrue($conf->get('api.enabled'));
+        $this->assertTrue($conf->exists('api.secret'));
+        unlink($confFile .'.json.php');
+    }
+
+    /**
+     * Test updateMethodApiSettings(): already set, do nothing.
+     */
+    public function testUpdateApiSettingsNothingToDo()
+    {
+        $confFile = 'sandbox/config';
+        copy(self::$configFile .'.json.php', $confFile .'.json.php');
+        $conf = new ConfigManager($confFile);
+        $conf->set('api.enabled', false);
+        $conf->set('api.secret', '');
+        $updater = new Updater(array(), array(), $conf, true);
+        $updater->updateMethodApiSettings();
+        $this->assertFalse($conf->get('api.enabled'));
+        $this->assertEmpty($conf->get('api.secret'));
+        unlink($confFile .'.json.php');
     }
 }

--- a/tests/UtilsTest.php
+++ b/tests/UtilsTest.php
@@ -253,4 +253,21 @@ class UtilsTest extends PHPUnit_Framework_TestCase
             is_session_id_valid('c0ZqcWF3VFE2NmJBdm1HMVQ0ZHJ3UmZPbTFsNGhkNHI=')
         );
     }
+
+    /**
+     * Test generateSecretApi.
+     */
+    public function testGenerateSecretApi()
+    {
+        $this->assertEquals(12, strlen(generate_api_secret('foo', 'bar')));
+    }
+
+    /**
+     * Test generateSecretApi with invalid parameters.
+     */
+    public function testGenerateSecretApiInvalid()
+    {
+        $this->assertFalse(generate_api_secret('', ''));
+        $this->assertFalse(generate_api_secret(false, false));
+    }
 }

--- a/tests/api/ApiTest.php
+++ b/tests/api/ApiTest.php
@@ -1,0 +1,289 @@
+<?php
+
+require_once 'DummyApi.php';
+
+/**
+ * Class ApiTest
+ */
+class ApiTest extends PHPUnit_Framework_TestCase
+{
+    /**
+     * @var string datastore to test write operations 
+     */
+    protected static $testDatastore = 'sandbox/datastore.php';
+
+    /**
+     * @var  ConfigManager instance 
+     */
+    protected $conf;
+
+    /** 
+     * @var  DummyApi instance. Api extension, with a test service. 
+     */
+    protected $api;
+
+    /**
+     * @var ReferenceLinkDB instance.
+     */
+    protected $refDB = null;
+
+    /**
+     * @var LinkDB instance.
+     */
+    protected $linkDB = null;
+
+    /**
+     * Before every test, instanciate a new Api with its config, plugins and links.
+     */
+    public function setUp()
+    {
+        $this->conf = new ConfigManager('tests/utils/config/configJson.json.php');
+        $this->conf->set('api.secret', 'NapoleonWasALizard');
+
+        $this->refDB = new ReferenceLinkDB();
+        $this->refDB->write(self::$testDatastore);
+
+        $this->linkDB = new LinkDB(self::$testDatastore, true, false);
+
+        $this->api = new DummyApi($this->conf, $this->linkDB, new PluginManager($this->conf));
+    }
+
+    /**
+     * After every test, remove the test datastore.
+     */
+    public function tearDown()
+    {
+        @unlink(self::$testDatastore);
+    }
+
+    /**
+     * Make a valid call to the test method in DummyApi.
+     * This test aims to test the call() method which validates parameters and call the appropriate service.
+     */
+    public function testDummyApiCallValid()
+    {
+        $token = self::generateJwtToken($this->conf->get('api.secret'));
+        $server = array(
+            'REQUEST_METHOD' => 'GET',
+        );
+        $headers = array('jwt' => $token);
+        $get = array(
+            'q' => '/dummy/path',
+            'foo' => 'bar',
+        );
+        $body = array('pika' => 'chu');
+        $response = $this->api->call($server, $headers, $get, json_encode($body));
+        $this->assertEquals(666, $response->getCode());
+        $this->assertEquals(array('header1', 'header2'), $response->getHeaders());
+        $this->assertEquals(
+            array(
+                'query' => $get,
+                'path' => array('path'),
+                'body' => $body,
+            ),
+            $response->getBody()
+        );
+
+        // Minimal call.
+        $get = array(
+            'q' => '/dummy',
+        );
+        $body = null;
+        $response = $this->api->call($server, $headers, $get, $body);
+        $this->assertEquals(666, $response->getCode());
+        $this->assertEquals(array('header1', 'header2'), $response->getHeaders());
+        $this->assertEquals(
+            array(
+                'query' => $get,
+                'path' => array(),
+                'body' => $body,
+            ),
+            $response->getBody()
+        );
+    }
+
+    /**
+     * Test call() with invalid parameters (missing HTTP method, etc.).
+     */
+    public function testDummyApiCallInvalid()
+    {
+        // Missing HTTP Method
+        $response = $this->api->call(array(), array(), array('q' => '/dummy'), '');
+        $this->assertInvalidCallResponse($response);
+
+        // Missing request
+        $response = $this->api->call(array('REQUEST_METHOD' => 'GET'), array(), array(), '');
+        $this->assertInvalidCallResponse($response);
+
+        // Bad body
+        $token = self::generateJwtToken($this->conf->get('api.secret'));
+        $response = $this->api->call(
+            array('REQUEST_METHOD' => 'GET'),
+            array('jwt' => $token),
+            array('q' => '/dummy'),
+            'not json'
+        );
+        $this->assertErrorResponse($response, 400, 'Invalid request content');
+    }
+
+    /**
+     * Make an unauthorized call().
+     * FIXME! split the test methods
+     */
+    public function testDummyApiCallNotAuthorized()
+    {
+        // Keep PHPUnit execution clean.
+        $oldlog = ini_get('error_log');
+        ini_set('error_log', '/dev/null');
+
+        // Missing token
+        $response = $this->api->call(array('REQUEST_METHOD' => 'GET'), array(), array('q' => '/dummy'), '');
+        $this->assertBadTokenResponse($response);
+
+        // Bad token
+        $response = $this->api->call(
+            array('REQUEST_METHOD' => 'GET'),
+            array('jwt' => 'nope.nope.nopes'),
+            array('q' => '/dummy'),
+            ''
+        );
+        $this->assertBadTokenResponse($response);
+        
+        // Invalid API service
+        $token = self::generateJwtToken($this->conf->get('api.secret'));
+        $response = $this->api->call(
+            array('REQUEST_METHOD' => 'GET'),
+            array('jwt' => $token),
+            array('q' => '/nope'),
+            ''
+        );
+        $this->assertBadTokenResponse($response);
+
+        // The API is disabled
+        $token = self::generateJwtToken($this->conf->get('api.secret'));
+        $this->conf->set('api.enabled', false);
+        $response = $this->api->call(
+            array('REQUEST_METHOD' => 'GET'),
+            array('jwt' => $token),
+            array('q' => '/dummy'),
+            ''
+        );
+        $this->assertBadTokenResponse($response);
+        $this->conf->set('api.enabled', true);
+
+        // Valid token but secret isn't set.
+        $this->conf->set('api.secret', '');
+        $response = $this->api->call(
+            array('REQUEST_METHOD' => 'GET'),
+            array('jwt' => $token),
+            array('q' => '/dummy'),
+            ''
+        );
+        $this->assertBadTokenResponse($response);
+
+        ini_set('error_log', $oldlog);
+    }
+
+    /**
+     * Test /info service.
+     */
+    public function testGetInfo()
+    {
+        /** @var ApiResponse $response */
+        $response = $this->api->getInfo();
+        $this->assertInstanceOf('ApiResponse', $response);
+        $this->assertEquals(200, $response->getCode());
+        $this->assertEmpty($response->getHeaders());
+        $data = $response->getBody();
+        $this->assertEquals(7, $data['global_counter']);
+        $this->assertEquals(2, $data['private_counter']);
+        $this->assertEquals('Shaarli', $data['settings']['title']);
+        $this->assertEquals('?', $data['settings']['header_link']);
+        $this->assertEquals('UTC', $data['settings']['timezone']);
+        $this->assertEquals(ConfigManager::$DEFAULT_PLUGINS, $data['settings']['enabled_plugins']);
+        $this->assertEquals(false, $data['settings']['default_private_links']);
+
+        $title = 'My links';
+        $headerLink = 'http://shaarli.tld';
+        $timezone = 'Europe/Paris';
+        $enabledPlugins = array('foo', 'bar');
+        $defaultPrivateLinks = true;
+        $this->conf->set('general.title', $title);
+        $this->conf->set('general.header_link', $headerLink);
+        $this->conf->set('general.timezone', $timezone);
+        $this->conf->set('general.enabled_plugins', $enabledPlugins);
+        $this->conf->set('privacy.default_private_links', $defaultPrivateLinks);
+
+        $response = $this->api->getInfo();
+        $this->assertEquals(200, $response->getCode());
+        $this->assertEmpty($response->getHeaders());
+        $data = $response->getBody();
+        $this->assertInstanceOf('ApiResponse', $response);
+        $this->assertEquals(7, $data['global_counter']);
+        $this->assertEquals(2, $data['private_counter']);
+        $this->assertEquals($title, $data['settings']['title']);
+        $this->assertEquals($headerLink, $data['settings']['header_link']);
+        $this->assertEquals($timezone, $data['settings']['timezone']);
+        $this->assertEquals($enabledPlugins, $data['settings']['enabled_plugins']);
+        $this->assertEquals($defaultPrivateLinks, $data['settings']['default_private_links']);
+    }
+
+    /**
+     * Assert than the given ApiResponse equals the error.
+     *
+     * @param ApiResponse $response The ApiResponse to test.
+     * @param int         $code     Expected HTTP code.
+     * @param string      $error    Expected error string.
+     */
+    public function assertErrorResponse($response, $code, $error = '')
+    {
+        $this->assertEquals($code, $response->getCode());
+        $this->assertEquals(array(), $response->getHeaders());
+        $error = ApiUtils::formatError($code, $error);
+        $body = $response->getBody();
+        $this->assertEquals($error['code'], $body['code']);
+        if (!empty($error['message'])) {
+            $this->assertContains($error['message'], $body['message']);
+        }
+    }
+
+    /**
+     * Assert than the given response equals a default bad token response.
+     *
+     * @param ApiResponse $response
+     */
+    protected function assertBadTokenResponse($response)
+    {
+        $this->assertErrorResponse($response, 401, 'Not authorized');
+    }
+
+    /**
+     * Assert than the given response equals a default invalid call response.
+     *
+     * @param ApiResponse $response
+     */
+    protected function assertInvalidCallResponse($response)
+    {
+        $this->assertErrorResponse($response, 400, 'Invalid API call');
+    }
+
+    /**
+     * Generate a valid JWT token.
+     * 
+     * @param string $secret API secret used to generate the signature.
+     * 
+     * @return string Generated token.
+     */
+    public static function generateJwtToken($secret)
+    {
+        $header = base64_encode('{
+            "typ": "JWT",
+            "alg": "HS512"
+        }');
+        $payload = base64_encode('{
+            "iat": '. time() .'
+        }');
+        $signature = hash_hmac('sha512', $header .'.'. $payload , $secret);
+        return $header .'.'. $payload .'.'. $signature;
+    }
+}

--- a/tests/api/ApiUtilsTest.php
+++ b/tests/api/ApiUtilsTest.php
@@ -1,0 +1,434 @@
+<?php
+
+require_once('application/api/ApiUtils.php');
+
+/**
+ * Class ApiUtilsTest
+ */
+class ApiUtilsTest extends PHPUnit_Framework_TestCase
+{
+    /**
+     * Force the timezone for ISO datetimes.
+     */
+    public static function setUpBeforeClass()
+    {
+        date_default_timezone_set('UTC');
+    }
+
+    /**
+     * Test getMethod() with valid data.
+     */
+    public function testGetMethod()
+    {
+        $this->assertEquals('getLinks', ApiUtils::getMethod('get', '/links'));
+        $this->assertEquals('getLinks', ApiUtils::getMethod('get', '/links/foo/bar'));
+    }
+
+    /**
+     * Test getMethod() with invalid data.
+     * No error/exception is raised, but invalid data should be ignored.
+     */
+    public function testGetMethodInvalid()
+    {
+        $this->assertEquals('foo', ApiUtils::getMethod('foo', 'bar'));
+        $this->assertEquals('getInvalid', ApiUtils::getMethod('get', 'links/invalid'));
+        $this->assertEquals('', ApiUtils::getMethod(false, false));
+        $this->assertEquals('', ApiUtils::getMethod('', ''));
+    }
+
+    /**
+     * Test getPathParameters with valid data.
+     */
+    public function testGetPathParameters()
+    {
+        $this->assertEquals(array(), ApiUtils::getPathParameters('/links'));
+        $this->assertEquals(array('foo'), ApiUtils::getPathParameters('/links/foo'));
+        $this->assertEquals(array('foo', 'bar'), ApiUtils::getPathParameters('/links/foo/bar'));
+    }
+
+    /**
+     * Test getPathParameters with invalid data.
+     */
+    public function testGetPathParametersInvalid()
+    {
+        $this->assertEquals(array(), ApiUtils::getPathParameters('bar'));
+        $this->assertEquals(array(), ApiUtils::getPathParameters('links/invalid'));
+        $this->assertEquals(array('path'), ApiUtils::getPathParameters('links/invalid/path'));
+        $this->assertEquals(array(), ApiUtils::getPathParameters(false));
+        $this->assertEquals(array(), ApiUtils::getPathParameters(''));
+    }
+
+    /**
+     * Test formatLink with complete an incomplete data.
+     */
+    public function testFormatLink()
+    {
+        $link = array(
+            'linkdate' => '20160718_100001',
+            'url' => 'http://foobar.tld',
+            'title' => 'Foo Bar',
+            'description' => 'foobar',
+            'tags' => 'foo bar',
+            'private' => true,
+        );
+        $expected = array(
+            'id' => '20160718_100001',
+            'url' => 'http://foobar.tld',
+            'title' => 'Foo Bar',
+            'description' => 'foobar',
+            'tags' => array('foo', 'bar'),
+            'private' => true,
+            'created' => '2016-07-18T10:00:01+0000',
+            'updated' => '',
+        );
+        $this->assertEquals($expected, ApiUtils::formatLink($link));
+
+        $link = array(
+            'linkdate' => '20160718_100001',
+        );
+        $expected = array(
+            'id' => '20160718_100001',
+            'url' => '',
+            'title' => '',
+            'description' => '',
+            'tags' => array(),
+            'private' => false,
+            'created' => '2016-07-18T10:00:01+0000',
+            'updated' => '',
+        );
+        $this->assertEquals($expected, ApiUtils::formatLink($link));
+        $this->assertEquals(array(), ApiUtils::formatLink(array()));
+    }
+
+    /**
+     * Test formatError().
+     */
+    public function testFormatError()
+    {
+        $expected = array(
+            'code' => 100,
+            'message' => 'foo bar',
+        );
+        $this->assertEquals($expected, ApiUtils::formatError(100, 'foo bar'));
+        $expected = array(
+            'code' => '',
+            'message' => '',
+        );
+        $this->assertEquals($expected, ApiUtils::formatError(false, false));
+    }
+
+    /**
+     * Test buildLinkFromRequest().
+     */
+    public function testBuildLinkFromRequest()
+    {
+        $linkdate = '123456';
+        $input = array(
+            'url' => 'http://foobar.tld',
+            'title' => 'Foo Bar',
+            'description' => 'foobar',
+            'tags' => array('foo', 'bar'),
+            'private' => true,
+        );
+        $link = ApiUtils::buildLinkFromRequest($linkdate, $input, true);
+        $this->assertEquals($linkdate, $link['linkdate']);
+        $this->assertEquals($input['url'], $link['url']);
+        $this->assertEquals($input['title'], $link['title']);
+        $this->assertEquals($input['description'], $link['description']);
+        $this->assertEquals('foo bar', $link['tags']);
+        $this->assertEquals($input['private'], $link['private']);
+
+        // Empty input link.
+        $link = ApiUtils::buildLinkFromRequest($linkdate, array(), true);
+        $this->assertEquals($linkdate, $link['linkdate']);
+        $this->assertRegExp('#\?[\d \w\-_]{6}#', $link['url']);
+        $this->assertEquals($link['url'], $link['title']);
+        $this->assertEmpty($link['description']);
+        $this->assertEmpty($link['tags']);
+        $this->assertTrue($link['private']);
+
+        $link = ApiUtils::buildLinkFromRequest($linkdate, array(), false);
+        $this->assertFalse($link['private']);
+    }
+
+    /**
+     * Test validateJwtToken() with a valid JWT token.
+     */
+    public function testValidateJwtTokenValid()
+    {
+        $secret = 'WarIsPeace';
+        ApiUtils::validateJwtToken(ApiTest::generateJwtToken($secret), $secret);
+    }
+
+    /**
+     * Test validateJwtToken() with a malformed JWT token.
+     *
+     * @expectedException ApiAuthorizationException
+     * @expectedExceptionMessage Malformed JWT token
+     */
+    public function testValidateJwtTokenMalformed()
+    {
+        $token = 'ABC.DEF';
+        ApiUtils::validateJwtToken($token, 'foo');
+    }
+
+    /**
+     * Test validateJwtToken() with an empty JWT token.
+     *
+     * @expectedException ApiAuthorizationException
+     * @expectedExceptionMessage Malformed JWT token
+     */
+    public function testValidateJwtTokenMalformedEmpty()
+    {
+        $token = false;
+        ApiUtils::validateJwtToken($token, 'foo');
+    }
+
+    /**
+     * Test validateJwtToken() with a JWT token without header.
+     *
+     * @expectedException ApiAuthorizationException
+     * @expectedExceptionMessage Malformed JWT token
+     */
+    public function testValidateJwtTokenMalformedEmptyHeader()
+    {
+        $token = '.payload.signature';
+        ApiUtils::validateJwtToken($token, 'foo');
+    }
+
+    /**
+     * Test validateJwtToken() with a JWT token without payload
+     *
+     * @expectedException ApiAuthorizationException
+     * @expectedExceptionMessage Malformed JWT token
+     */
+    public function testValidateJwtTokenMalformedEmptyPayload()
+    {
+        $token = 'header..signature';
+        ApiUtils::validateJwtToken($token, 'foo');
+    }
+
+    /**
+     * Test validateJwtToken() with a JWT token with an empty signature.
+     *
+     * @expectedException ApiAuthorizationException
+     * @expectedExceptionMessage Invalid JWT signature
+     */
+    public function testValidateJwtTokenInvalidSignatureEmpty()
+    {
+        $token = 'header.payload.';
+        ApiUtils::validateJwtToken($token, 'foo');
+    }
+
+    /**
+     * Test validateJwtToken() with a JWT token with an invalid signature.
+     *
+     * @expectedException ApiAuthorizationException
+     * @expectedExceptionMessage Invalid JWT signature
+     */
+    public function testValidateJwtTokenInvalidSignature()
+    {
+        $token = 'header.payload.nope';
+        ApiUtils::validateJwtToken($token, 'foo');
+    }
+
+    /**
+     * Test validateJwtToken() with a JWT token with a signature generated with the wrong API secret.
+     *
+     * @expectedException ApiAuthorizationException
+     * @expectedExceptionMessage Invalid JWT signature
+     */
+    public function testValidateJwtTokenInvalidSignatureSecret()
+    {
+        ApiUtils::validateJwtToken(ApiTest::generateJwtToken('foo'), 'bar');
+    }
+
+    /**
+     * Test validateJwtToken() with a JWT token with a an invalid header (not JSON).
+     *
+     * @expectedException ApiAuthorizationException
+     * @expectedExceptionMessage Invalid JWT header
+     */
+    public function testValidateJwtTokenInvalidHeader()
+    {
+        $token = $this->generateJwtToken('notJSON', '{"JSON":1}', 'secret');
+        ApiUtils::validateJwtToken($token, 'secret');
+    }
+
+    /**
+     * Test validateJwtToken() with a JWT token with a an invalid payload (not JSON).
+     *
+     * @expectedException ApiAuthorizationException
+     * @expectedExceptionMessage Invalid JWT payload
+     */
+    public function testValidateJwtTokenInvalidPayload()
+    {
+        $token = $this->generateJwtToken('{"JSON":1}', 'notJSON', 'secret');
+        ApiUtils::validateJwtToken($token, 'secret');
+    }
+
+    /**
+     * Test validateJwtToken() with a JWT token without issued time.
+     *
+     * @expectedException ApiAuthorizationException
+     * @expectedExceptionMessage Invalid JWT issued time
+     */
+    public function testValidateJwtTokenInvalidTimeEmpty()
+    {
+        $token = $this->generateJwtToken('{"JSON":1}', '{"JSON":1}', 'secret');
+        ApiUtils::validateJwtToken($token, 'secret');
+    }
+
+    /**
+     * Test validateJwtToken() with an expired JWT token.
+     *
+     * @expectedException ApiAuthorizationException
+     * @expectedExceptionMessage Invalid JWT issued time
+     */
+    public function testValidateJwtTokenInvalidTimeExpired()
+    {
+        $token = $this->generateJwtToken('{"JSON":1}', '{"iat":' . (time() - 600) . '}', 'secret');
+        ApiUtils::validateJwtToken($token, 'secret');
+    }
+
+    /**
+     * Test validateJwtToken() with a JWT token issued in the future.
+     *
+     * @expectedException ApiAuthorizationException
+     * @expectedExceptionMessage Invalid JWT issued time
+     */
+    public function testValidateJwtTokenInvalidTimeFuture()
+    {
+        $token = $this->generateJwtToken('{"JSON":1}', '{"iat":' . (time() + 60) . '}', 'secret');
+        ApiUtils::validateJwtToken($token, 'secret');
+    }
+
+    /**
+     * Test render() with a body and headers.
+     *
+     * This have to run in a separate process because headers
+     * can't be set after anything has been output.
+     *
+     * Note: This is bit slower than regular tests.
+     *
+     * @runInSeparateProcess
+     */
+    public function testRender()
+    {
+        $code = 621;
+        $headers = array(
+            'Sandwich: ham, cheese, more-cheese',
+            'Foo: Bar',
+        );
+        $data = array('key' => 'value');
+
+        $this->expectOutputString(json_encode($data));
+        ApiUtils::render(new ApiResponse($code, $headers, $data));
+
+        $responseHeaders = xdebug_get_headers();
+        foreach ($headers as $header) {
+            $this->assertTrue(in_array($header, $responseHeaders));
+        }
+        $this->assertTrue($this->arrayContains('application/json', $responseHeaders));
+
+        // PHP 5.4.
+        if (function_exists('http_response_code')) {
+            $this->assertEquals($code, http_response_code());
+        } else {
+            $this->assertTrue(in_array('X-PHP-Response-Code: ' . $code, $responseHeaders));
+        }
+    }
+
+    /**
+     * Test render() with a response without headers or a body.
+     *
+     * @runInSeparateProcess
+     */
+    public function testRenderMinimal()
+    {
+        $code = 123;
+        $this->expectOutputString('');
+        ApiUtils::render(new ApiResponse($code, array(), null));
+
+        $responseHeaders = xdebug_get_headers();
+        $this->assertTrue($this->arrayContains('application/json', $responseHeaders));
+
+        // PHP 5.4.
+        if (function_exists('http_response_code')) {
+            $this->assertEquals($code, http_response_code());
+        } else {
+            $this->assertTrue(in_array('X-PHP-Response-Code: ' . $code, $responseHeaders));
+        }
+    }
+
+    /**
+     * Test parseRequestBody() with valid data.
+     */
+    public function testParseRequestBodyValid()
+    {
+        $data = array(
+            'foo' => 'bar',
+            false,
+            'test' => array()
+        );
+        $this->assertEquals($data, ApiUtils::parseRequestBody(json_encode($data)));
+        $data = 'string';
+        $this->assertEquals($data, ApiUtils::parseRequestBody(json_encode($data)));
+        $data = false;
+        $this->assertEquals($data, ApiUtils::parseRequestBody(json_encode($data)));
+        $data = '';
+        $this->assertEquals($data, ApiUtils::parseRequestBody(json_encode($data)));
+        $data = false;
+        $this->assertNull(ApiUtils::parseRequestBody($data));
+        $data = '';
+        $this->assertNull(ApiUtils::parseRequestBody($data));
+    }
+
+    /**
+     * Test parseRequestBody() with invalid data.
+     *
+     * @expectedException ApiBadParametersException
+     * @expectedExceptionMessageRegExp /Invalid request content:/
+     */
+    public function testParseRequestBodyNotValid()
+    {
+        $data = 'syntax error (not json)';
+        ApiUtils::parseRequestBody($data);
+    }
+
+    /**
+     * Generate a JWT token from given header and payload.
+     *
+     * @param string $header  Header in JSON format.
+     * @param string $payload Payload in JSON format.
+     * @param string $secret  API secret used to hash the signature.
+     * 
+     * @return string JWT token.
+     */
+    public function generateJwtToken($header, $payload, $secret)
+    {
+        $header = base64_encode($header);
+        $payload = base64_encode($payload);
+        $signature = hash_hmac('sha512', $header . '.' . $payload, $secret);
+        return $header . '.' . $payload . '.' . $signature;
+    }
+
+    /**
+     * Helper function checking if an array contains a string.
+     * in_array() only checks if the needle is equal with an array element.
+     *
+     * @param string $needle   String to search.
+     * @param array  $haystack Array to search in.
+     *
+     * @return bool true if the needle is found in the haystack, false otherwise.
+     */
+    public function arrayContains($needle, $haystack)
+    {
+        foreach ($haystack as $element) {
+            if (strpos($element, $needle) !== false) {
+                return true;
+            }
+        }
+        return false;
+    }
+}

--- a/tests/api/DummyApi.php
+++ b/tests/api/DummyApi.php
@@ -1,0 +1,38 @@
+<?php
+
+require_once 'application/api/Api.php';
+
+/**
+ * Class DummyApi
+ *
+ * An Api extension with a single dummy service available.
+ */
+class DummyApi extends Api
+{
+    /**
+     * @var array Overrides Api allowed methods.
+     */
+    protected static $allowedMethod = array('getDummy');
+
+    /**
+     * Dummy API service for tests purpose.
+     *
+     * @param array  $queryParams Request parameters.
+     * @param array  $pathParams  Path parameters.
+     * @param string $body            Request body as a string.
+     *
+     * @return ApiResponse with code, headers, and body based on given data.
+     */
+    public function getDummy($queryParams, $pathParams, $body)
+    {
+        return new ApiResponse(
+            666,
+            array('header1', 'header2'),
+            array(
+                'query' => $queryParams,
+                'path' => $pathParams,
+                'body' => $body,
+            )
+        );
+    }
+}

--- a/tpl/configure.html
+++ b/tpl/configure.html
@@ -80,6 +80,20 @@
           <label for="updateCheck">&nbsp;Notify me when a new release is ready</label>
         </td>
       </tr>
+      <tr>
+        <td valign="top"><b>Enable API</b></td>
+        <td>
+          <input type="checkbox" name="apiEnabled" id="apiEnabled"
+                 {if="$api_enabled"}checked{/if}/>
+          <label for="apiEnabled">&nbsp;Allow third party software to use Shaarli such as mobile application.</label>
+        </td>
+      </tr>
+      <tr>
+        <td valign="top"><b>API secret</b></td>
+        <td>
+          <input type="text" name="apiSecret" id="apiSecret" size="50" value="{$api_secret}" />
+        </td>
+      </tr>
 
       <tr>
         <td></td>

--- a/tpl/install.html
+++ b/tpl/install.html
@@ -14,6 +14,18 @@
             <tr><td valign="top"><b>Update:</b></td><td>
                 <input type="checkbox" name="updateCheck" id="updateCheck" checked="checked"><label for="updateCheck">&nbsp;Notify me when a new release is ready</label></td>
             </tr>
+            <tr>
+                <td valign="top">
+                    <b>API:</b>
+                </td>
+                <td>
+                    <input type="checkbox" name="enableApi" id="enableApi" checked="checked">
+                    <label for="enableApi">
+                        &nbsp;Enable Shaarli's API.
+                        Allow third party software to use Shaarli such as mobile application.
+                    </label>
+                </td>
+            </tr>
             <tr><td colspan="2"><input type="submit" name="Save" value="Save config" class="bigbutton"></td></tr>
         </table>
     </form>


### PR DESCRIPTION
Related to #609:

  * Add the API settings in Shaarli administration and install forms (enabled/secret).
  * API implementation structure, with unit tests.
  * Implement 1 service for now: `/info`.
  * Plug the API to be able to reach it.

You can test it with any REST client with:

   * http://instance/api/v1/info behind an Apache server.
   * http://instance/?do=api&version=1&test=fee&q=/info2 otherwise.
   * A valid JWT token in a header call `jwt`.

You can use this script to get a valid token easily (they're valid during 9 minutes):

```php
<?php

function generateJwtToken($secret)
    {
        $header = base64_encode('{
            "typ": "JWT",
            "alg": "HS512"
        }');
        $payload = base64_encode('{
            "iat": '. time() .'
        }');
        $signature = hash_hmac('sha512', $header .'.'. $payload , $secret);
        return $header .'.'. $payload .'.'. $signature;
    }

echo generateJwtToken('jaimeLePate');
```

You can add this in you config file to get more info about the errors:
```json
"dev": { "debug": true }
```

EDIT: @nodiscc regarding shaarli/api-documentation#1
```
cloc application/api
       4 text files.
       4 unique files.                              
       0 files ignored.

github.com/AlDanial/cloc v 1.70  T=0.01 s (308.8 files/s, 49942.3 lines/s)
-------------------------------------------------------------------------------
Language                     files          blank        comment           code
-------------------------------------------------------------------------------
PHP                              4             59            274            314
-------------------------------------------------------------------------------
SUM:                             4             59            274            314
-------------------------------------------------------------------------------
```