### PR TITLE
REST API - getLinks: support the visibility parameter

### DIFF
--- a/application/api/controllers/Links.php
+++ b/application/api/controllers/Links.php
@@ -34,15 +34,14 @@ class Links extends ApiController
      */
     public function getLinks($request, $response)
     {
-        $private = $request->getParam('private');
+        $private = $request->getParam('visibility');
         $links = $this->linkDb->filterSearch(
             [
                 'searchtags' => $request->getParam('searchtags', ''),
                 'searchterm' => $request->getParam('searchterm', ''),
             ],
             false,
-            // to updated in another PR depending on the API doc
-            ($private === 'true' || $private === '1') ? 'private' : 'all'
+            $private
         );
 
         // Return links from the {offset}th link, starting from 0.

--- a/tests/api/controllers/LinksTest.php
+++ b/tests/api/controllers/LinksTest.php
@@ -188,25 +188,33 @@ class LinksTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * Test getLinks with private attribute to 1 or true.
+     * Test getLinks with visibility parameter set to all
      */
-    public function testGetLinksPrivate()
+    public function testGetLinksVisibilityAll()
     {
-        $env = Environment::mock([
-            'REQUEST_METHOD' => 'GET',
-            'QUERY_STRING' => 'private=true'
-        ]);
+        $env = Environment::mock(
+            [
+                'REQUEST_METHOD' => 'GET',
+                'QUERY_STRING' => 'visibility=all'
+            ]
+        );
         $request = Request::createFromEnvironment($env);
         $response = $this->controller->getLinks($request, new Response());
         $this->assertEquals(200, $response->getStatusCode());
-        $data = json_decode((string) $response->getBody(), true);
-        $this->assertEquals($this->refDB->countPrivateLinks(), count($data));
-        $this->assertEquals(6, $data[0]['id']);
+        $data = json_decode((string)$response->getBody(), true);
+        $this->assertEquals($this->refDB->countLinks(), count($data));
+        $this->assertEquals(41, $data[0]['id']);
         $this->assertEquals(self::NB_FIELDS_LINK, count($data[0]));
+    }
 
+    /**
+     * Test getLinks with visibility parameter set to private
+     */
+    public function testGetLinksVisibilityPrivate()
+    {
         $env = Environment::mock([
             'REQUEST_METHOD' => 'GET',
-            'QUERY_STRING' => 'private=1'
+            'QUERY_STRING' => 'visibility=private'
         ]);
         $request = Request::createFromEnvironment($env);
         $response = $this->controller->getLinks($request, new Response());
@@ -218,35 +226,21 @@ class LinksTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * Test getLinks with private attribute to false or 0
+     * Test getLinks with visibility parameter set to public
      */
-    public function testGetLinksNotPrivate()
+    public function testGetLinksVisibilityPublic()
     {
         $env = Environment::mock(
             [
                 'REQUEST_METHOD' => 'GET',
-                'QUERY_STRING' => 'private=0'
+                'QUERY_STRING' => 'visibility=public'
             ]
         );
         $request = Request::createFromEnvironment($env);
         $response = $this->controller->getLinks($request, new Response());
         $this->assertEquals(200, $response->getStatusCode());
         $data = json_decode((string)$response->getBody(), true);
-        $this->assertEquals($this->refDB->countLinks(), count($data));
-        $this->assertEquals(41, $data[0]['id']);
-        $this->assertEquals(self::NB_FIELDS_LINK, count($data[0]));
-
-        $env = Environment::mock(
-            [
-                'REQUEST_METHOD' => 'GET',
-                'QUERY_STRING' => 'private=false'
-            ]
-        );
-        $request = Request::createFromEnvironment($env);
-        $response = $this->controller->getLinks($request, new Response());
-        $this->assertEquals(200, $response->getStatusCode());
-        $data = json_decode((string)$response->getBody(), true);
-        $this->assertEquals($this->refDB->countLinks(), count($data));
+        $this->assertEquals($this->refDB->countPublicLinks(), count($data));
         $this->assertEquals(41, $data[0]['id']);
         $this->assertEquals(self::NB_FIELDS_LINK, count($data[0]));
     }


### PR DESCRIPTION
Service `GET links`, the parameter `private` is replaced by `visibility`. See [the documentation](http://shaarli.github.io/api-documentation/#links-links-collection-get).