### PR TITLE
API: fix Slim namespaces

### DIFF
--- a/index.php
+++ b/index.php
@@ -2231,8 +2231,8 @@ $app = new \Slim\App($container);
 
 // REST API routes
 $app->group('/api/v1', function() {
-    $this->get('/info', '\Api\Controllers\Info:getInfo');
-})->add('\Api\ApiMiddleware');
+    $this->get('/info', '\Shaarli\Api\Controllers\Info:getInfo');
+})->add('\Shaarli\Api\ApiMiddleware');
 
 $response = $app->run(true);
 // Hack to make Slim and Shaarli router work together:


### PR DESCRIPTION
Hi!

I've started toying a bit with the API to prepare the nginx configuration and have stumbled upon a few quirks:
- Slim namespaces (addressed in this PR)
- side-effects of using 2 routers + URL rewriting: accessing non-existent resources leads to unexpected results (e.g. try accessing `http://my.supah.shaarley.io/titi/toto/tutu/tatapouf`)
- (non-standard?) expected JWT header / format:
    - current: `jwt: <my jwt token>`
    - [documented](https://jwt.io/introduction/#how-do-json-web-tokens-work-): `Authorization: Bearer <my jwt token>`

I've used the following script (derived from #666) to run checks:
```php
<?php

function generateJwtToken($secret)
{
    $header = base64_encode('{
            "typ": "JWT",
            "alg": "HS512"
        }');
    $payload = base64_encode('{
            "iat": '. time() .'
        }');
    $signature = hash_hmac('sha512', $header .'.'. $payload , $secret);
    return $header .'.'. $payload .'.'. $signature;
}

function get($uri, $token)
{
    $ch = curl_init($uri);
    curl_setopt_array($ch, array(
        CURLOPT_HTTPHEADER => array('jwt: '.$token),
        CURLOPT_RETURNTRANSFER =>true,
        CURLOPT_VERBOSE => 1
    ));
    $response = curl_exec($ch);
    curl_close($ch);
    return $response;
}

$uri = 'http://localhost/~virtualtam/shaarli/api/v1/info';
$secret = '70u7p0urr1';

$token = generateJwtToken($secret);
echo $token;
echo get($uri, $token);
```