### PR TITLE
Markdown: fixes feed rendering with nomarkdown tag

### DIFF
--- a/plugins/markdown/README.md
+++ b/plugins/markdown/README.md
@@ -20,26 +20,35 @@ The directory structure should look like:
      |--- markdown.css
      |--- markdown.meta
      |--- markdown.php
-     |--- Parsedown.php
      |--- README.md
 ```
 
 To enable the plugin, just check it in the plugin administration page.
 
-You can also add `markdown` to your list of enabled plugins in `data/config.php`
-(`ENABLED_PLUGINS` array).
+You can also add `markdown` to your list of enabled plugins in `data/config.json.php`
+(`general.enabled_plugins` list).
 
 This should look like:
 
 ```
-$GLOBALS['config']['ENABLED_PLUGINS'] = array('qrcode', 'any_other_plugin', 'markdown')
+"general": {
+  "enabled_plugins": [
+    "markdown",
+    [...]
+  ],
+}
 ```
+
+Parsedown parsing library is imported using Composer. If you installed Shaarli using `git`,
+or the `master` branch, run
+
+    composer update --no-dev --prefer-dist
 
 ### No Markdown tag
 
-If the tag `.nomarkdown` is set for a shaare, it won't be converted to Markdown syntax.
+If the tag `nomarkdown` is set for a shaare, it won't be converted to Markdown syntax.
  
-> Note: it's a private tag (leading dot), so it won't be displayed to visitors.
+> Note: this is a special tag, so it won't be displayed in link list.
 
 ### Known issue
 

--- a/plugins/markdown/markdown.php
+++ b/plugins/markdown/markdown.php
@@ -22,7 +22,7 @@ function hook_markdown_render_linklist($data)
 {
     foreach ($data['links'] as &$value) {
         if (!empty($value['tags']) && noMarkdownTag($value['tags'])) {
-            $value['taglist'] = stripNoMarkdownTag($value['taglist']);
+            $value = stripNoMarkdownTag($value);
             continue;
         }
         $value['description'] = process_markdown($value['description']);
@@ -41,7 +41,7 @@ function hook_markdown_render_feed($data)
 {
     foreach ($data['links'] as &$value) {
         if (!empty($value['tags']) && noMarkdownTag($value['tags'])) {
-            $value['tags'] = stripNoMarkdownTag($value['tags']);
+            $value = stripNoMarkdownTag($value);
             continue;
         }
         $value['description'] = process_markdown($value['description']);
@@ -63,6 +63,7 @@ function hook_markdown_render_daily($data)
     foreach ($data['cols'] as &$value) {
         foreach ($value as &$value2) {
             if (!empty($value2['tags']) && noMarkdownTag($value2['tags'])) {
+                $value2 = stripNoMarkdownTag($value2);
                 continue;
             }
             $value2['formatedDescription'] = process_markdown($value2['formatedDescription']);
@@ -81,20 +82,30 @@ function hook_markdown_render_daily($data)
  */
 function noMarkdownTag($tags)
 {
-    return strpos($tags, NO_MD_TAG) !== false;
+    return preg_match('/(^|\s)'. NO_MD_TAG .'(\s|$)/', $tags);
 }
 
 /**
  * Remove the no-markdown meta tag so it won't be displayed.
  *
- * @param string $tags Tag list.
+ * @param array $link Link data.
  *
- * @return string tag list without no markdown tag.
+ * @return array Updated link without no markdown tag.
  */
-function stripNoMarkdownTag($tags)
+function stripNoMarkdownTag($link)
 {
-    unset($tags[array_search(NO_MD_TAG, $tags)]);
-    return array_values($tags);
+    if (! empty($link['taglist'])) {
+        $offset = array_search(NO_MD_TAG, $link['taglist']);
+        if ($offset !== false) {
+            unset($link['taglist'][$offset]);
+        }
+    }
+
+    if (!empty($link['tags'])) {
+        str_replace(NO_MD_TAG, '', $link['tags']);
+    }
+
+    return $link;
 }
 
 /**

--- a/tests/plugins/PluginMarkdownTest.php
+++ b/tests/plugins/PluginMarkdownTest.php
@@ -8,8 +8,8 @@ require_once 'application/Utils.php';
 require_once 'plugins/markdown/markdown.php';
 
 /**
- * Class PlugQrcodeTest
- * Unit test for the QR-Code plugin
+ * Class PluginMarkdownTest
+ * Unit test for the Markdown plugin
  */
 class PluginMarkdownTest extends PHPUnit_Framework_TestCase
 {
@@ -130,8 +130,11 @@ class PluginMarkdownTest extends PHPUnit_Framework_TestCase
             ))
         );
 
-        $data = hook_markdown_render_linklist($data);
-        $this->assertEquals($str, $data['links'][0]['description']);
+        $processed = hook_markdown_render_linklist($data);
+        $this->assertEquals($str, $processed['links'][0]['description']);
+
+        $processed = hook_markdown_render_feed($data);
+        $this->assertEquals($str, $processed['links'][0]['description']);
 
         $data = array(
             // Columns data
@@ -150,6 +153,24 @@ class PluginMarkdownTest extends PHPUnit_Framework_TestCase
 
         $data = hook_markdown_render_daily($data);
         $this->assertEquals($str, $data['cols'][0][0]['formatedDescription']);
+    }
+
+    /**
+     * Test that a close value to nomarkdown is not understand as nomarkdown (previous value `.nomarkdown`).
+     */
+    function testNoMarkdownNotExcactlyMatching()
+    {
+        $str = 'All _work_ and `no play` makes Jack a *dull* boy.';
+        $data = array(
+            'links' => array(array(
+                'description' => $str,
+                'tags' => '.' . NO_MD_TAG,
+                'taglist' => array('.'. NO_MD_TAG),
+            ))
+        );
+
+        $data = hook_markdown_render_feed($data);
+        $this->assertContains('<em>', $data['links'][0]['description']);
     }
 
     /**


### PR DESCRIPTION
 * pass taglist as an array for `stripNoMarkdownTag`
 * make sure we match exactly `nomarkdown` tag

Fixes #689