### PR TITLE
Fix: ensure Internet Explorer bookmark dumps can be imported

### DIFF
--- a/application/NetscapeBookmarkUtils.php
+++ b/application/NetscapeBookmarkUtils.php
@@ -98,8 +98,7 @@ class NetscapeBookmarkUtils
         $filesize = $files['filetoupload']['size'];
         $data = file_get_contents($files['filetoupload']['tmp_name']);
 
-        // Sniff file type
-        if (! startsWith($data, '<!DOCTYPE NETSCAPE-Bookmark-file-1>')) {
+        if (strpos($data, '<!DOCTYPE NETSCAPE-Bookmark-file-1>') === false) {
             return self::importStatus($filename, $filesize);
         }
 

--- a/tests/NetscapeBookmarkUtils/BookmarkImportTest.php
+++ b/tests/NetscapeBookmarkUtils/BookmarkImportTest.php
@@ -83,6 +83,34 @@ class BookmarkImportTest extends PHPUnit_Framework_TestCase
     }
 
     /**
+     * Ensure IE dumps are supported
+     */
+    public function testImportInternetExplorerEncoding()
+    {
+        $files = file2array('internet_explorer_encoding.htm');
+        $this->assertEquals(
+            'File internet_explorer_encoding.htm (356 bytes) was successfully processed:'
+            .' 1 links imported, 0 links overwritten, 0 links skipped.',
+            NetscapeBookmarkUtils::import(array(), $files, $this->linkDb, $this->pagecache)
+        );
+        $this->assertEquals(1, count($this->linkDb));
+        $this->assertEquals(0, count_private($this->linkDb));
+
+        $this->assertEquals(
+            array(
+                'linkdate' => '20160618_173944',
+                'title' => 'Hg Init a Mercurial tutorial by Joel Spolsky',
+                'url' => 'http://hginit.com/',
+                'description' => '',
+                'private' => 0,
+                'tags' => ''
+            ),
+            $this->linkDb->getLinkFromUrl('http://hginit.com/')
+        );
+    }
+
+
+    /**
      * Import bookmarks nested in a folder hierarchy
      */
     public function testImportNested()

--- a/tests/NetscapeBookmarkUtils/input/internet_explorer_encoding.htm
+++ b/tests/NetscapeBookmarkUtils/input/internet_explorer_encoding.htm
@@ -1,0 +1,9 @@
+﻿<!DOCTYPE NETSCAPE-Bookmark-file-1>
+<!-- This is an automatically generated file.
+It will be read and overwritten.
+Do Not Edit! -->
+<TITLE>Bookmarks</TITLE>
+<H1>Bookmarks</H1>
+<DL><p>
+    <DT><A HREF="http://hginit.com/" ADD_DATE="1466271584" LAST_VISIT="1466271584" LAST_MODIFIED="1466271584" >Hg Init a Mercurial tutorial by Joel Spolsky</A>
+</DL><p>


### PR DESCRIPTION
Relates to https://github.com/shaarli/Shaarli/issues/607

Modifications:
- [application][tests] NetscapeBookmarkUtils: more permissive doctype detection

The IE bookmark exports contain extra escape sequences, which can be observed
by binary comparison of the reference input data used in tests:

```bash
   $ cmp -b -l -n 8 netscape_basic.htm internet_explorer_encoding.htm

   1  74 <    357 M-o
   2  41 !    273 M-;
   3 104 D    277 M-?
   4 117 O     74 <
   5 103 C     41 !
   6 124 T    104 D
   7 131 Y    117 O
   8 120 P    103 C
```