### PR TITLE
Initialize a translation function

### DIFF
--- a/application/Languages.php
+++ b/application/Languages.php
@@ -1,0 +1,21 @@
+<?php
+
+/**
+ * Wrapper function for translation which match the API
+ * of gettext()/_() and ngettext().
+ *
+ * Not doing translation for now.
+ *
+ * @param string $text  Text to translate.
+ * @param string $nText The plural message ID.
+ * @param int    $nb    The number of items for plural forms.
+ *
+ * @return String Text translated.
+ */
+function t($text, $nText = '', $nb = 0) {
+    if (empty($nText)) {
+        return $text;
+    }
+    $actualForm = $nb > 1 ? $nText : $text;
+    return sprintf($actualForm, $nb);
+}

--- a/index.php
+++ b/index.php
@@ -53,6 +53,7 @@ require_once 'application/config/ConfigPlugin.php';
 require_once 'application/FeedBuilder.php';
 require_once 'application/FileUtils.php';
 require_once 'application/HttpUtils.php';
+require_once 'application/Languages.php';
 require_once 'application/LinkDB.php';
 require_once 'application/LinkFilter.php';
 require_once 'application/LinkUtils.php';

--- a/tests/LanguagesTest.php
+++ b/tests/LanguagesTest.php
@@ -1,0 +1,41 @@
+<?php
+
+require_once 'application/Languages.php';
+
+/**
+ * Class LanguagesTest.
+ */
+class LanguagesTest extends PHPUnit_Framework_TestCase
+{
+    /**
+     * Test t() with a simple non identified value.
+     */
+    public function testTranslateSingleNotID()
+    {
+        $text = 'abcdé 564 fgK';
+        $this->assertEquals($text, t($text));
+    }
+
+    /**
+     * Test t() with a non identified plural form.
+     */
+    public function testTranslatePluralNotID()
+    {
+        $text = '%s sandwich';
+        $nText = '%s sandwiches';
+        $this->assertEquals('0 sandwich', t($text, $nText));
+        $this->assertEquals('1 sandwich', t($text, $nText, 1));
+        $this->assertEquals('2 sandwiches', t($text, $nText, 2));
+    }
+
+    /**
+     * Test t() with a non identified invalid plural form.
+     */
+    public function testTranslatePluralNotIDInvalid()
+    {
+        $text = 'sandwich';
+        $nText = 'sandwiches';
+        $this->assertEquals('sandwich', t($text, $nText, 1));
+        $this->assertEquals('sandwiches', t($text, $nText, 2));
+    }
+}


### PR DESCRIPTION
It matches the API of ngettext(), regarding #121. 

It allows to call the translation function in the future templates.