### PR TITLE
Remove new line between content tag and CDATA in ATOM feed

### DIFF
--- a/tpl/feed.atom.html
+++ b/tpl/feed.atom.html
@@ -30,9 +30,7 @@
         <published>{$value.pub_iso_date}</published>
         <updated>{$value.up_iso_date}</updated>
       {/if}
-      <content type="html" xml:lang="{$language}">
-        <![CDATA[{$value.description}]]>
-      </content>
+      <content type="html" xml:lang="{$language}"><![CDATA[{$value.description}]]></content>
       {loop="$value.taglist"}
         <category scheme="{$index_url}?searchtags=" term="{$value|strtolower}" label="{$value}" />
       {/loop}


### PR DESCRIPTION
Content not starting directly with CDATA can be misinterpreted by some feed parsers.