### PR TITLE
Composer: reference shaarli/netscape-bookmark-parser from Packagist

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,15 +9,9 @@
         "wiki": "https://github.com/shaarli/Shaarli/wiki"
     },
     "keywords": ["bookmark", "link", "share", "web"],
-    "repositories": [
-        {
-            "type": "vcs",
-            "url": "https://github.com/shaarli/netscape-bookmark-parser"
-        }
-    ],
     "require": {
         "php": ">=5.3.4",
-        "kafene/netscape-bookmark-parser": "dev-shaarli-stable"
+        "shaarli/netscape-bookmark-parser": "1.*"
     },
     "require-dev": {
         "phpmd/phpmd" : "@stable",


### PR DESCRIPTION
Relates to https://github.com/shaarli/Shaarli/pull/607
Relates to https://github.com/shaarli/Shaarli/pull/612
Relates to https://github.com/shaarli/netscape-bookmark-parser/issues/15

Modification:
- reference the "shaarli" vendor repository on Packagist instead of
  overriding the upstream package with an SCM repository

See https://packagist.org/packages/shaarli/netscape-bookmark-parser