### PR TITLE
Make use of rel="noreferrer" on external links

### DIFF
--- a/tpl/daily.html
+++ b/tpl/daily.html
@@ -66,7 +66,7 @@
                             </div>
                         {/if}
                         <div class="dailyEntryTitle">
-                            <a href="{$link.real_url}">{$link.title}</a>
+                            <a href="{$link.real_url}" rel="noreferrer">{$link.title}</a>
                         </div>
                         {if="$link.thumbnail"}
                             <div class="dailyEntryThumbnail">{$link.thumbnail}</div>

--- a/tpl/linklist.html
+++ b/tpl/linklist.html
@@ -84,7 +84,7 @@
                     </div>
                 {/if}
                 <span class="linktitle">
-                    <a href="{$value.real_url}">{$value.title}</a>
+                    <a href="{$value.real_url}" rel="noreferrer">{$value.title}</a>
                 </span>
                 <br>
                 {if="$value.description"}<div class="linkdescription">{$value.description}</div>{/if}
@@ -107,7 +107,7 @@
                     <span>{$value}</span> -
                 {/loop}
 
-                <a href="{$value.real_url}"><span class="linkurl" title="Short link">{$value.url}</span></a><br>
+                <a href="{$value.real_url}" rel="noreferrer"><span class="linkurl" title="Short link">{$value.url}</span></a><br>
                 {if="$value.tags"}
                     <div class="linktaglist">
                     {loop="$value.taglist"}<span class="linktag" title="Add tag"><a href="?addtag={$value|urlencode}">{$value}</a></span> {/loop}

--- a/tpl/picwall.html
+++ b/tpl/picwall.html
@@ -16,7 +16,7 @@
         <div id="picwall_container">
             {loop="$linksToDisplay"}
             <div class="picwall_pictureframe">
-        	    {$value.thumbnail}<a href="{$value.real_url}"><span class="info">{$value.title}</span></a>
+        	    {$value.thumbnail}<a href="{$value.real_url}" rel="noreferrer"><span class="info">{$value.title}</span></a>
                 {loop="$value.picwall_plugin"}
                     {$value}
                 {/loop}


### PR DESCRIPTION
This PR is for using (if available) the HTML feature of telling the browser not to send the *referrer* on the bookmarked links.
This, on browser that supports it, would defeat the purpose of using a redirector / referrer cleaner.

Issue: #685