### PR TITLE
Improve datetime display

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,4 +20,4 @@ install:
 script:
   - make clean
   - make check_permissions
-  - make test
+  - make all_tests

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,11 @@
 sudo: false
 language: php
+addons:
+  apt:
+    packages:
+      - locales
+      - language-pack-de
+      - language-pack-fr
 cache:
   directories:
     - $HOME/.composer/cache

--- a/Makefile
+++ b/Makefile
@@ -124,8 +124,20 @@ test:
 	@echo "-------"
 	@echo "PHPUNIT"
 	@echo "-------"
-	@mkdir -p sandbox
-	@$(BIN)/phpunit tests
+	@mkdir -p sandbox coverage
+	@$(BIN)/phpunit --coverage-php coverage/main.cov --testsuite unit-tests
+
+locale_test_%:
+	@UT_LOCALE=$*.utf8 \
+		$(BIN)/phpunit \
+		--coverage-php coverage/$(firstword $(subst _, ,$*)).cov \
+		--bootstrap tests/languages/bootstrap.php \
+		--testsuite language-$(firstword $(subst _, ,$*))
+
+all_tests: test locale_test_de_DE locale_test_en_US locale_test_fr_FR
+	@$(BIN)/phpcov merge --html coverage coverage
+	@# --text doesn't work with phpunit 4.* (v5 requires PHP 5.6)
+	@#$(BIN)/phpcov merge --text coverage/txt coverage
 
 ##
 # Custom release archive generation

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,8 @@
         "phpmd/phpmd" : "@stable",
         "phpunit/phpunit": "4.8.*",
         "sebastian/phpcpd": "*",
-        "squizlabs/php_codesniffer": "2.*"
+        "squizlabs/php_codesniffer": "2.*",
+        "phpunit/phpcov": "*"
     },
     "autoload": {
         "psr-4": {

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -3,13 +3,25 @@
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:noNamespaceSchemaLocation="http://schema.phpunit.de/4.5/phpunit.xsd"
     colors="true">
+  <testsuites>
+    <testsuite name="unit-tests">
+      <directory>tests</directory>
+      <exclude>tests/languages</exclude>
+    </testsuite>
+    <testsuite name="language-de">
+      <directory>tests/languages/de</directory>
+    </testsuite>
+    <testsuite name="language-en">
+      <directory>tests/languages/en</directory>
+    </testsuite>
+    <testsuite name="language-fr">
+      <directory>tests/languages/fr</directory>
+    </testsuite>
+  </testsuites>
+
   <filter>
     <whitelist addUncoveredFilesFromWhitelist="true">
       <directory suffix=".php">application</directory>
     </whitelist>
   </filter>
-  <logging>
-    <log type="coverage-html" target="coverage" lowUpperBound="30" highLowerBound="80"/>
-    <log type="coverage-text" target="php://stdout" showUncoveredFiles="true"/>
-  </logging>
 </phpunit>

--- a/tests/UtilsTest.php
+++ b/tests/UtilsTest.php
@@ -282,4 +282,24 @@ class UtilsTest extends PHPUnit_Framework_TestCase
         $this->assertEquals('', normalize_spaces(''));
         $this->assertEquals(null, normalize_spaces(null));
     }
+
+    /**
+     * Test arrays_combine
+     */
+    public function testArraysCombination()
+    {
+        $arr = [['ab', 'cd'], ['ef', 'gh'], ['ij', 'kl'], ['m']];
+        $expected = [
+            'abefijm',
+            'cdefijm',
+            'abghijm',
+            'cdghijm',
+            'abefklm',
+            'cdefklm',
+            'abghklm',
+            'cdghklm',
+        ];
+        $this->assertEquals($expected, arrays_combination($arr));
+    }
+
 }

--- a/tests/UtilsTest.php
+++ b/tests/UtilsTest.php
@@ -23,7 +23,12 @@ class UtilsTest extends PHPUnit_Framework_TestCase
 
     // Expected log date format
     protected static $dateFormat = 'Y/m/d H:i:s';
