### PR TITLE
Isso comments plugin

### DIFF
--- a/plugins/isso/isso.css
+++ b/plugins/isso/isso.css
@@ -1,0 +1,3 @@
+#isso-thread > h4 {
+    text-align: center;
+}

--- a/plugins/isso/isso.html
+++ b/plugins/isso/isso.html
@@ -1,0 +1,14 @@
+<script data-isso="//%s"
+        data-isso-css="true"
+        data-isso-lang="en"
+        data-isso-reply-to-self="true"
+        data-isso-max-comments-top="20"
+        data-isso-max-comments-nested="5"
+        data-isso-reveal-on-click="5"
+        data-isso-avatar="true"
+        data-isso-avatar-bg="#f0f0f0"
+        data-isso-avatar-fg="#9abf88 #5698c4 #e279a3 #9163b6 ..."
+        data-isso-vote="true"
+        src="//%s/js/embed.min.js">
+</script>
+<section id="isso-thread" data-isso-id="%s" data-title="%s"></section>

--- a/plugins/isso/isso.meta
+++ b/plugins/isso/isso.meta
@@ -1,0 +1,3 @@
+description="Let visitor comment your shaares on permalinks with Isso."
+parameters="ISSO_SERVER"
+parameter.ISSO_SERVER="Isso server URL (without 'http://')"

--- a/plugins/isso/isso.php
+++ b/plugins/isso/isso.php
@@ -1,0 +1,54 @@
+<?php
+
+/**
+ * Plugin Isso.
+ */
+
+/**
+ * Display an error everywhere if the plugin is enabled without configuration.
+ *
+ * @param $data array         List of links
+ * @param $conf ConfigManager instance
+ *
+ * @return mixed - linklist data with Isso plugin.
+ */
+function isso_init($conf)
+{
+    $issoUrl = $conf->get('plugins.ISSO_SERVER');
+    if (empty($issoUrl)) {
+        $error = 'Isso plugin error: '.
+            'Please define the "ISSO_SERVER" setting in the plugin administration page.';
+        return array($error);
+    }
+}
+
+/**
+ * Render linklist hook.
+ * Will only display Isso comments on permalinks.
+ *
+ * @param $data array         List of links
+ * @param $conf ConfigManager instance
+ *
+ * @return mixed - linklist data with Isso plugin.
+ */
+function hook_isso_render_linklist($data, $conf)
+{
+    $issoUrl = $conf->get('plugins.ISSO_SERVER');
+    if (empty($issoUrl)) {
+        return $data;
+    }
+
+    // Only display comments for permalinks.
+    if (count($data['links']) == 1 && empty($data['search_tags']) && empty($data['search_term'])) {
+        $link = reset($data['links']);
+        $isso_html = file_get_contents(PluginManager::$PLUGINS_PATH . '/isso/isso.html');
+
+        $isso = sprintf($isso_html, $issoUrl, $issoUrl, $link['linkdate'], $link['linkdate']);
+        $data['plugin_end_zone'][] = $isso;
+
+        // Hackish way to include this CSS file only when necessary.
+        $data['plugins_includes']['css_files'][] = PluginManager::$PLUGINS_PATH . '/isso/isso.css';
+    }
+
+    return $data;
+}

--- a/tests/plugins/PluginIssoTest.php
+++ b/tests/plugins/PluginIssoTest.php
@@ -1,0 +1,136 @@
+<?php
+
+require_once 'plugins/isso/isso.php';
+
+/**
+ * Class PluginIssoTest
+ *
+ * Test the Isso plugin (comment system).
+ */
+class PluginIssoTest extends PHPUnit_Framework_TestCase
+{
+    /**
+     * Reset plugin path
+     */
+    function setUp()
+    {
+        PluginManager::$PLUGINS_PATH = 'plugins';
+    }
+
+    /**
+     * Test Isso init without errors.
+     */
+    function testWallabagInitNoError()
+    {
+        $conf = new ConfigManager('');
+        $conf->set('plugins.ISSO_SERVER', 'value');
+        $errors = isso_init($conf);
+        $this->assertEmpty($errors);
+    }
+
+    /**
+     * Test Isso init with errors.
+     */
+    function testWallabagInitError()
+    {
+        $conf = new ConfigManager('');
+        $errors = isso_init($conf);
+        $this->assertNotEmpty($errors);
+    }
+
+    /**
+     * Test render_linklist hook with valid settings to display the comment form.
+     */
+    function testIssoDisplayed()
+    {
+        $conf = new ConfigManager('');
+        $conf->set('plugins.ISSO_SERVER', 'value');
+
+        $str = 'http://randomstr.com/test';
+        $data = array(
+            'title' => $str,
+            'links' => array(
+                array(
+                    'url' => $str,
+                    'linkdate' => 'abc',
+                )
+            )
+        );
+
+        $data = hook_isso_render_linklist($data, $conf);
+
+        // data shouldn't be altered
+        $this->assertEquals($str, $data['title']);
+        $this->assertEquals($str, $data['links'][0]['url']);
+
+        // plugin data
+        $this->assertEquals(1, count($data['plugin_end_zone']));
+        $this->assertNotFalse(strpos($data['plugin_end_zone'][0], 'abc'));
+        $this->assertNotFalse(strpos($data['plugin_end_zone'][0], 'embed.min.js'));
+    }
+
+    /**
+     * Test isso plugin when multiple links are displayed (shouldn't be displayed).
+     */
+    function testIssoMultipleLinks()
+    {
+        $conf = new ConfigManager('');
+        $conf->set('plugins.ISSO_SERVER', 'value');
+
+        $str = 'http://randomstr.com/test';
+        $data = array(
+            'title' => $str,
+            'links' => array(
+                array(
+                    'url' => $str,
+                    'linkdate' => 'abc',
+                ),
+                array(
+                    'url' => $str . '2',
+                    'linkdate' => 'abc2',
+                ),
+            )
+        );
+
+        $processed = hook_isso_render_linklist($data, $conf);
+        // data shouldn't be altered
+        $this->assertEquals($data, $processed);
+    }
+
+    /**
+     * Test isso plugin when using search (shouldn't be displayed).
+     */
+    function testIssoNotDisplayedWhenSearch()
+    {
+        $conf = new ConfigManager('');
+        $conf->set('plugins.ISSO_SERVER', 'value');
+
+        $str = 'http://randomstr.com/test';
+        $data = array(
+            'title' => $str,
+            'links' => array(
+                array(
+                    'url' => $str,
+                    'linkdate' => 'abc',
+                )
+            ),
+            'search_term' => $str
+        );
+
+        $processed = hook_isso_render_linklist($data, $conf);
+
+        // data shouldn't be altered
+        $this->assertEquals($data, $processed);
+    }
+
+    /**
+     * Test isso plugin without server configuration (shouldn't be displayed).
+     */
+    function testIssoWithoutConf()
+    {
+        $data = 'abc';
+        $conf = new ConfigManager('');
+        $processed = hook_isso_render_linklist($data, $conf);
+        $this->assertEquals($data, $processed);
+    }
+}


### PR DESCRIPTION
Use Isso client to let visitors comments on permalinks

Note: also affect private links because links can previously commented links can be set to private and the other way around.

Note bis: It's not beautifully integrated for now.

![](http://i.imgur.com/SjyzpyV.png)

ping #181
