### PR TITLE
Generate a token for every pages

### DIFF
--- a/application/PageBuilder.php
+++ b/application/PageBuilder.php
@@ -80,6 +80,7 @@ class PageBuilder
         if (!empty($GLOBALS['plugin_errors'])) {
             $this->tpl->assign('plugin_errors', $GLOBALS['plugin_errors']);
         }
+        $this->tpl->assign('token', getToken($this->conf));
         // To be removed with a proper theme configuration.
         $this->tpl->assign('conf', $this->conf);
     }

--- a/index.php
+++ b/index.php
@@ -783,8 +783,6 @@ function renderPage($conf, $pluginManager)
     if ($targetPage == Router::$PAGE_LOGIN)
     {
         if ($conf->get('security.open_shaarli')) { header('Location: ?'); exit; }  // No need to login for open Shaarli
-        $token=''; if (ban_canLogin($conf)) $token=getToken($conf); // Do not waste token generation if not useful.
-        $PAGE->assign('token',$token);
         if (isset($_GET['username'])) {
             $PAGE->assign('username', escape($_GET['username']));
         }
@@ -1105,7 +1103,6 @@ function renderPage($conf, $pluginManager)
         }
         else // show the change password form.
         {
-            $PAGE->assign('token',getToken($conf));
             $PAGE->renderPage('changepassword');
             exit;
         }
@@ -1152,7 +1149,6 @@ function renderPage($conf, $pluginManager)
         }
         else // Show the configuration form.
         {
-            $PAGE->assign('token',getToken($conf));
             $PAGE->assign('title', $conf->get('general.title'));
             $PAGE->assign('redirector', $conf->get('redirector.url'));
             list($timezone_form, $timezone_js) = generateTimeZoneForm($conf->get('general.timezone'));
@@ -1172,7 +1168,6 @@ function renderPage($conf, $pluginManager)
     if ($targetPage == Router::$PAGE_CHANGETAG)
     {
         if (empty($_POST['fromtag']) || (empty($_POST['totag']) && isset($_POST['renametag']))) {
-            $PAGE->assign('token', getToken($conf));
             $PAGE->assign('tags', $LINKSDB->allTags());
             $PAGE->renderPage('changetag');
             exit;
@@ -1347,7 +1342,6 @@ function renderPage($conf, $pluginManager)
         $data = array(
             'link' => $link,
             'link_is_new' => false,
-            'token' => getToken($conf),
             'http_referer' => (isset($_SERVER['HTTP_REFERER']) ? escape($_SERVER['HTTP_REFERER']) : ''),
             'tags' => $LINKSDB->allTags(),
         );
@@ -1414,7 +1408,6 @@ function renderPage($conf, $pluginManager)
         $data = array(
             'link' => $link,
             'link_is_new' => $link_is_new,
-            'token' => getToken($conf), // XSRF protection.
             'http_referer' => (isset($_SERVER['HTTP_REFERER']) ? escape($_SERVER['HTTP_REFERER']) : ''),
             'source' => (isset($_GET['source']) ? $_GET['source'] : ''),
             'tags' => $LINKSDB->allTags(),
@@ -1492,7 +1485,6 @@ function renderPage($conf, $pluginManager)
     // -------- Show upload/import dialog:
     if ($targetPage == Router::$PAGE_IMPORT)
     {
-        $PAGE->assign('token',getToken($conf));
         $PAGE->assign('maxfilesize',getMaxFileSize());
         $PAGE->renderPage('import');
         exit;
@@ -1734,7 +1726,6 @@ function buildLinkList($PAGE,$LINKSDB, $conf, $pluginManager)
         'search_term' => $searchterm,
         'search_tags' => $searchtags,
         'redirector' => $conf->get('redirector.url'),  // Optional redirector URL.
-        'token' => $token,
         'links' => $linkDisp,
         'tags' => $LINKSDB->allTags(),
     );


### PR DESCRIPTION
Token will be generated for every pages instead of generating and assigning one for a few pages specifically.

Use case: javascript login form in the header template (accessible anywhere) in the webdesign branch. 