### PR TITLE
Move Pubsubhub to a default plugin

### DIFF
--- a/application/FeedBuilder.php
+++ b/application/FeedBuilder.php
@@ -63,11 +63,6 @@ class FeedBuilder
     protected $hideDates;
 
     /**
-     * @var string PubSub hub URL.
-     */
-    protected $pubsubhubUrl;
-
-    /**
      * @var string server locale.
      */
     protected $locale;
@@ -120,7 +115,6 @@ class FeedBuilder
         }
 
         $data['language'] = $this->getTypeLanguage();
-        $data['pubsubhub_url'] = $this->pubsubhubUrl;
         $data['last_update'] = $this->getLatestDateFormatted();
         $data['show_dates'] = !$this->hideDates || $this->isLoggedIn;
         // Remove leading slash from REQUEST_URI.
@@ -180,16 +174,6 @@ class FeedBuilder
         $link['taglist'] = $taglist;
 
         return $link;
-    }
-
-    /**
-     * Assign PubSub hub URL.
-     *
-     * @param string $pubsubhubUrl PubSub hub url.
-     */
-    public function setPubsubhubUrl($pubsubhubUrl)
-    {
-        $this->pubsubhubUrl = $pubsubhubUrl;
     }
 
     /**

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,8 @@
         "php": ">=5.5",
         "shaarli/netscape-bookmark-parser": "1.*",
         "erusev/parsedown": "1.6",
-        "slim/slim": "^3.0"
+        "slim/slim": "^3.0",
+        "pubsubhubbub/publisher": "dev-master"
     },
     "require-dev": {
         "phpmd/phpmd" : "@stable",

--- a/index.php
+++ b/index.php
@@ -910,10 +910,6 @@ function renderPage($conf, $pluginManager, $LINKSDB)
         $feedGenerator->setLocale(strtolower(setlocale(LC_COLLATE, 0)));
         $feedGenerator->setHideDates($conf->get('privacy.hide_timestamps') && !isLoggedIn());
         $feedGenerator->setUsePermalinks(isset($_GET['permalinks']) || !$conf->get('feed.rss_permalinks'));
-        $pshUrl = $conf->get('config.PUBSUBHUB_URL');
-        if (!empty($pshUrl)) {
-            $feedGenerator->setPubsubhubUrl($pshUrl);
-        }
         $data = $feedGenerator->buildData();
 
         // Process plugin hook.
@@ -1289,7 +1285,6 @@ function renderPage($conf, $pluginManager, $LINKSDB)
 
         $LINKSDB[$id] = $link;
         $LINKSDB->save($conf->get('resource.page_cache'));
-        pubsubhub($conf);
 
         // If we are called from the bookmarklet, we must close the popup:
         if (isset($_GET['source']) && ($_GET['source']=='bookmarklet' || $_GET['source']=='firefoxsocialapi')) {

--- a/plugins/pubsubhubbub/README.md
+++ b/plugins/pubsubhubbub/README.md
@@ -1,0 +1,20 @@
+# PubSubHubbub plugin
+
+Enable this plugin to notify a Hub everytime you add or edit a link.
+ 
+This allow hub subcribers to receive update notifications in real time,
+which is useful for feed syndication service which supports PubSubHubbub.
+
+## Public Hub
+
+By default, Shaarli will use [Google's public hub](http://pubsubhubbub.appspot.com/).
+
+[Here](https://github.com/pubsubhubbub/PubSubHubbub/wiki/Hubs) is a list of public hubs.
+
+You can also host your own PubSubHubbub server implementation, such as [phubb](https://github.com/cweiske/phubb).
+
+## cURL
+
+While there is a fallback function to notify the hub, it's recommended that
+you have PHP cURL extension enabled to use this plugin.
+

--- a/plugins/pubsubhubbub/hub.atom.xml
+++ b/plugins/pubsubhubbub/hub.atom.xml
@@ -1,0 +1,1 @@
+<link rel="hub" href="%s" />

--- a/plugins/pubsubhubbub/hub.rss.xml
+++ b/plugins/pubsubhubbub/hub.rss.xml
@@ -1,0 +1,1 @@
+<atom:link rel="hub" href="%s" />

--- a/plugins/pubsubhubbub/pubsubhubbub.meta
+++ b/plugins/pubsubhubbub/pubsubhubbub.meta
@@ -1,0 +1,2 @@
+description="Enable PubSubHubbub feed publishing."
+parameters="PUBSUBHUB_URL"

--- a/plugins/pubsubhubbub/pubsubhubbub.php
+++ b/plugins/pubsubhubbub/pubsubhubbub.php
@@ -1,0 +1,101 @@
+<?php
+
+/**
+ * PubSubHubbub plugin.
+ *
+ * PubSub is a protocol which fasten up RSS fetching:
+ *   - Every time a new link is posted, Shaarli notify the hub.
+ *   - The hub notify all feed subscribers that a new link has been posted.
+ *   - Subscribers retrieve the new link. 
+ */
+
+use pubsubhubbub\publisher\Publisher;
+
+/**
+ * Plugin init function - set the hub to the default appspot one.
+ *
+ * @param ConfigManager $conf instance.
+ */
+function pubsubhubbub_init($conf)
+{
+    $hub = $conf->get('plugins.PUBSUBHUB_URL');
+    if (empty($hub)) {
+        // Default hub.
+        $conf->set('plugins.PUBSUBHUB_URL', 'https://pubsubhubbub.appspot.com/');
+    }
+}
+
+
+/**
+ * Render feed hook.
+ * Adds the hub URL in ATOM and RSS feed.
+ *
+ * @param array         $data Template data.
+ * @param ConfigManager $conf instance.
+ *
+ * @return array updated template data.
+ */
+function hook_pubsubhubbub_render_feed($data, $conf)
+{
+    $feedType = $data['_PAGE_'] == Router::$PAGE_FEED_RSS ? FeedBuilder::$FEED_RSS : FeedBuilder::$FEED_ATOM;
+    $template = file_get_contents(PluginManager::$PLUGINS_PATH . '/pubsubhubbub/hub.'. $feedType .'.xml');
+    $data['feed_plugins_header'][] = sprintf($template, $conf->get('plugins.PUBSUBHUB_URL'));
+
+    return $data;
+}
+
+/**
+ * Save link hook.
+ * Publish to the hub when a link is saved.
+ *
+ * @param array         $data Template data.
+ * @param ConfigManager $conf instance.
+ *
+ * @return array unaltered data.
+ */
+function hook_pubsubhubbub_save_link($data, $conf)
+{
+    $feeds = array(
+        index_url($_SERVER) .'?do=atom',
+        index_url($_SERVER) .'?do=rss',
+    );
+
+    $httpPost = function_exists('curl_version') ? false : 'nocurl_http_post';
+    try {
+        $p = new Publisher($conf->get('plugins.PUBSUBHUB_URL'));
+        $p->publish_update($feeds, $httpPost);
+    } catch (Exception $e) {
+        error_log('Could not publish to PubSubHubbub: ' . $e->getMessage());
+    }
+
+    return $data;
+}
+
+/**
+ * Http function used to post to the hub endpoint without cURL extension.
+ *
+ * @param  string $url        Hub endpoint.
+ * @param  string $postString String to POST.
+ *
+ * @return bool
+ *
+ * @throws Exception An error occurred.
+ */
+function nocurl_http_post($url, $postString) {
+    $params = array('http' => array(
+        'method' => 'POST',
+        'content' => $postString,
+        'user_agent' => 'PubSubHubbub-Publisher-PHP/1.0',
+    ));
+
+    $context = stream_context_create($params);
+    $fp = @fopen($url, 'rb', false, $context);
+    if (!$fp) {
+        throw new Exception('Could not post to '. $url);
+    }
+    $response = @stream_get_contents($fp);
+    if ($response === false) {
+        throw new Exception('Bad response from the hub '. $url);
+    }
+    return $response;
+}

