### PR TITLE
Docker: fix & improve nginx+php-fpm configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
     - archives contain a `Shaarli` directory, itself containing sources + dependencies
     - the tarball is now gzipped
 - Minor code cleanup: PHPDoc, spelling, unused variables, etc.
+- Docker: explicitly set the maximum file upload size to 10 MiB
 
 ### Fixed
 - Fix the server `<self>` value in Atom/RSS feeds
@@ -27,6 +28,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
     - Tools: only display parameter description when it exists
     - archive.org: do not propose archival of private notes
 - Use absolute URL for hashtags in RSS and ATOM feeds
+- Docker: specify the location of the favicon
 
 ### Security
 - Allow whitelisting trusted IPs, else continue banning clients upon login failure

--- a/docker/development/Dockerfile
+++ b/docker/development/Dockerfile
@@ -15,6 +15,8 @@ RUN apt-get update \
        nano \
     && apt-get clean
 
+RUN sed -i 's/post_max_size.*/post_max_size = 10M/' /etc/php5/fpm/php.ini
+RUN sed -i 's/upload_max_filesize.*/upload_max_filesize = 10M/' /etc/php5/fpm/php.ini
 COPY nginx.conf /etc/nginx/nginx.conf
 COPY supervised.conf /etc/supervisor/conf.d/supervised.conf
 

--- a/docker/development/nginx.conf
+++ b/docker/development/nginx.conf
@@ -11,6 +11,8 @@ http {
     default_type       application/octet-stream;
     keepalive_timeout  20;
 
+    client_max_body_size 10m;
+
     index index.html index.php;
 
     server {

--- a/docker/development/nginx.conf
+++ b/docker/development/nginx.conf
@@ -49,6 +49,11 @@ http {
             add_header Cache-Control "public, must-revalidate, proxy-revalidate";
         }
 
+        location = /favicon.ico {
+            # serve the Shaarli favicon from its custom location
+            alias /var/www/shaarli/images/favicon.ico;
+        }
+
         location ~ (index)\.php$ {
             # filter and proxy PHP requests to PHP-FPM
             fastcgi_pass   unix:/var/run/php5-fpm.sock;

--- a/docker/production/Dockerfile
+++ b/docker/production/Dockerfile
@@ -14,6 +14,8 @@ RUN apt-get update \
        supervisor \
     && apt-get clean
 
+RUN sed -i 's/post_max_size.*/post_max_size = 10M/' /etc/php5/fpm/php.ini
+RUN sed -i 's/upload_max_filesize.*/upload_max_filesize = 10M/' /etc/php5/fpm/php.ini
 COPY nginx.conf /etc/nginx/nginx.conf
 COPY supervised.conf /etc/supervisor/conf.d/supervised.conf
 

--- a/docker/production/nginx.conf
+++ b/docker/production/nginx.conf
@@ -11,6 +11,8 @@ http {
     default_type       application/octet-stream;
     keepalive_timeout  20;
 
+    client_max_body_size 10m;
+
     index index.html index.php;
 
     server {

--- a/docker/production/nginx.conf
+++ b/docker/production/nginx.conf
@@ -41,6 +41,11 @@ http {
             add_header Cache-Control "public, must-revalidate, proxy-revalidate";
         }
 
+        location = /favicon.ico {
+            # serve the Shaarli favicon from its custom location
+            alias /var/www/shaarli/images/favicon.ico;
+        }
+
         location ~ (index)\.php$ {
             # filter and proxy PHP requests to PHP-FPM
             fastcgi_pass   unix:/var/run/php5-fpm.sock;

--- a/docker/production/stable/Dockerfile
+++ b/docker/production/stable/Dockerfile
@@ -14,6 +14,8 @@ RUN apt-get update \
        supervisor \
     && apt-get clean
 
+RUN sed -i 's/post_max_size.*/post_max_size = 10M/' /etc/php5/fpm/php.ini
+RUN sed -i 's/upload_max_filesize.*/upload_max_filesize = 10M/' /etc/php5/fpm/php.ini
 COPY nginx.conf /etc/nginx/nginx.conf
 COPY supervised.conf /etc/supervisor/conf.d/supervised.conf
 

--- a/docker/production/stable/nginx.conf
+++ b/docker/production/stable/nginx.conf
@@ -11,6 +11,8 @@ http {
     default_type       application/octet-stream;
     keepalive_timeout  20;
 
+    client_max_body_size 10m;
+
     index index.html index.php;
 
     server {

--- a/docker/production/stable/nginx.conf
+++ b/docker/production/stable/nginx.conf
@@ -41,6 +41,11 @@ http {
             add_header Cache-Control "public, must-revalidate, proxy-revalidate";
         }
 
+        location = /favicon.ico {
+            # serve the Shaarli favicon from its custom location
+            alias /var/www/shaarli/images/favicon.ico;
+        }
+
         location ~ (index)\.php$ {
             # filter and proxy PHP requests to PHP-FPM
             fastcgi_pass   unix:/var/run/php5-fpm.sock;


### PR DESCRIPTION
Relates to #681

Changed:
- nginx+php-fpm: set maximum upload size to 10 MiB

Fixed:
- nginx: set the favicon location

See:
- https://nginx.org/en/docs/http/ngx_http_core_module.html#client_max_body_size
- https://secure.php.net/manual/en/ini.core.php#ini.post-max-size
- https://secure.php.net/manual/en/ini.core.php#ini.upload-max-filesize
- http://serverfault.com/a/352861