### PR TITLE
LinkDB: code cleanup

### DIFF
--- a/application/LinkDB.php
+++ b/application/LinkDB.php
@@ -100,8 +100,8 @@ class LinkDB implements Iterator, Countable, ArrayAccess
         $this->hidePublicLinks = $hidePublicLinks;
         $this->redirector = $redirector;
         $this->redirectorEncode = $redirectorEncode === true;
-        $this->checkDB();
-        $this->readDB();
+        $this->check();
+        $this->read();
     }
 
     /**
@@ -210,7 +210,7 @@ class LinkDB implements Iterator, Countable, ArrayAccess
      *
      * If no DB file is found, creates a dummy DB.
      */
-    private function checkDB()
+    private function check()
     {
         if (file_exists($this->datastore)) {
             return;
@@ -243,13 +243,13 @@ You use the community supported version of the original Shaarli project, by Seba
         $this->links[$link['linkdate']] = $link;
 
         // Write database to disk
-        $this->writeDB();
+        $this->write();
     }
 
     /**
      * Reads database from disk to memory
      */
-    private function readDB()
+    private function read()
     {
 
         // Public links are hidden and user not logged in => nothing to show
@@ -315,7 +315,7 @@ You use the community supported version of the original Shaarli project, by Seba
      *
      * @throws IOException the datastore is not writable
      */
-    private function writeDB()
+    private function write()
     {
         if (is_file($this->datastore) && !is_writeable($this->datastore)) {
             // The datastore exists but is not writeable
@@ -337,14 +337,14 @@ You use the community supported version of the original Shaarli project, by Seba
      *
      * @param string $pageCacheDir page cache directory
      */
-    public function savedb($pageCacheDir)
+    public function save($pageCacheDir)
     {
         if (!$this->loggedIn) {
             // TODO: raise an Exception instead
             die('You are not authorized to change the database.');
         }
 
-        $this->writeDB();
+        $this->write();
 
         invalidateCaches($pageCacheDir);
     }

--- a/application/LinkDB.php
+++ b/application/LinkDB.php
@@ -87,7 +87,7 @@ class LinkDB implements Iterator, Countable, ArrayAccess
      * @param string  $redirector       link redirector set in user settings.
      * @param boolean $redirectorEncode Enable urlencode on redirected urls (default: true).
      */
-    function __construct(
+    public function __construct(
         $datastore,
         $isLoggedIn,
         $hidePublicLinks,
@@ -164,7 +164,7 @@ class LinkDB implements Iterator, Countable, ArrayAccess
     /**
      * Iterator - Returns the current element
      */
-    function current()
+    public function current()
     {
         return $this->links[$this->keys[$this->position]];
     }
@@ -172,7 +172,7 @@ class LinkDB implements Iterator, Countable, ArrayAccess
     /**
      * Iterator - Returns the key of the current element
      */
-    function key()
+    public function key()
     {
         return $this->keys[$this->position];
     }
@@ -180,7 +180,7 @@ class LinkDB implements Iterator, Countable, ArrayAccess
     /**
      * Iterator - Moves forward to next element
      */
-    function next()
+    public function next()
     {
         ++$this->position;
     }
@@ -190,7 +190,7 @@ class LinkDB implements Iterator, Countable, ArrayAccess
      *
      * Entries are sorted by date (latest first)
      */
-    function rewind()
+    public function rewind()
     {
         $this->keys = array_keys($this->links);
         rsort($this->keys);
@@ -200,7 +200,7 @@ class LinkDB implements Iterator, Countable, ArrayAccess
     /**
      * Iterator - Checks if current position is valid
      */
-    function valid()
+    public function valid()
     {
         return isset($this->keys[$this->position]);
     }

--- a/application/NetscapeBookmarkUtils.php
+++ b/application/NetscapeBookmarkUtils.php
@@ -183,7 +183,7 @@ class NetscapeBookmarkUtils
             $importCount++;
         }
 
-        $linkDb->savedb($pagecache);
+        $linkDb->save($pagecache);
         return self::importStatus(
             $filename,
             $filesize,

--- a/application/Updater.php
+++ b/application/Updater.php
@@ -143,7 +143,7 @@ class Updater
             $link['tags'] = implode(' ', array_unique(LinkFilter::tagsStrToArray($link['tags'], true)));
             $this->linkDB[$link['linkdate']] = $link;
         }
-        $this->linkDB->savedb($this->conf->get('resource.page_cache'));
+        $this->linkDB->save($this->conf->get('resource.page_cache'));
         return true;
     }
 

--- a/index.php
+++ b/index.php
@@ -1211,7 +1211,7 @@ function renderPage($conf, $pluginManager)
                 $value['tags']=trim(implode(' ',$tags));
                 $LINKSDB[$key]=$value;
             }
-            $LINKSDB->savedb($conf->get('resource.page_cache'));
+            $LINKSDB->save($conf->get('resource.page_cache'));
             echo '<script>alert("Tag was removed from '.count($linksToAlter).' links.");document.location=\'?\';</script>';
             exit;
         }
@@ -1228,7 +1228,7 @@ function renderPage($conf, $pluginManager)
                 $value['tags']=trim(implode(' ',$tags));
                 $LINKSDB[$key]=$value;
             }
-            $LINKSDB->savedb($conf->get('resource.page_cache')); // Save to disk.
+            $LINKSDB->save($conf->get('resource.page_cache')); // Save to disk.
             echo '<script>alert("Tag was renamed in '.count($linksToAlter).' links.");document.location=\'?searchtags='.urlencode($_POST['totag']).'\';</script>';
             exit;
         }
@@ -1283,7 +1283,7 @@ function renderPage($conf, $pluginManager)
         $pluginManager->executeHooks('save_link', $link);
 
         $LINKSDB[$linkdate] = $link;
-        $LINKSDB->savedb($conf->get('resource.page_cache'));
+        $LINKSDB->save($conf->get('resource.page_cache'));
         pubsubhub($conf);
 
         // If we are called from the bookmarklet, we must close the popup:
@@ -1325,7 +1325,7 @@ function renderPage($conf, $pluginManager)
         $pluginManager->executeHooks('delete_link', $LINKSDB[$linkdate]);
 
         unset($LINKSDB[$linkdate]);
-        $LINKSDB->savedb('resource.page_cache'); // save to disk
+        $LINKSDB->save('resource.page_cache'); // save to disk
 
         // If we are called from the bookmarklet, we must close the popup:
         if (isset($_GET['source']) && ($_GET['source']=='bookmarklet' || $_GET['source']=='firefoxsocialapi')) { echo '<script>self.close();</script>'; exit; }

--- a/tests/LinkDBTest.php
+++ b/tests/LinkDBTest.php
@@ -117,7 +117,7 @@ class LinkDBTest extends PHPUnit_Framework_TestCase
         unlink(self::$testDatastore);
         $this->assertFileNotExists(self::$testDatastore);
 
-        $checkDB = self::getMethod('_checkDB');
+        $checkDB = self::getMethod('checkDB');
         $checkDB->invokeArgs($linkDB, array());
         $this->assertFileExists(self::$testDatastore);
 
@@ -134,7 +134,7 @@ class LinkDBTest extends PHPUnit_Framework_TestCase
         $datastoreSize = filesize(self::$testDatastore);
         $this->assertGreaterThan(0, $datastoreSize);
 
-        $checkDB = self::getMethod('_checkDB');
+        $checkDB = self::getMethod('checkDB');
         $checkDB->invokeArgs($linkDB, array());
 
         // ensure the datastore is left unmodified

--- a/tests/LinkDBTest.php
+++ b/tests/LinkDBTest.php
@@ -117,7 +117,7 @@ class LinkDBTest extends PHPUnit_Framework_TestCase
         unlink(self::$testDatastore);
         $this->assertFileNotExists(self::$testDatastore);
 
-        $checkDB = self::getMethod('checkDB');
+        $checkDB = self::getMethod('check');
         $checkDB->invokeArgs($linkDB, array());
         $this->assertFileExists(self::$testDatastore);
 
@@ -134,7 +134,7 @@ class LinkDBTest extends PHPUnit_Framework_TestCase
         $datastoreSize = filesize(self::$testDatastore);
         $this->assertGreaterThan(0, $datastoreSize);
 
-        $checkDB = self::getMethod('checkDB');
+        $checkDB = self::getMethod('check');
         $checkDB->invokeArgs($linkDB, array());
 
         // ensure the datastore is left unmodified
@@ -180,7 +180,7 @@ class LinkDBTest extends PHPUnit_Framework_TestCase
     /**
      * Save the links to the DB
      */
-    public function testSaveDB()
+    public function testSave()
     {
         $testDB = new LinkDB(self::$testDatastore, true, false);
         $dbSize = sizeof($testDB);
@@ -194,7 +194,7 @@ class LinkDBTest extends PHPUnit_Framework_TestCase
             'tags'=>'unit test'
         );
         $testDB[$link['linkdate']] = $link;
-        $testDB->savedb('tests');
+        $testDB->save('tests');
 
         $testDB = new LinkDB(self::$testDatastore, true, false);
         $this->assertEquals($dbSize + 1, sizeof($testDB));

--- a/tests/utils/ReferenceLinkDB.php
+++ b/tests/utils/ReferenceLinkDB.php
@@ -13,7 +13,7 @@ class ReferenceLinkDB
     /**
      * Populates the test DB with reference data
      */
-    function __construct()
+    public function __construct()
     {
         $this->addLink(
             'Link title: @website',


### PR DESCRIPTION
A bit of cleanup of `LinkDB`'s internals before working on #351:
- apply coding conventions (no leading underscore in privates' names)
- simplify method names
- explicit (public) method visibility