-    
+
+    /**
+     * @var string Save the current timezone.
+     */
+    protected static $defaultTimeZone;
+
 
     /**
      * Assign reference data
@@ -31,6 +36,17 @@ class UtilsTest extends PHPUnit_Framework_TestCase
     public static function setUpBeforeClass()
     {
         self::$sidHashes = ReferenceSessionIdHashes::getHashes();
+        self::$defaultTimeZone = date_default_timezone_get();
+        // Timezone without DST for test consistency
+        date_default_timezone_set('Africa/Nairobi');
+    }
+
+    /**
+     * Reset the timezone
+     */
+    public static function tearDownAfterClass()
+    {
+        date_default_timezone_set(self::$defaultTimeZone);
     }
 
     /**
@@ -286,20 +302,28 @@ class UtilsTest extends PHPUnit_Framework_TestCase
     /**
      * Test arrays_combine
      */
-    public function testArraysCombination()
+    public function testCartesianProductGenerator()
     {
         $arr = [['ab', 'cd'], ['ef', 'gh'], ['ij', 'kl'], ['m']];
         $expected = [
-            'abefijm',
-            'cdefijm',
-            'abghijm',
-            'cdghijm',
-            'abefklm',
-            'cdefklm',
-            'abghklm',
-            'cdghklm',
+            ['ab', 'ef', 'ij', 'm'],
+            ['ab', 'ef', 'kl', 'm'],
+            ['ab', 'gh', 'ij', 'm'],
+            ['ab', 'gh', 'kl', 'm'],
+            ['cd', 'ef', 'ij', 'm'],
+            ['cd', 'ef', 'kl', 'm'],
+            ['cd', 'gh', 'ij', 'm'],
+            ['cd', 'gh', 'kl', 'm'],
         ];
-        $this->assertEquals($expected, arrays_combination($arr));
+        $this->assertEquals($expected, iterator_to_array(cartesian_product_generator($arr)));
     }
 
+    /**
+     * Test date_format() with invalid parameter.
+     */
+    public function testDateFormatInvalid()
+    {
+        $this->assertFalse(format_date([]));
+        $this->assertFalse(format_date(null));
+    }
 }

--- a/tests/languages/bootstrap.php
+++ b/tests/languages/bootstrap.php
@@ -1,0 +1,7 @@
+<?php
+if (! empty('UT_LOCALE')) {
+    setlocale(LC_ALL, getenv('UT_LOCALE'));
+}
+
+require_once 'vendor/autoload.php';
+

--- a/tests/languages/de/UtilsDeTest.php
+++ b/tests/languages/de/UtilsDeTest.php
@@ -1,0 +1,25 @@
+<?php
+
+require_once 'tests/UtilsTest.php';
+
+
+class UtilsDeTest extends UtilsTest
+{
+    /**
+     * Test date_format().
+     */
+    public function testDateFormat()
+    {
+        $date = DateTime::createFromFormat('Ymd_His', '20170101_101112');
+        $this->assertRegExp('/1. Januar 2017 (um )?10:11:12 GMT\+0?3(:00)?/', format_date($date, true));
+    }
+
+    /**
+     * Test date_format() using builtin PHP function strftime.
+     */
+    public function testDateFormatDefault()
+    {
+        $date = DateTime::createFromFormat('Ymd_His', '20170101_101112');
+        $this->assertEquals('So 01 Jan 2017 10:11:12 EAT', format_date($date, false));
+    }
+}

