### PR TITLE
Update release archive generation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,23 +6,26 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 
 ## [v0.8.1](https://github.com/shaarli/Shaarli/releases/tag/v0.8.1) - UNPUBLISHED
-## Added
+### Added
 - Add CHANGELOG.md to track the whole project's history
 - Save the last edition date for shaares and use it in Atom/RSS feeds
 - Plugins:
     - Add an [Isso](https://posativ.org/isso/) plugin to enable user comments on permalinks
     - Allow defining init functions, e.g. for performing checks and error processing
 
-## Changed
+### Changed
 - Cleanup `{loop}` declarations in templates
+- Release archives now have the same structure as GitHub-generated archives:
+    - archives contain a `Shaarli` directory, itself containing sources + dependencies
+    - the tarball is now gzipped
 
-## Fixed
+### Fixed
 - Fix the server `<self>` value in Atom/RSS feeds
 - Plugins:
     - Tools: only display parameter description when it exists
     - archive.org: do not propose archival of private notes
 
-## Security
+### Security
 - Allow whitelisting trusted IPs, else continue banning clients upon login failure
 
 

--- a/Makefile
+++ b/Makefile
@@ -137,6 +137,7 @@ test:
 # to ease deployment on shared hosting.
 ##
 ARCHIVE_VERSION := shaarli-$$(git describe)-full
+ARCHIVE_PREFIX=Shaarli/
 
 release_archive: release_tar release_zip
 
@@ -147,13 +148,17 @@ composer_dependencies: clean
 
 ### generate a release tarball and include 3rd-party dependencies
 release_tar: composer_dependencies
-	git archive -o $(ARCHIVE_VERSION).tar HEAD
-	tar rvf $(ARCHIVE_VERSION).tar vendor/
+	git archive --prefix=$(ARCHIVE_PREFIX) -o $(ARCHIVE_VERSION).tar HEAD
+	tar rvf $(ARCHIVE_VERSION).tar --transform "s|^vendor|$(ARCHIVE_PREFIX)vendor|" vendor/
+	gzip $(ARCHIVE_VERSION).tar
 
 ### generate a release zip and include 3rd-party dependencies
 release_zip: composer_dependencies
-	git archive -o $(ARCHIVE_VERSION).zip -9 HEAD
-	zip -r $(ARCHIVE_VERSION).zip vendor/
+	git archive --prefix=$(ARCHIVE_PREFIX) -o $(ARCHIVE_VERSION).zip -9 HEAD
+	mkdir $(ARCHIVE_PREFIX)
+	rsync -a vendor/ $(ARCHIVE_PREFIX)vendor/
+	zip -r $(ARCHIVE_VERSION).zip $(ARCHIVE_PREFIX)vendor/
+	rm -rf $(ARCHIVE_PREFIX)
 
 ##
 # Targets for repository and documentation maintenance


### PR DESCRIPTION
Relates to https://github.com/shaarli/Shaarli/issues/607
Relates to https://github.com/shaarli/Shaarli/pull/608

TODO:
- [x] match the arborescence of the archives provided by GitHub
- [x] generate compressed tarballs
- [x] update https://github.com/shaarli/Shaarli/wiki/Download-and-Installation
- [ ] upload new release archives to https://github.com/shaarli/Shaarli/releases/tag/v0.8.0

@ArthurHoaro [wrote](https://github.com/shaarli/Shaarli/pull/608#issuecomment-253752275):
> @virtualtam: the archives generated with this target contain the Shaarli files "directly", while Github auto-generated archives contain them in a sub-folder. Is there a reason behind this? If not it might be a good idea to preserve the same behaviour.

Now I remember: I left the archives as generated by `git-archive` -that is, without an internal `Shaarli-XXX` prefix. While the prefix itself is quite easy to add through the `--transform` flag, this makes adding extra files (the `vendor` dir) a bit tedious/hackish (pick your favourite adjective ^^).