### PR TITLE
Fixes presence of empty tags for private tags and in search results

### DIFF
--- a/application/LinkFilter.php
+++ b/application/LinkFilter.php
@@ -348,7 +348,7 @@ class LinkFilter
         $tagsOut = $casesensitive ? $tags : mb_convert_case($tags, MB_CASE_LOWER, 'UTF-8');
         $tagsOut = str_replace(',', ' ', $tagsOut);
 
-        return array_values(array_filter(explode(' ', trim($tagsOut)), 'strlen'));
+        return preg_split('/\s+/', $tagsOut, -1, PREG_SPLIT_NO_EMPTY);
     }
 }
 

--- a/application/Utils.php
+++ b/application/Utils.php
@@ -257,3 +257,16 @@ function generate_api_secret($username, $salt)
 
     return str_shuffle(substr(hash_hmac('sha512', uniqid($salt), $username), 10, 12));
 }
+
+/**
+ * Trim string, replace sequences of whitespaces by a single space.
+ * PHP equivalent to `normalize-space` XSLT function.
+ *
+ * @param string $string Input string.
+ *
+ * @return mixed Normalized string.
+ */
+function normalize_spaces($string)
+{
+    return preg_replace('/\s{2,}/', ' ', trim($string));
+}

--- a/index.php
+++ b/index.php
@@ -1601,8 +1601,8 @@ function renderPage($conf, $pluginManager, $LINKSDB)
 function buildLinkList($PAGE,$LINKSDB, $conf, $pluginManager)
 {
     // Used in templates
-    $searchtags = !empty($_GET['searchtags']) ? escape($_GET['searchtags']) : '';
-    $searchterm = !empty($_GET['searchterm']) ? escape($_GET['searchterm']) : '';
+    $searchtags = !empty($_GET['searchtags']) ? escape(normalize_spaces($_GET['searchtags'])) : '';
+    $searchterm = !empty($_GET['searchterm']) ? escape(normalize_spaces($_GET['searchterm'])) : '';
 
     // Smallhash filter
     if (! empty($_SERVER['QUERY_STRING'])
@@ -1649,7 +1649,7 @@ function buildLinkList($PAGE,$LINKSDB, $conf, $pluginManager)
         } else {
             $link['updated_timestamp'] = '';
         }
-        $taglist = explode(' ', $link['tags']);
+        $taglist = preg_split('/\s+/', $link['tags'], -1, PREG_SPLIT_NO_EMPTY);
         uasort($taglist, 'strcasecmp');
         $link['taglist'] = $taglist;
         // Check for both signs of a note: starting with ? and 7 chars long.

--- a/tests/UtilsTest.php
+++ b/tests/UtilsTest.php
@@ -253,7 +253,7 @@ class UtilsTest extends PHPUnit_Framework_TestCase
             is_session_id_valid('c0ZqcWF3VFE2NmJBdm1HMVQ0ZHJ3UmZPbTFsNGhkNHI=')
         );
     }
-
+    
     /**
      * Test generateSecretApi.
      */
@@ -269,5 +269,17 @@ class UtilsTest extends PHPUnit_Framework_TestCase
     {
         $this->assertFalse(generate_api_secret('', ''));
         $this->assertFalse(generate_api_secret(false, false));
+    }
+
+    /**
+     * Test normalize_spaces.
+     */
+    public function testNormalizeSpace()
+    {
+        $str = ' foo   bar is   important ';
+        $this->assertEquals('foo bar is important', normalize_spaces($str));
+        $this->assertEquals('foo', normalize_spaces('foo'));
+        $this->assertEquals('', normalize_spaces(''));
+        $this->assertEquals(null, normalize_spaces(null));
     }
 }


### PR DESCRIPTION
  * Private tags: make sure empty tags are properly filtered
  * Search results:
    * Use preg_split instead of function combination
    * Add normalize_spaces to remove extra whitespaces displaying empty tags search

Fixes #722 