### PR TITLE
Cleanup: explicitely loop over PHP variables in templates

### DIFF
--- a/tpl/daily.html
+++ b/tpl/daily.html
@@ -42,10 +42,10 @@
     <div class="clear"></div>
 
     {if="$linksToDisplay"}
-        {loop="cols"}
+        {loop="$cols"}
             {if="isset($value[0])"}
             <div id="daily_col{$counter+1}">
-                {loop="value"}
+                {loop="$value"}
                     {$link=$value}
                     <div class="dailyEntry">
                         <div class="dailyEntryPermalink">
@@ -60,7 +60,7 @@
                         {/if}
                         {if="$link.tags"}
                             <div class="dailyEntryTags">
-                                {loop="link.taglist"}
+                                {loop="$link.taglist"}
                                     {$value} -
                                 {/loop}
                             </div>

--- a/tpl/dailyrss.html
+++ b/tpl/dailyrss.html
@@ -4,7 +4,7 @@
     <link>{$absurl}</link>
     <pubDate>{$rssdate}</pubDate>
     <description><![CDATA[
-        {loop="links"}
+        {loop="$links"}
         	<h3><a href="{$value.url}">{$value.title}</a></h3>
         	<small>{if="!$hide_timestamps"}{function="strftime('%c', $value.timestamp)"} - {/if}{if="$value.tags"}{$value.tags}{/if}<br>
         	{$value.url}</small><br>

--- a/tpl/export.bookmarks.html
+++ b/tpl/export.bookmarks.html
@@ -5,6 +5,6 @@
      Do Not Edit! -->{ignore}The RainTPL loop is formatted to avoid generating extra newlines{/ignore}
 <TITLE>{$pagetitle}</TITLE>
 <H1>Shaarli export of {$selection} bookmarks on {$date}</H1>
-<DL><p>{loop="links"}
+<DL><p>{loop="$links"}
 <DT><A HREF="{$value.url}" ADD_DATE="{$value.timestamp}" PRIVATE="{$value.private}" TAGS="{$value.taglist}">{$value.title}</A>{if="$value.description"}{$eol}<DD>{$value.description}{/if}{/loop}
 </DL><p>

--- a/tpl/feed.atom.html
+++ b/tpl/feed.atom.html
@@ -17,7 +17,7 @@
   </author>
   <id>{$index_url}</id>
   <generator>Shaarli</generator>
-  {loop="links"}
+  {loop="$links"}
     <entry>
       <title>{$value.title}</title>
       {if="$usepermalinks"}

--- a/tpl/feed.rss.html
+++ b/tpl/feed.rss.html
@@ -12,7 +12,7 @@
       <!-- PubSubHubbub Discovery -->
       <atom:link rel="hub" href="{$pubsubhub_url}" />
     {/if}
-    {loop="links"}
+    {loop="$links"}
       <item>
         <title>{$value.title}</title>
         <guid isPermaLink="{if="$usepermalinks"}true{else}false{/if}">{$value.guid}</guid>

--- a/tpl/linklist.html
+++ b/tpl/linklist.html
@@ -63,7 +63,7 @@
         </div>
     {/if}
     <ul>
-        {loop="links"}
+        {loop="$links"}
         <li{if="$value.class"} class="{$value.class}"{/if}>
             <a id="{$value.shorturl}"></a>
             <div class="thumbnail">{$value.url|thumbnail}</div>
@@ -110,7 +110,7 @@
                 <a href="{$value.real_url}"><span class="linkurl" title="Short link">{$value.url}</span></a><br>
                 {if="$value.tags"}
                     <div class="linktaglist">
-                    {loop="value.taglist"}<span class="linktag" title="Add tag"><a href="?addtag={$value|urlencode}">{$value}</a></span> {/loop}
+                    {loop="$value.taglist"}<span class="linktag" title="Add tag"><a href="?addtag={$value|urlencode}">{$value}</a></span> {/loop}
                     </div>
                 {/if}
 

--- a/tpl/page.header.html
+++ b/tpl/page.header.html
@@ -43,7 +43,7 @@
 
 {if="!empty($plugin_errors) && isLoggedIn()"}
     <ul class="errors">
-        {loop="plugin_errors"}
+        {loop="$plugin_errors"}
             <li>{$value}</li>
         {/loop}
     </ul>

--- a/tpl/picwall.html
+++ b/tpl/picwall.html
@@ -14,7 +14,7 @@
 
 <div class="center">
         <div id="picwall_container">
-            {loop="linksToDisplay"}
+            {loop="$linksToDisplay"}
             <div class="picwall_pictureframe">
         	    {$value.thumbnail}<a href="{$value.real_url}"><span class="info">{$value.title}</span></a>
                 {loop="$value.picwall_plugin"}

--- a/tpl/tagcloud.html
+++ b/tpl/tagcloud.html
@@ -11,7 +11,7 @@
     </div>
 
     <div id="cloudtag">
-        {loop="tags"}
+        {loop="$tags"}
             <span class="count">{$value.count}</span><a
                 href="?searchtags={$key|urlencode}" style="font-size:{$value.size}em;">{$key}</a>
             {loop="$value.tag_plugin"}


### PR DESCRIPTION
Relates to https://github.com/shaarli/Shaarli/issues/613

Before: `{loop="someVariable"}`
After:  `{loop="$someVariable"}`