### PR TITLE
API: expect JWT in the Authorization header

### DIFF
--- a/application/api/ApiMiddleware.php
+++ b/application/api/ApiMiddleware.php
@@ -98,8 +98,7 @@ class ApiMiddleware
      * @throws ApiAuthorizationException The token couldn't be validated.
      */
     protected function checkToken($request) {
-        $jwt = $request->getHeaderLine('jwt');
-        if (empty($jwt)) {
+        if (! $request->hasHeader('Authorization')) {
             throw new ApiAuthorizationException('JWT token not provided');
         }
 
@@ -107,7 +106,13 @@ class ApiMiddleware
             throw new ApiAuthorizationException('Token secret must be set in Shaarli\'s administration');
         }
 
-        ApiUtils::validateJwtToken($jwt, $this->conf->get('api.secret'));
+        $authorization = $request->getHeaderLine('Authorization');
+
+        if (! preg_match('/^Bearer (.*)/i', $authorization, $matches)) {
+            throw new ApiAuthorizationException('Invalid JWT header');
+        }
+
+        ApiUtils::validateJwtToken($matches[1], $this->conf->get('api.secret'));
     }
 
     /**

--- a/tests/api/ApiMiddlewareTest.php
+++ b/tests/api/ApiMiddlewareTest.php
@@ -143,7 +143,7 @@ class ApiMiddlewareTest extends \PHPUnit_Framework_TestCase
         $env = Environment::mock([
             'REQUEST_METHOD' => 'GET',
             'REQUEST_URI' => '/echo',
-            'HTTP_JWT'=> 'jwt',
+            'HTTP_AUTHORIZATION'=> 'Bearer jwt',
         ]);
         $request = Request::createFromEnvironment($env);
         $response = new Response();
@@ -157,7 +157,30 @@ class ApiMiddlewareTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * Invoke the middleware without an invalid JWT token (debug):
+     * Invoke the middleware with an invalid JWT token header
+     */
+    public function testInvalidJwtAuthHeaderDebug()
+    {
+        $this->conf->set('dev.debug', true);
+        $mw = new ApiMiddleware($this->container);
+        $env = Environment::mock([
+            'REQUEST_METHOD' => 'GET',
+            'REQUEST_URI' => '/echo',
+            'HTTP_AUTHORIZATION'=> 'PolarBearer jwt',
+        ]);
+        $request = Request::createFromEnvironment($env);
+        $response = new Response();
+        /** @var Response $response */
+        $response = $mw($request, $response, null);
+
+        $this->assertEquals(401, $response->getStatusCode());
+        $body = json_decode((string) $response->getBody());
+        $this->assertEquals('Not authorized: Invalid JWT header', $body->message);
+        $this->assertContains('ApiAuthorizationException', $body->stacktrace);
+    }
+
+    /**
+     * Invoke the middleware with an invalid JWT token (debug):
      * should return a 401 error Unauthorized - with a specific message and a stacktrace.
      *
      * Note: specific JWT errors tests are handled in ApiUtilsTest.
@@ -169,7 +192,7 @@ class ApiMiddlewareTest extends \PHPUnit_Framework_TestCase
         $env = Environment::mock([
             'REQUEST_METHOD' => 'GET',
             'REQUEST_URI' => '/echo',
-            'HTTP_JWT'=> 'bad jwt',
+            'HTTP_AUTHORIZATION'=> 'Bearer jwt',
         ]);
         $request = Request::createFromEnvironment($env);
         $response = new Response();


### PR DESCRIPTION
Relates to https://github.com/shaarli/Shaarli/pull/731

Added:
- require the presence of the 'Authorization' header

Changed:
- use the HTTP Bearer Token authorization schema

See:
- https://jwt.io/introduction/#how-do-json-web-tokens-work-
- https://tools.ietf.org/html/rfc6750
- http://security.stackexchange.com/q/108662

### HTTP header format
`Authorization: Bearer <JWT token>`

### Example client code
Python + [Requests](http://docs.python-requests.org/en/master/user/advanced/#custom-authentication) + [Requests-JWT](https://github.com/tgs/requests-jwt)

```python
#!/usr/bin/env python3
"""Shaarli REST API test client"""
import calendar
import json
import time

import requests
from requests_jwt import JWTAuth


def main():
    """Main entrypoint"""
    uri = 'http://localhost/~user/shaarli/api/v1/info'
    secret = 'ch4ng3m3!'

    auth = JWTAuth(secret, alg='HS512', header_format='Bearer %s')
    auth.add_field('iat', lambda req: calendar.timegm(time.gmtime()))

    response = requests.get(uri, auth=auth)

    print(response.request.headers)
    print(json.dumps(response.json(), sort_keys=True, indent=4))


if __name__ == '__main__':
    main()
```