### PR TITLE
.htaccess files: support Apache 2.4+ syntax

### DIFF
--- a/application/.htaccess
+++ b/application/.htaccess
@@ -1,2 +1,13 @@
-Allow from none
-Deny from all
+<IfModule version_module>
+  <IfVersion >= 2.4>
+     Require all denied
+  </IfVersion>
+  <IfVersion < 2.4>
+     Allow from none
+     Deny from all
+  </IfVersion>
+</IfModule>
+
+<IfModule !version_module>
+    Require all denied
+</IfModule>

--- a/cache/.htaccess
+++ b/cache/.htaccess
@@ -1,2 +1,13 @@
-Allow from none
-Deny from all
+<IfModule version_module>
+  <IfVersion >= 2.4>
+     Require all denied
+  </IfVersion>
+  <IfVersion < 2.4>
+     Allow from none
+     Deny from all
+  </IfVersion>
+</IfModule>
+
+<IfModule !version_module>
+    Require all denied
+</IfModule>

--- a/data/.htaccess
+++ b/data/.htaccess
@@ -1,2 +1,13 @@
-Allow from none
-Deny from all
+<IfModule version_module>
+  <IfVersion >= 2.4>
+     Require all denied
+  </IfVersion>
+  <IfVersion < 2.4>
+     Allow from none
+     Deny from all
+  </IfVersion>
+</IfModule>
+
+<IfModule !version_module>
+    Require all denied
+</IfModule>

--- a/docker/.htaccess
+++ b/docker/.htaccess
@@ -1,2 +1,13 @@
-Allow from none
-Deny from all
+<IfModule version_module>
+  <IfVersion >= 2.4>
+     Require all denied
+  </IfVersion>
+  <IfVersion < 2.4>
+     Allow from none
+     Deny from all
+  </IfVersion>
+</IfModule>
+
+<IfModule !version_module>
+    Require all denied
+</IfModule>

--- a/pagecache/.htaccess
+++ b/pagecache/.htaccess
@@ -1,2 +1,13 @@
-Allow from none
-Deny from all
+<IfModule version_module>
+  <IfVersion >= 2.4>
+     Require all denied
+  </IfVersion>
+  <IfVersion < 2.4>
+     Allow from none
+     Deny from all
+  </IfVersion>
+</IfModule>
+
+<IfModule !version_module>
+    Require all denied
+</IfModule>

--- a/tests/.htaccess
+++ b/tests/.htaccess
@@ -1,2 +1,13 @@
-Allow from none
-Deny from all
+<IfModule version_module>
+  <IfVersion >= 2.4>
+     Require all denied
+  </IfVersion>
+  <IfVersion < 2.4>
+     Allow from none
+     Deny from all
+  </IfVersion>
+</IfModule>
+
+<IfModule !version_module>
+    Require all denied
+</IfModule>

--- a/tmp/.htaccess
+++ b/tmp/.htaccess
@@ -1,2 +1,13 @@
-Allow from none
-Deny from all
+<IfModule version_module>
+  <IfVersion >= 2.4>
+     Require all denied
+  </IfVersion>
+  <IfVersion < 2.4>
+     Allow from none
+     Deny from all
+  </IfVersion>
+</IfModule>
+
+<IfModule !version_module>
+    Require all denied
+</IfModule>


### PR DESCRIPTION
If `mod_version` is enabled, the previous syntax will apply for Apache <2.4.
If not, the new syntax is used by default.

Fixes #676 

~~TODO: mention this in the server documentation.~~

[Wiki updated](https://github.com/shaarli/Shaarli/wiki/Server-configuration#htaccess)