### PR TITLE
Add an AUTHORS file, simplify COPYING, bump year to 2017

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -19,6 +19,7 @@ Dockerfile      text
 
 # Exclude from Git archives
 .gitattributes  export-ignore
+.github         export-ignore
 .gitignore      export-ignore
 .travis.yml     export-ignore
 doc/**/*.json   export-ignore

--- a/.github/mailmap
+++ b/.github/mailmap
@@ -1,0 +1,13 @@
+ArthurHoaro <arthur@hoa.ro>
+Florian Eula <eula.florian@gmail.com> feula
+Florian Eula <eula.florian@gmail.com> <mr.pikzen@gmail.com>
+Nicolas Danelon <hi@nicolasmd.com.ar> nicolasm
+Nicolas Danelon <hi@nicolasmd.com.ar> <nda@3818.com.ar>
+Nicolas Danelon <hi@nicolasmd.com.ar> <nicolasdanelon@gmail.com>
+Nicolas Danelon <hi@nicolasmd.com.ar> <nicolasdanelon@users.noreply.github.com>
+Sébastien Sauvage <sebsauvage@sebsauvage.net>
+Timo Van Neerden <fire@lehollandaisvolant.net>
+Timo Van Neerden <fire@lehollandaisvolant.net> lehollandaisvolant <levoltigeurhollandais@gmail.com>
+VirtualTam <virtualtam@flibidi.net> <tamisier.aurelien@gmail.com>
+VirtualTam <virtualtam@flibidi.net> <virtualtam+github@flibidi.net>
+VirtualTam <virtualtam@flibidi.net> <virtualtam@flibidi.org>

--- a/AUTHORS
+++ b/AUTHORS
@@ -1,0 +1,40 @@
+   327	ArthurHoaro <arthur@hoa.ro>
+   188	VirtualTam <virtualtam@flibidi.net>
+   132	nodiscc <nodiscc@gmail.com>
+    56	Sébastien Sauvage <sebsauvage@sebsauvage.net>
+    15	Florian Eula <eula.florian@gmail.com>
+    13	Emilien Klein <emilien@klein.st>
+    12	Nicolas Danelon <hi@nicolasmd.com.ar>
+     7	Christophe HENRY <christophe.henry@sbgodin.fr>
+     4	Alexandre Alapetite <alexandre@alapetite.fr>
+     4	David Sferruzza <david.sferruzza@gmail.com>
+     3	Teromene <teromene@teromene.fr>
+     2	Chris Kuethe <chris.kuethe@gmail.com>
+     2	Knah Tsaeb <Knah-Tsaeb@knah-tsaeb.org>
+     2	Mathieu Chabanon <git@matchab.fr>
+     2	Miloš Jovanović <mjovanovic@gmail.com>
+     2	Qwerty <champlywood@free.fr>
+     2	Timo Van Neerden <fire@lehollandaisvolant.net>
+     2	julienCXX <software@chmodplusx.eu>
+     2	kalvn <kalvnthereal@gmail.com>
+     1	Adrien Oliva <adrien.oliva@yapbreak.fr>
+     1	Alexis J <alexis@effingo.be>
+     1	BoboTiG <bobotig@gmail.com>
+     1	Bronco <bronco@warriordudimanche.net>
+     1	D Low <daniellowtw@gmail.com>
+     1	Dimtion <zizou.xena@gmail.com>
+     1	Fanch <fanch-github@qth.fr>
+     1	Felix Bartels <felix@host-consultants.de>
+     1	Felix Kästner <github.com-fpunktk@fpunktk.de>
+     1	Florian Voigt <flvoigt@me.com>
+     1	Gary Marigliano <gmarigliano93@gmail.com>
+     1	Guillaume Virlet <github@virlet.org>
+     1	Jonathan Druart <jonathan.druart@gmail.com>
+     1	Julien Pivotto <roidelapluie@inuits.eu>
+     1	Kevin Canévet <kevin@streamroot.io>
+     1	Knah Tsaeb <knah-tsaeb@knah-tsaeb.org>
+     1	Lionel Martin <renarddesmers@gmail.com>
+     1	Marsup <marsup@gmail.com>
+     1	Sbgodin <Sbgodin@users.noreply.github.com>
+     1	TsT <tst2005@gmail.com>
+     1	dimtion <zizou.xena@gmail.com>

