### PR TITLE
Save link update dates and render it in templates and feeds

### DIFF
--- a/application/LinkDB.php
+++ b/application/LinkDB.php
@@ -12,8 +12,9 @@
  *
  * Available keys:
  *  - description: description of the entry
- *  - linkdate: date of the creation of this entry, in the form YYYYMMDD_HHMMSS
+ *  - linkdate: creation date of this entry, format: YYYYMMDD_HHMMSS
  *              (e.g.'20110914_192317')
+ *  - updated:  last modification date of this entry, format: YYYYMMDD_HHMMSS
  *  - private:  Is this link private? 0=no, other value=yes
  *  - tags:     tags attached to this entry (separated by spaces)
  *  - title     Title of the link

--- a/index.php
+++ b/index.php
@@ -1227,6 +1227,9 @@ function renderPage($conf, $pluginManager)
     // -------- User clicked the "Save" button when editing a link: Save link to database.
     if (isset($_POST['save_edit']))
     {
+        $linkdate = $_POST['lf_linkdate'];
+        $updated = isset($LINKSDB[$linkdate]) ? strval(date('Ymd_His')) : false;
+
         // Go away!
         if (! tokenOk($_POST['token'])) {
             die('Wrong token.');
@@ -1237,7 +1240,7 @@ function renderPage($conf, $pluginManager)
         $tags = preg_replace('/(^| )\-/', '$1', $tags);
         // Remove duplicates.
         $tags = implode(' ', array_unique(explode(' ', $tags)));
-        $linkdate = $_POST['lf_linkdate'];
+
         $url = trim($_POST['lf_url']);
         if (! startsWith($url, 'http:') && ! startsWith($url, 'https:')
             && ! startsWith($url, 'ftp:') && ! startsWith($url, 'magnet:')
@@ -1252,6 +1255,7 @@ function renderPage($conf, $pluginManager)
             'description' => $_POST['lf_description'],
             'private' => (isset($_POST['lf_private']) ? 1 : 0),
             'linkdate' => $linkdate,
+            'updated' => $updated,
             'tags' => str_replace(',', ' ', $tags)
         );
         // If title is empty, use the URL as title.
@@ -1696,6 +1700,12 @@ function buildLinkList($PAGE,$LINKSDB, $conf, $pluginManager)
         $link['class'] = $link['private'] == 0 ? $classLi : 'private';
         $date = DateTime::createFromFormat(LinkDB::LINK_DATE_FORMAT, $link['linkdate']);
         $link['timestamp'] = $date->getTimestamp();
+        if (! empty($link['updated'])) {
+            $date = DateTime::createFromFormat(LinkDB::LINK_DATE_FORMAT, $link['updated']);
+            $link['updated_timestamp'] = $date->getTimestamp();
+        } else {
+            $link['updated_timestamp'] = '';
+        }
         $taglist = explode(' ', $link['tags']);
         uasort($taglist, 'strcasecmp');
         $link['taglist'] = $taglist;

--- a/tests/FeedBuilderTest.php
+++ b/tests/FeedBuilderTest.php
@@ -76,7 +76,7 @@ class FeedBuilderTest extends PHPUnit_Framework_TestCase
         // Test headers (RSS)
         $this->assertEquals(self::$RSS_LANGUAGE, $data['language']);
         $this->assertEmpty($data['pubsubhub_url']);
-        $this->assertRegExp('/Tue, 10 Mar 2015 11:46:51 \+\d{4}/', $data['last_update']);
+        $this->assertRegExp('/Wed, 03 Aug 2016 09:30:33 \+\d{4}/', $data['last_update']);
         $this->assertEquals(true, $data['show_dates']);
         $this->assertEquals('http://host.tld/index.php?do=feed', $data['self_link']);
         $this->assertEquals('http://host.tld/', $data['index_url']);
@@ -88,7 +88,10 @@ class FeedBuilderTest extends PHPUnit_Framework_TestCase
         $this->assertEquals('20150310_114651', $link['linkdate']);
         $this->assertEquals('http://host.tld/?WDWyig', $link['guid']);
         $this->assertEquals('http://host.tld/?WDWyig', $link['url']);
-        $this->assertRegExp('/Tue, 10 Mar 2015 11:46:51 \+\d{4}/', $link['iso_date']);
+        $this->assertRegExp('/Tue, 10 Mar 2015 11:46:51 \+\d{4}/', $link['pub_iso_date']);
+        $pub = DateTime::createFromFormat(DateTime::RSS, $link['pub_iso_date']);
+        $up  = DateTime::createFromFormat(DateTime::ATOM, $link['up_iso_date']);
+        $this->assertEquals($pub, $up);
         $this->assertContains('Stallman has a beard', $link['description']);
         $this->assertContains('Permalink', $link['description']);
         $this->assertContains('http://host.tld/?WDWyig', $link['description']);
@@ -101,6 +104,9 @@ class FeedBuilderTest extends PHPUnit_Framework_TestCase
         // Test multitags.
         $this->assertEquals(5, count($data['links']['20141125_084734']['taglist']));
         $this->assertEquals('css', $data['links']['20141125_084734']['taglist'][0]);
+
+        // Test update date
+        $this->assertRegExp('/2016-08-03T09:30:33\+\d{2}:\d{2}/', $data['links']['20150310_114633']['up_iso_date']);
     }
 
     /**
@@ -112,8 +118,10 @@ class FeedBuilderTest extends PHPUnit_Framework_TestCase
         $feedBuilder->setLocale(self::$LOCALE);
         $data = $feedBuilder->buildData();
         $this->assertEquals(ReferenceLinkDB::$NB_LINKS_TOTAL, count($data['links']));
+        $this->assertRegExp('/2016-08-03T09:30:33\+\d{2}:\d{2}/', $data['last_update']);
         $link = array_shift($data['links']);
-        $this->assertRegExp('/2015-03-10T11:46:51\+\d{2}:+\d{2}/', $link['iso_date']);
+        $this->assertRegExp('/2015-03-10T11:46:51\+\d{2}:\d{2}/', $link['pub_iso_date']);
+        $this->assertRegExp('/2016-08-03T09:30:33\+\d{2}:\d{2}/', $data['links']['20150310_114633']['up_iso_date']);
     }
 
     /**

--- a/tests/utils/ReferenceLinkDB.php
+++ b/tests/utils/ReferenceLinkDB.php
@@ -30,7 +30,8 @@ class ReferenceLinkDB
             'Richard Stallman and the Free Software Revolution. Read this. #hashtag',
             0,
             '20150310_114633',
-            'free gnu software stallman -exclude stuff hashtag'
+            'free gnu software stallman -exclude stuff hashtag',
+            '20160803_093033'
         );
 
         $this->addLink(
@@ -82,7 +83,7 @@ class ReferenceLinkDB
     /**
      * Adds a new link
      */
-    protected function addLink($title, $url, $description, $private, $date, $tags)
+    protected function addLink($title, $url, $description, $private, $date, $tags, $updated = '')
     {
         $link = array(
             'title' => $title,
@@ -91,6 +92,7 @@ class ReferenceLinkDB
             'private' => $private,
             'linkdate' => $date,
             'tags' => $tags,
+            'updated' => $updated,
         );
         $this->_links[$date] = $link;
 

--- a/tpl/feed.atom.html
+++ b/tpl/feed.atom.html
@@ -27,7 +27,8 @@
       {/if}
       <id>{$value.guid}</id>
       {if="$show_dates"}
-        <updated>{$value.iso_date}</updated>
+        <published>{$value.pub_iso_date}</published>
+        <updated>{$value.up_iso_date}</updated>
       {/if}
       <content type="html" xml:lang="{$language}">
         <![CDATA[{$value.description}]]>

--- a/tpl/feed.rss.html
+++ b/tpl/feed.rss.html
@@ -22,7 +22,8 @@
           <link>{$value.url}</link>
         {/if}
         {if="$show_dates"}
-          <pubDate>{$value.iso_date}</pubDate>
+          <pubDate>{$value.pub_iso_date}</pubDate>
+          <atom:modified>{$value.up_iso_date}</atom:modified>
         {/if}
         <description><![CDATA[{$value.description}]]></description>
         {loop="$value.taglist"}

--- a/tpl/linklist.html
+++ b/tpl/linklist.html
@@ -89,7 +89,16 @@
                 <br>
                 {if="$value.description"}<div class="linkdescription">{$value.description}</div>{/if}
                 {if="!$hide_timestamps || isLoggedIn()"}
-                    <span class="linkdate" title="Permalink"><a href="?{$value.linkdate|smallHash}">{function="strftime('%c', $value.timestamp)"} - permalink</a> - </span>
+                    {$updated=$value.updated_timestamp ? 'Edited: '. strftime('%c', $value.updated_timestamp) : 'Permalink'}
+                    <span class="linkdate" title="Permalink">
+                        <a href="?{$value.linkdate|smallHash}">
+                            <span title="{$updated}">
+                                {function="strftime('%c', $value.timestamp)"}
+                                {if="$value.updated_timestamp"}*{/if}
+                            </span>
+                            - permalink
+                        </a> -
+                    </span>
                 {else}
                     <span class="linkdate" title="Short link here"><a href="?{$value.shorturl}">permalink</a> - </span>
                 {/if}


### PR DESCRIPTION
**Templates**

The update date is now save when a link is updated. This date is passed to the linklist template, as a timestamp, under the key `updated_timestamp`.

I've updated the default templates to show the update date when the creation date is hovered.

**Feeds**

*RSS*

RSS feeds doesn't support an update date for each item, so we use the ATOM extension, like this:

    <atom:modified>[date in ATOM format]</atom:modified>

*ATOM*

  * The tag `updated` in the header can be updated with update dates.
  * The tag `published` has been added for each element.
  * The tag `updated` present in each items is now changed if a link is updated.

> Note: the RFC states that all items in ATOM feeds MUST include an `updated` tag, so it will be initialized with the `published` tag value.

Fixes #563 