--- a/tests/FeedBuilderTest.php
+++ b/tests/FeedBuilderTest.php
@@ -75,7 +75,6 @@ class FeedBuilderTest extends PHPUnit_Framework_TestCase
         $data = $feedBuilder->buildData();
         // Test headers (RSS)
         $this->assertEquals(self::$RSS_LANGUAGE, $data['language']);
-        $this->assertEmpty($data['pubsubhub_url']);
         $this->assertRegExp('/Wed, 03 Aug 2016 09:30:33 \+\d{4}/', $data['last_update']);
         $this->assertEquals(true, $data['show_dates']);
         $this->assertEquals('http://host.tld/index.php?do=feed', $data['self_link']);
@@ -208,19 +207,6 @@ class FeedBuilderTest extends PHPUnit_Framework_TestCase
         $data = $feedBuilder->buildData();
         $this->assertEquals(ReferenceLinkDB::$NB_LINKS_TOTAL, count($data['links']));
         $this->assertTrue($data['show_dates']);
-    }
-
-    /**
-     * Test buildData with hide dates settings.
-     */
-    public function testBuildDataPubsubhub()
-    {
-        $feedBuilder = new FeedBuilder(self::$linkDB, FeedBuilder::$FEED_ATOM, self::$serverInfo, null, false);
-        $feedBuilder->setLocale(self::$LOCALE);
-        $feedBuilder->setPubsubhubUrl('http://pubsubhub.io');
-        $data = $feedBuilder->buildData();
-        $this->assertEquals(ReferenceLinkDB::$NB_LINKS_TOTAL, count($data['links']));
-        $this->assertEquals('http://pubsubhub.io', $data['pubsubhub_url']);
     }
 
     /**

--- a/tests/plugins/PluginPubsubhubbubTest.php
+++ b/tests/plugins/PluginPubsubhubbubTest.php
@@ -1,0 +1,54 @@
+<?php
+
+require_once 'plugins/pubsubhubbub/pubsubhubbub.php';
+require_once 'application/Router.php';
+
+/**
+ * Class PluginPubsubhubbubTest
+ * Unit test for the pubsubhubbub plugin
+ */
+class PluginPubsubhubbubTest extends PHPUnit_Framework_TestCase
+{
+    /**
+     * @var string Config file path (without extension).
+     */
+    protected static $configFile = 'tests/utils/config/configJson';
+
+    /**
+     * Reset plugin path
+     */
+    function setUp()
+    {
+        PluginManager::$PLUGINS_PATH = 'plugins';
+    }
+
+    /**
+     * Test render_feed hook with an RSS feed.
+     */
+    function testPubSubRssRenderFeed()
+    {
+        $hub = 'http://domain.hub';
+        $conf = new ConfigManager(self::$configFile);
+        $conf->set('plugins.PUBSUBHUB_URL', $hub);
+        $data['_PAGE_'] = Router::$PAGE_FEED_RSS;
+
+        $data = hook_pubsubhubbub_render_feed($data, $conf);
+        $expected = '<atom:link rel="hub" href="'. $hub .'" />';
+        $this->assertEquals($expected, $data['feed_plugins_header'][0]);
+    }
+
+    /**
+     * Test render_feed hook with an ATOM feed.
+     */
+    function testPubSubAtomRenderFeed()
+    {
+        $hub = 'http://domain.hub';
+        $conf = new ConfigManager(self::$configFile);
+        $conf->set('plugins.PUBSUBHUB_URL', $hub);
+        $data['_PAGE_'] = Router::$PAGE_FEED_ATOM;
+
+        $data = hook_pubsubhubbub_render_feed($data, $conf);
+        $expected = '<link rel="hub" href="'. $hub .'" />';
+        $this->assertEquals($expected, $data['feed_plugins_header'][0]);
+    }
+}