--- a/COPYING
+++ b/COPYING
@@ -1,33 +1,7 @@
 Files: *
 License: zlib/libpng
 Copyright: (c) 2011-2015 Sébastien SAUVAGE <sebsauvage@sebsauvage.net>
-           (c) 2011-2015 Alexandre Alapetite <alexandre@alapetite.fr>
-           (c) 2011-2015 David Sferruzza <david.sferruzza@gmail.com>
-           (c) 2011-2015 Christophe HENRY <christophe.henry@sbgodin.fr>
-           (c) 2011-2015 Mathieu Chabanon <git@matchab.fr>
-           (c) 2011-2015 BoboTiG <bobotig@gmail.com>
-           (c) 2011-2015 Bronco <bronco@warriordudimanche.net>
-           (c) 2011-2015 Emilien Klein <emilien@klein.st>
-           (c) 2011-2015 Knah Tsaeb <knah-tsaeb@knah-tsaeb.org>
-           (c) 2011-2015 Lionel Martin <renarddesmers@gmail.com>
-           (c) 2011-2015 lehollandaisvolant <levoltigeurhollandais@gmail.com>
-           (c) 2011-2015 timo van neerden <fire@lehollandaisvolant.net>
-           (c) 2011-2015 nodiscc <nodiscc@gmail.com>
-           (c) 2011-2015 Florian Eula <mr.pikzen@gmail.com>
-           (c) 2011-2015 Arthur Hoaro <arthur@hoa.ro>
-           (c) 2011-2015 Aurélien "VirtualTam" Tamisier <virtualtam@flibidi.net>
-           (c) 2011-2015 qwertygc <champlywood@free.fr>
-           (c) 2011-2015 idleman <idleman@idleman.fr>
-           (c) 2015 Alexis Ju <alexis@effingo.be>
-           (c) 2015 dimtion <zizou.xena@gmail.com>
-           (c) 2015 Fanch <fanch-github@qth.fr>
-           (c) 2015 Guillaume Virlet <github@virlet.org>
-           (c) 2015 Felix Bartels <felix@host-consultants.de>
-           (c) 2015 Marsup <marsup@gmail.com>
-           (c) 2015 Miloš Jovanović <mjovanovic@gmail.com>
-           (c) 2015 Nicolás Danelón <hola@nicolasdanelon.com.ar>
-           (c) 2015 TsT <tst2005@gmail.com>
-
+           (c) 2011-2017 The Shaarli Community, see AUTHORS
 
 Files: inc/reset.css
 License: BSD (http://opensource.org/licenses/BSD-3-Clause)

--- a/Makefile
+++ b/Makefile
@@ -169,6 +169,12 @@ clean:
 	@git clean -df
 	@rm -rf sandbox
 
+### generate the AUTHORS file from Git commit information
+authors:
+	@cp .github/mailmap .mailmap
+	@git shortlog -sne > AUTHORS
+	@rm .mailmap
+
 ### generate Doxygen documentation
 doxygen: clean
 	@rm -rf doxygen
@@ -214,4 +220,4 @@ htmlpages:
 			-o doc/$$base.html $$file; \
 	done;
 
-htmldoc: doc htmlsidebar htmlpages
+htmldoc: authors doc htmlsidebar htmlpages


### PR DESCRIPTION
Added:
- AUTHORS file listing Shaarli contributors
- Makefile target to list contributors from Git commit data

Changed:
- Simplify COPYING by using a single "Shaarli Community" entry
- Bump year to 2017
