### PR TITLE
Add a description to plugin parameters

### DIFF
--- a/application/PluginManager.php
+++ b/application/PluginManager.php
@@ -185,7 +185,11 @@ class PluginManager
                     continue;
                 }
 
-                $metaData[$plugin]['parameters'][$param] = '';
+                $metaData[$plugin]['parameters'][$param]['value'] = '';
+                // Optional parameter description in parameter.PARAM_NAME=
+                if (isset($metaData[$plugin]['parameter.'. $param])) {
+                    $metaData[$plugin]['parameters'][$param]['desc'] = $metaData[$plugin]['parameter.'. $param];
+                }
             }
         }
 

--- a/application/config/ConfigPlugin.php
+++ b/application/config/ConfigPlugin.php
@@ -80,9 +80,13 @@ function validate_plugin_order($formData)
 }
 
 /**
- * Affect plugin parameters values into plugins array.
+ * Affect plugin parameters values from the ConfigManager into plugins array.
  *
- * @param mixed $plugins Plugins array ($plugins[<plugin_name>]['parameters']['param_name'] = <value>.
+ * @param mixed $plugins Plugins array:
+ *                         $plugins[<plugin_name>]['parameters'][<param_name>] = [
+ *                                                                                 'value' => <value>,
+ *                                                                                 'desc' => <description>
+ *                                                                               ]
  * @param mixed $conf  Plugins configuration.
  *
  * @return mixed Updated $plugins array.
@@ -97,7 +101,7 @@ function load_plugin_parameter_values($plugins, $conf)
 
         foreach ($plugin['parameters'] as $key => $param) {
             if (!empty($conf[$key])) {
-                $out[$name]['parameters'][$key] = $conf[$key];
+                $out[$name]['parameters'][$key]['value'] = $conf[$key];
             }
         }
     }

--- a/inc/shaarli.css
+++ b/inc/shaarli.css
@@ -1156,7 +1156,7 @@ ul.errors {
 }
 
 #pluginsadmin .plugin_parameter {
-    padding: 5px 0;
+    padding: 10px 0;
     border-width: 1px 0;
     border-style: solid;
     border-color: #c0c0c0;
@@ -1164,7 +1164,7 @@ ul.errors {
 
 #pluginsadmin .float_label {
     float: left;
-    width: 20%;
+    width: 40%;
 }
 
 #pluginsadmin a {

--- a/plugins/wallabag/wallabag.meta
+++ b/plugins/wallabag/wallabag.meta
@@ -1,2 +1,4 @@
 description="For each link, add a Wallabag icon to save it in your instance."
 parameters="WALLABAG_URL;WALLABAG_VERSION"
+parameter.WALLABAG_URL="Wallabag API URL"
+parameter.WALLABAG_VERSION="Wallabag API version (1 or 2)"

--- a/tests/PluginManagerTest.php
+++ b/tests/PluginManagerTest.php
@@ -79,8 +79,14 @@ class PluginManagerTest extends PHPUnit_Framework_TestCase
         $this->pluginManager->load(array(self::$pluginName));
 
         $expectedParameters = array(
-            'pop' => '',
-            'hip' => '',
+            'pop' => array(
+                'value' => '',
+                'desc'  => 'pop description',
+            ),
+            'hip' => array(
+                'value' => '',
+                'desc' => '',
+            ),
         );
         $meta = $this->pluginManager->getPluginsMeta();
         $this->assertEquals('test plugin', $meta[self::$pluginName]['description']);

--- a/tests/config/ConfigPluginTest.php
+++ b/tests/config/ConfigPluginTest.php
@@ -101,9 +101,9 @@ class ConfigPluginTest extends PHPUnit_Framework_TestCase
         $plugins = array(
             'plugin_name' => array(
                 'parameters' => array(
-                    'param1' => true,
-                    'param2' => false,
-                    'param3' => '',
+                    'param1' => array('value' => true),
+                    'param2' => array('value' => false),
+                    'param3' => array('value' => ''),
                 )
             )
         );
@@ -114,8 +114,8 @@ class ConfigPluginTest extends PHPUnit_Framework_TestCase
         );
 
         $result = load_plugin_parameter_values($plugins, $parameters);
-        $this->assertEquals('value1', $result['plugin_name']['parameters']['param1']);
-        $this->assertEquals('value2', $result['plugin_name']['parameters']['param2']);
-        $this->assertEquals('', $result['plugin_name']['parameters']['param3']);
+        $this->assertEquals('value1', $result['plugin_name']['parameters']['param1']['value']);
+        $this->assertEquals('value2', $result['plugin_name']['parameters']['param2']['value']);
+        $this->assertEquals('', $result['plugin_name']['parameters']['param3']['value']);
     }
 }

--- a/tests/plugins/test/test.meta
+++ b/tests/plugins/test/test.meta
@@ -1,2 +1,4 @@
 description="test plugin"
 parameters="pop;hip"
+parameter.pop="pop description"
+parameter.hip=

--- a/tpl/pluginsadmin.html
+++ b/tpl/pluginsadmin.html
@@ -104,11 +104,12 @@
                   <div class="plugin_parameter">
                     <div class="float_label">
                       <label for="{$key}">
-                        <code>{$key}</code>
+                        <code>{$key}</code><br>
+                        {$value.desc}
                       </label>
                     </div>
                     <div class="float_input">
-                      <input name="{$key}" value="{$value}" id="{$key}"/>
+                      <input name="{$key}" value="{$value.value}" id="{$key}"/>
                     </div>
                   </div>
                 {/loop}


### PR DESCRIPTION
  * Plugin parameter can contain a description in their meta file under the key:

      `parameter.<param_name>="<description>"`

  * Update the plugin admin template to display it.
  * Description added for the Wallabag plugin.

Fixes #463 