--- a/tpl/feed.atom.html
+++ b/tpl/feed.atom.html
@@ -6,11 +6,9 @@
     <updated>{$last_update}</updated>
   {/if}
   <link rel="self" href="{$self_link}#" />
-  {if="!empty($pubsubhub_url)"}
-    <!-- PubSubHubbub Discovery -->
-    <link rel="hub" href="{$pubsubhub_url}#" />
-    <!-- End Of PubSubHubbub Discovery -->
-  {/if}
+  {loop="$plugins_feed_header"}
+    {$value}
+  {/loop}
   <author>
     <name>{$index_url}</name>
     <uri>{$index_url}</uri>
@@ -33,6 +31,9 @@
       <content type="html" xml:lang="{$language}"><![CDATA[{$value.description}]]></content>
       {loop="$value.taglist"}
         <category scheme="{$index_url}?searchtags=" term="{$value|strtolower}" label="{$value}" />
+      {/loop}
+      {loop="$value.feed_plugins"}
+        {$value}
       {/loop}
     </entry>
   {/loop}

--- a/tpl/feed.atom.html
+++ b/tpl/feed.atom.html
@@ -6,7 +6,7 @@
     <updated>{$last_update}</updated>
   {/if}
   <link rel="self" href="{$self_link}#" />
-  {loop="$plugins_feed_header"}
+  {loop="$feed_plugins_header"}
     {$value}
   {/loop}
   <author>

--- a/tpl/feed.rss.html
+++ b/tpl/feed.rss.html
@@ -8,10 +8,9 @@
     <copyright>{$index_url}</copyright>
     <generator>Shaarli</generator>
     <atom:link rel="self" href="{$self_link}"  />
-    {if="!empty($pubsubhub_url)"}
-      <!-- PubSubHubbub Discovery -->
-      <atom:link rel="hub" href="{$pubsubhub_url}" />
-    {/if}
+    {loop="$plugins_feed_header"}
+      {$value}
+    {/loop}
     {loop="$links"}
       <item>
         <title>{$value.title}</title>
@@ -28,6 +27,9 @@
         <description><![CDATA[{$value.description}]]></description>
         {loop="$value.taglist"}
           <category domain="{$index_url}?searchtags=">{$value}</category>
+        {/loop}
+        {loop="$value.feed_plugins"}
+          {$value}
         {/loop}
       </item>
     {/loop}

--- a/tpl/feed.rss.html
+++ b/tpl/feed.rss.html
@@ -8,7 +8,7 @@
     <copyright>{$index_url}</copyright>
     <generator>Shaarli</generator>
     <atom:link rel="self" href="{$self_link}"  />
-    {loop="$plugins_feed_header"}
+    {loop="$feed_plugins_header"}
       {$value}
     {/loop}
     {loop="$links"}


### PR DESCRIPTION
- Adds placeholders in feeds templates to specify which hub is used (`render_feed` hook).
- Retrieve the publisher lib with Composer.
- Notify the hub everytime a link is saved (`save_link`).
- Adds a default PHP fallback if `cURL` is not installed.
- Silently log exceptions.

TODO:
- [x] Update plugin doc for the new placeholders

Fixes #459
