### PR TITLE
New init function for plugins, supports errors reporting

### DIFF
--- a/application/PageBuilder.php
+++ b/application/PageBuilder.php
@@ -77,9 +77,6 @@ class PageBuilder
         $this->tpl->assign('openshaarli', $this->conf->get('security.open_shaarli', false));
         $this->tpl->assign('showatom', $this->conf->get('feed.show_atom', false));
         $this->tpl->assign('hide_timestamps', $this->conf->get('privacy.hide_timestamps', false));
-        if (!empty($GLOBALS['plugin_errors'])) {
-            $this->tpl->assign('plugin_errors', $GLOBALS['plugin_errors']);
-        }
         $this->tpl->assign('token', getToken($this->conf));
         // To be removed with a proper theme configuration.
         $this->tpl->assign('conf', $this->conf);

--- a/application/PluginManager.php
+++ b/application/PluginManager.php
@@ -25,6 +25,11 @@ class PluginManager
     protected $conf;
 
     /**
+     * @var array List of plugin errors.
+     */
+    protected $errors;
+
+    /**
      * Plugins subdirectory.
      * @var string $PLUGINS_PATH
      */
@@ -44,6 +49,7 @@ class PluginManager
     public function __construct(&$conf)
     {
         $this->conf = $conf;
+        $this->errors = array();
     }
 
     /**
@@ -106,6 +112,7 @@ class PluginManager
 
     /**
      * Load a single plugin from its files.
+     * Call the init function if it exists, and collect errors.
      * Add them in $loadedPlugins if successful.
      *
      * @param string $dir        plugin's directory.
@@ -127,6 +134,14 @@ class PluginManager
 
         $conf = $this->conf;
         include_once $pluginFilePath;
+
+        $initFunction = $pluginName . '_init';
+        if (function_exists($initFunction)) {
+            $errors = call_user_func($initFunction, $this->conf);
+            if (!empty($errors)) {
+                $this->errors = array_merge($this->errors, $errors);
+            }
+        }
 
         $this->loadedPlugins[] = $pluginName;
     }
@@ -194,6 +209,16 @@ class PluginManager
         }
 
         return $metaData;
+    }
+
+    /**
+     * Return the list of encountered errors.
+     *
+     * @return array List of errors (empty array if none exists).
+     */
+    public function getErrors()
+    {
+        return $this->errors;
     }
 }
 

--- a/index.php
+++ b/index.php
@@ -778,6 +778,7 @@ function renderPage($conf, $pluginManager)
     $PAGE = new PageBuilder($conf);
     $PAGE->assign('linkcount', count($LINKSDB));
     $PAGE->assign('privateLinkcount', count_private($LINKSDB));
+    $PAGE->assign('plugin_errors', $pluginManager->getErrors());
 
     // Determine which page will be rendered.
     $query = (isset($_SERVER['QUERY_STRING'])) ? $_SERVER['QUERY_STRING'] : '';

