### PR TITLE
Bugfixes on link deletion, and use a GET form

### DIFF
--- a/application/Router.php
+++ b/application/Router.php
@@ -31,6 +31,8 @@ class Router
 
     public static $PAGE_EDITLINK = 'edit_link';
 
+    public static $PAGE_DELETELINK = 'delete_link';
+
     public static $PAGE_EXPORT = 'export';
 
     public static $PAGE_IMPORT = 'import';
@@ -118,6 +120,10 @@ class Router
 
         if (isset($get['edit_link']) || isset($get['post'])) {
             return self::$PAGE_EDITLINK;
+        }
+
+        if (isset($get['delete_link'])) {
+            return self::$PAGE_DELETELINK;
         }
 
         if (startsWith($query, 'do='. self::$PAGE_EXPORT)) {

--- a/index.php
+++ b/index.php
@@ -1325,21 +1325,21 @@ function renderPage($conf, $pluginManager)
     }
 
     // -------- User clicked the "Delete" button when editing a link: Delete link from database.
-    if (isset($_POST['delete_link']))
+    if ($targetPage == Router::$PAGE_DELETELINK)
     {
-        if (!tokenOk($_POST['token'])) die('Wrong token.');
-
         // We do not need to ask for confirmation:
         // - confirmation is handled by JavaScript
         // - we are protected from XSRF by the token.
 
-        // FIXME! We keep `lf_linkdate` for consistency before a proper API. To be removed.
-        $id = isset($_POST['lf_id']) ? intval(escape($_POST['lf_id'])) : intval(escape($_POST['lf_linkdate']));
+        if (! tokenOk($_GET['token'])) {
+            die('Wrong token.');
+        }
 
-        $pluginManager->executeHooks('delete_link', $LINKSDB[$id]);
-
+        $id = intval(escape($_GET['lf_linkdate']));
+        $link = $LINKSDB[$id];
+        $pluginManager->executeHooks('delete_link', $link);
         unset($LINKSDB[$id]);
-        $LINKSDB->save('resource.page_cache'); // save to disk
+        $LINKSDB->save($conf->get('resource.page_cache')); // save to disk
 
         // If we are called from the bookmarklet, we must close the popup:
         if (isset($_GET['source']) && ($_GET['source']=='bookmarklet' || $_GET['source']=='firefoxsocialapi')) { echo '<script>self.close();</script>'; exit; }

--- a/tpl/linklist.html
+++ b/tpl/linklist.html
@@ -84,7 +84,7 @@
                             <input type="hidden" name="edit_link" value="{$value.id}">
                             <input type="image" alt="Edit" src="images/edit_icon.png#" title="Edit" class="button_edit">
                         </form><br>
-                        <form method="POST" class="buttoneditform">
+                        <form method="GET" class="buttoneditform">
                             <input type="hidden" name="lf_linkdate" value="{$value.id}">
                             <input type="hidden" name="token" value="{$token}">
                             <input type="hidden" name="delete_link">


### PR DESCRIPTION
Use a GET form to delete links: harmonize with edit_link and preparation for #585

Bug fixes:

  * LinkDB element can't be passed as reference, fix warning:

> PHP Notice:  Indirect modification of overloaded element of LinkDB has no effect

  * Resource cache folder setting wasn't set correctly

Fixes #718 