### PR TITLE
Improve theme dependent plugin placeholders:

### DIFF
--- a/plugins/addlink_toolbar/addlink_toolbar.css
+++ b/plugins/addlink_toolbar/addlink_toolbar.css
@@ -1,4 +1,0 @@
-#addlink_toolbar {
-    display: inline;
-    margin: 0 0 0 25px;
-}

--- a/plugins/addlink_toolbar/addlink_toolbar.html
+++ b/plugins/addlink_toolbar/addlink_toolbar.html
@@ -1,6 +1,0 @@
-<div id="addlink_toolbar">
-    <form method="GET" action="" name="addform" class="addform">
-        <input type="text" name="post" placeholder="URI">
-        <input type="submit" value="Add link" class="bigbutton">
-    </form>
-</div>

--- a/plugins/addlink_toolbar/addlink_toolbar.php
+++ b/plugins/addlink_toolbar/addlink_toolbar.php
@@ -15,7 +15,27 @@
 function hook_addlink_toolbar_render_header($data)
 {
     if ($data['_PAGE_'] == Router::$PAGE_LINKLIST && $data['_LOGGEDIN_'] === true) {
-        $data['fields_toolbar'][] = file_get_contents(PluginManager::$PLUGINS_PATH . '/addlink_toolbar/addlink_toolbar.html');
+        $form = array(
+            'attr' => array(
+                'method' => 'GET',
+                'action' => '',
+                'name'   => 'addform',
+                'class'  => 'addform',
+            ),
+            'inputs' => array(
+                array(
+                    'type' => 'text',
+                    'name' => 'post',
+                    'placeholder' => 'URI',
+                ),
+                array(
+                    'type' => 'submit',
+                    'value' => 'Add link',
+                    'class' => 'bigbutton',
+                ),
+            ),
+        );
+        $data['fields_toolbar'][] = $form;
     }
 
     return $data;

--- a/plugins/demo_plugin/custom_demo.css
+++ b/plugins/demo_plugin/custom_demo.css
@@ -2,10 +2,6 @@
     color: red;
 }
 
-.upper_plugin_demo {
-    float: left;
-}
-
 #demo_marquee {
 	background: darkmagenta;
 	color: white;

--- a/plugins/demo_plugin/demo_plugin.php
+++ b/plugins/demo_plugin/demo_plugin.php
@@ -50,15 +50,68 @@ function hook_demo_plugin_render_header($data)
 
         // If loggedin
         if ($data['_LOGGEDIN_'] === true) {
-            // Buttons in toolbar
-            $data['buttons_toolbar'][] = '<li><a href="#">DEMO_buttons_toolbar</a></li>';
+            /*
+             * Links in toolbar:
+             * A link is an array of its attributes (key="value"),
+             * and a mandatory `html` key, which contains its value.
+             */
+            $button = array(
+                'attr' => array (
+                    'href' => '#',
+                    'class' => 'mybutton',
+                    'title' => 'hover me',
+                ),
+                'html' => 'DEMO buttons toolbar',
+            );
+            $data['buttons_toolbar'][] = $button;
         }
 
-        // Fields in toolbar
-        $data['fields_toolbar'][] = 'DEMO_fields_toolbar';
+        /*
+         * Add additional input fields in the tools.
+         * A field is an array containing:
+         *  [
+         *      'form-attribute-1' => 'form attribute 1 value',
+         *      'form-attribute-2' => 'form attribute 2 value',
+         *      'inputs' => [
+         *          [
+         *              'input-1-attribute-1 => 'input 1 attribute 1 value',
+         *              'input-1-attribute-2 => 'input 1 attribute 2 value',
+         *          ],
+         *          [
+         *              'input-2-attribute-1 => 'input 2 attribute 1 value',
+         *          ],
+         *      ],
+         *  ]
+         * This example renders as:
+         *      <form form-attribute-1="form attribute 1 value" form-attribute-2="form attribute 2 value">
+         *          <input input-1-attribute-1="input 1 attribute 1 value" input-1-attribute-2="input 1 attribute 2 value">
+         *          <input input-2-attribute-1="input 2 attribute 1 value">
+         *      </form>
+         */
+        $form = array(
+            'attr' => array(
+                'method' => 'GET',
+                'action' => '?',
+                'class' => 'addform',
+            ),
+            'inputs' => array(
+                array(
+                    'type' => 'text',
+                    'name' => 'demo',
+                    'placeholder' => 'demo',
+                )
+            )
+        );
+        $data['fields_toolbar'][] = $form;
     }
     // Another button always displayed