--- a/plugins/demo_plugin/demo_plugin.php
+++ b/plugins/demo_plugin/demo_plugin.php
@@ -15,6 +15,23 @@
  */
 
 /**
+ * Initialization function.
+ * It will be called when the plugin is loaded.
+ * This function can be used to return a list of initialization errors.
+ *
+ * @param $conf ConfigManager instance.
+ *
+ * @return array List of errors (optional).
+ */
+function demo_plugin_init($conf)
+{
+    $conf->get('toto', 'nope');
+
+    $errors[] = 'This a demo init error.';
+    return $errors;
+}
+
+/**
  * Hook render_header.
  * Executed on every page redering.
  *

--- a/plugins/readityourself/readityourself.php
+++ b/plugins/readityourself/readityourself.php
@@ -8,10 +8,21 @@
 // it seems kinda dead.
 // Not tested.
 
-$riyUrl = $conf->get('plugins.READITYOUSELF_URL');
-if (empty($riyUrl)) {
-    $GLOBALS['plugin_errors'][] = 'Readityourself plugin error: '.
-        'Please define the "READITYOUSELF_URL" setting in the plugin administration page.';
+/**
+ * Init function, return an error if the server is not set.
+ *
+ * @param $conf ConfigManager instance.
+ *
+ * @return array Eventual error.
+ */
+function readityourself_init($conf)
+{
+    $riyUrl = $conf->get('plugins.READITYOUSELF_URL');
+    if (empty($riyUrl)) {
+        $error = 'Readityourself plugin error: '.
+            'Please define the "READITYOUSELF_URL" setting in the plugin administration page.';
+        return array($error);
+    }
 }
 
 /**

--- a/plugins/wallabag/wallabag.php
+++ b/plugins/wallabag/wallabag.php
@@ -6,10 +6,21 @@
 
 require_once 'WallabagInstance.php';
 
-$wallabagUrl = $conf->get('plugins.WALLABAG_URL');
-if (empty($wallabagUrl)) {
-    $GLOBALS['plugin_errors'][] = 'Wallabag plugin error: '.
-        'Please define the "WALLABAG_URL" setting in the plugin administration page.';
+/**
+ * Init function, return an error if the server is not set.
+ *
+ * @param $conf ConfigManager instance.
+ *
+ * @return array Eventual error.
+ */
+function wallabag_init($conf)
+{
+    $wallabagUrl = $conf->get('plugins.WALLABAG_URL');
+    if (empty($wallabagUrl)) {
+        $error = 'Wallabag plugin error: '.
+            'Please define the "WALLABAG_URL" setting in the plugin administration page.';
+        return array($error);
+    }
 }
 
 /**

--- a/tests/plugins/PluginReadityourselfTest.php
+++ b/tests/plugins/PluginReadityourselfTest.php
@@ -4,8 +4,6 @@
  * PluginReadityourselfTest.php.php
  */
 
-// FIXME! add an init method.
-$conf = new ConfigManager('');
 require_once 'plugins/readityourself/readityourself.php';
 
 /**
@@ -20,6 +18,27 @@ class PluginReadityourselfTest extends PHPUnit_Framework_TestCase
     function setUp()
     {
         PluginManager::$PLUGINS_PATH = 'plugins';
+    }
+
+    /**
+     * Test Readityourself init without errors.
+     */
+    function testReadityourselfInitNoError()
+    {
+        $conf = new ConfigManager('');
+        $conf->set('plugins.READITYOUSELF_URL', 'value');
+        $errors = readityourself_init($conf);
+        $this->assertEmpty($errors);
+    }
+
+    /**
+     * Test Readityourself init with errors.
+     */
+    function testReadityourselfInitError()
+    {
+        $conf = new ConfigManager('');
+        $errors = readityourself_init($conf);
+        $this->assertNotEmpty($errors);
     }
 
     /**

--- a/tests/plugins/PluginWallabagTest.php
+++ b/tests/plugins/PluginWallabagTest.php
@@ -4,8 +4,6 @@
  * PluginWallabagTest.php.php
  */
 
-// FIXME! add an init method.
-$conf = new ConfigManager('');
 require_once 'plugins/wallabag/wallabag.php';
 
 /**
@@ -20,6 +18,27 @@ class PluginWallabagTest extends PHPUnit_Framework_TestCase
     function setUp()
     {
         PluginManager::$PLUGINS_PATH = 'plugins';
+    }
+
+    /**
+     * Test wallabag init without errors.
+     */
+    function testWallabagInitNoError()
+    {
+        $conf = new ConfigManager('');
+        $conf->set('plugins.WALLABAG_URL', 'value');
+        $errors = wallabag_init($conf);
+        $this->assertEmpty($errors);
+    }
+
+    /**
+     * Test wallabag init with errors.
+     */
+    function testWallabagInitError()
+    {
+        $conf = new ConfigManager('');
+        $errors = wallabag_init($conf);
+        $this->assertNotEmpty($errors);
     }
 
     /**


### PR DESCRIPTION
All plugins can optionally add an init function named `pluginname_init()` which is called when the plugin is loaded.

This function is aware of the config, and can return initialization errors, which are displayed in the header template.

Note that the previous error system hack no longer work.