--- a/tests/languages/en/UtilsEnTest.php
+++ b/tests/languages/en/UtilsEnTest.php
@@ -1,0 +1,25 @@
+<?php
+
+require_once 'tests/UtilsTest.php';
+
+
+class UtilsEnTest extends UtilsTest
+{
+    /**
+     * Test date_format().
+     */
+    public function testDateFormat()
+    {
+        $date = DateTime::createFromFormat('Ymd_His', '20170101_101112');
+        $this->assertRegExp('/January 1, 2017 (at )?10:11:12 AM GMT\+0?3(:00)?/', format_date($date, true));
+    }
+
+    /**
+     * Test date_format() using builtin PHP function strftime.
+     */
+    public function testDateFormatDefault()
+    {
+        $date = DateTime::createFromFormat('Ymd_His', '20170101_101112');
+        $this->assertEquals('Sun 01 Jan 2017 10:11:12 AM EAT', format_date($date, false));
+    }
+}

--- a/tests/languages/fr/UtilsFrTest.php
+++ b/tests/languages/fr/UtilsFrTest.php
@@ -1,0 +1,25 @@
+<?php
+
+require_once 'tests/UtilsTest.php';
+
+
+class UtilsFrTest extends UtilsTest
+{
+    /**
+     * Test date_format().
+     */
+    public function testDateFormat()
+    {
+        $date = DateTime::createFromFormat('Ymd_His', '20170101_101112');
+        $this->assertRegExp('/1 janvier 2017 (à )?10:11:12 UTC\+0?3(:00)?/', format_date($date));
+    }
+
+    /**
+     * Test date_format() using builtin PHP function strftime.
+     */
+    public function testDateFormatDefault()
+    {
+        $date = DateTime::createFromFormat('Ymd_His', '20170101_101112');
+        $this->assertEquals('dim. 01 janv. 2017 10:11:12 EAT', format_date($date, false));
+    }
+}

--- a/tpl/default/linklist.html
+++ b/tpl/default/linklist.html
@@ -171,10 +171,11 @@
               <div class="linklist-item-infos-dateblock pure-u-lg-3-8 pure-u-1">
                 <a href="?{$value.shorturl}" title="{'Permalink'|t}">
                   {if="!$hide_timestamps || isLoggedIn()"}
-                    {$updated=$value.updated_timestamp ? 'Edited: '. strftime('%c', $value.updated_timestamp) : 'Permalink'}
+                    {$updated=$value.updated_timestamp ? 'Edited: '. format_date($value.updated) : 'Permalink'}
                     <span class="linkdate" title="{$updated}">
                       <i class="fa fa-clock-o"></i>
-                      {function="strftime('%c', $value.timestamp)"}{if="$value.updated_timestamp"}*{/if}
+                      {$value.created|format_date}
+                      {if="$value.updated_timestamp"}*{/if}
                       &middot;
                     </span>
                   {/if}

--- a/tpl/vintage/linklist.html
+++ b/tpl/vintage/linklist.html
@@ -99,11 +99,11 @@
                 <br>
                 {if="$value.description"}<div class="linkdescription">{$value.description}</div>{/if}
                 {if="!$hide_timestamps || isLoggedIn()"}
-                    {$updated=$value.updated_timestamp ? 'Edited: '. strftime('%c', $value.updated_timestamp) : 'Permalink'}
+                    {$updated=$value.updated_timestamp ? 'Edited: '. format_date($value.updated) : 'Permalink'}
                     <span class="linkdate" title="Permalink">
                         <a href="?{$value.shorturl}">
                             <span title="{$updated}">
-                                {function="strftime('%c', $value.timestamp)"}
+                                {$value.created|format_date}
                                 {if="$value.updated_timestamp"}*{/if}
                             </span>
                             - permalink


### PR DESCRIPTION
Use php-intl extension to display datetimes a bit more nicely, depending on the locale.

What changes:

  * the day is no longer displayed
  * day number and month are ordered according to the locale
  * the month label is complete instead of first 3 letters
  * the timezone is more readable (UTC+1 instead of CET)

I also ran into issues using `autoLocale()` so I improved it:

  - create arrays_combination function to cover all cases
  - add the underscore separator in the regex
  - add `utf8` encoding in addition to `UTF-8`