-    $data['buttons_toolbar'][] = '<li><a href="#">DEMO</a></li>';
+    $button = array(
+        'attr' => array(
+            'href' => '#',
+        ),
+        'html' => 'Demo',
+    );
+    $data['buttons_toolbar'][] = $button;
 
     return $data;
 }
@@ -143,8 +196,19 @@ function hook_demo_plugin_render_footer($data)
  */
 function hook_demo_plugin_render_linklist($data)
 {
-    // action_plugin
-    $data['action_plugin'][] = '<div class="upper_plugin_demo"><a href="?up" title="Uppercase!">←</a></div>';
+    /*
+     * Action links (action_plugin):
+     * A link is an array of its attributes (key="value"),
+     * and a mandatory `html` key, which contains its value.
+     * It's also recommended to add key 'on' or 'off' for theme rendering.
+     */
+    $action = array(
+        'attr' => array(
+            'href' => '?up',
+            'title' => 'Uppercase!',
+        ),
+        'html' => '←',
+    );
 
     if (isset($_GET['up'])) {
         // Manipulate link data
@@ -152,7 +216,11 @@ function hook_demo_plugin_render_linklist($data)
             $value['description'] = strtoupper($value['description']);
             $value['title'] = strtoupper($value['title']);
         }
+        $action['on'] = true;
+    } else {
+        $action['off'] = true;
     }
+    $data['action_plugin'][] = $action;
 
     // link_plugin (for each link)
     foreach ($data['links'] as &$value) {

--- a/plugins/playvideos/playvideos.html
+++ b/plugins/playvideos/playvideos.html
@@ -1,1 +1,0 @@
-<a href="#" id="playvideos">► Play Videos</a>

--- a/plugins/playvideos/playvideos.php
+++ b/plugins/playvideos/playvideos.php
@@ -16,7 +16,15 @@
 function hook_playvideos_render_header($data)
 {
     if ($data['_PAGE_'] == Router::$PAGE_LINKLIST) {
-        $data['buttons_toolbar'][] = file_get_contents(PluginManager::$PLUGINS_PATH . '/playvideos/playvideos.html');
+        $playvideo = array(
+            'attr' => array(
+                'href' => '#',
+                'title' => 'Video player',
+                'id' => 'playvideos',
+            ),
+            'html' => '► Play Videos'
+        );
+        $data['buttons_toolbar'][] = $playvideo;
     }
 
     return $data;

--- a/tpl/linklist.html
+++ b/tpl/linklist.html
@@ -28,7 +28,17 @@
             <input type="submit" value="Search" class="bigbutton">
         </form>
         {loop="$plugins_header.fields_toolbar"}
-            {$value}
+            <form
+                {loop="$value.attr"}
+                    {$key}="{$value}"
+                {/loop}>
+                {loop="$value.inputs"}
+                    <input
+                    {loop="$value"}
+                        {$key}="{$value}"
+                    {/loop}>
+                {/loop}
+            </form>
         {/loop}
     </div>
 </div>

--- a/tpl/linklist.paging.html
+++ b/tpl/linklist.paging.html
@@ -13,7 +13,14 @@
     </div>
 {/if}
     {loop="$action_plugin"}
-        {$value}
+      <div class="paging_privatelinks">
+        <a
+          {loop="$value.attr"}
+            {$key}="{$value}"
+          {/loop}>
+          {$value.html}
+        </a>
+      </div>
     {/loop}
     <div class="paging_linksperpage">
         Links per page: <a href="?linksperpage=20">20</a> <a href="?linksperpage=50">50</a> <a href="?linksperpage=100">100</a>

--- a/tpl/page.header.html
+++ b/tpl/page.header.html
@@ -35,7 +35,12 @@
     <li><a href="?do=picwall{$searchcrits}">Picture wall</a></li>
     <li><a href="?do=daily">Daily</a></li>
     {loop="$plugins_header.buttons_toolbar"}
-        {$value}
+        <li><a
+            {loop="$value.attr"}
+                {$key}="{$value}"
+            {/loop}>
+            {$value.html}
+        </a></li>
     {/loop}
 {/if}
   </ul>


### PR DESCRIPTION
  - buttons_toolbar: now expect links represented by an array instead of HTML content
  - fields_toolbar: now expect a form represented by an array instead of HTML content

Default templates updated accordingly

EDIT: Updated:

  - action_plugin: now expect links represented by an array instead of HTML content