### PR TITLE
Fixes #775: LinkDB do not access LinkDB before ID system migration

### DIFF
--- a/application/Updater.php
+++ b/application/Updater.php
@@ -133,21 +133,6 @@ class Updater
     }
 
     /**
-     * Rename tags starting with a '-' to work with tag exclusion search.
-     */
-    public function updateMethodRenameDashTags()
-    {
-        $linklist = $this->linkDB->filterSearch();
-        foreach ($linklist as $key => $link) {
-            $link['tags'] = preg_replace('/(^| )\-/', '$1', $link['tags']);
-            $link['tags'] = implode(' ', array_unique(LinkFilter::tagsStrToArray($link['tags'], true)));
-            $this->linkDB[$key] = $link;
-        }
-        $this->linkDB->save($this->conf->get('resource.page_cache'));
-        return true;
-    }
-
-    /**
      * Move old configuration in PHP to the new config system in JSON format.
      *
      * Will rename 'config.php' into 'config.save.php' and create 'config.json.php'.
@@ -254,6 +239,21 @@ class Updater
         $this->linkDB->save($this->conf->get('resource.page_cache'));
         $this->linkDB->reorder();
 
+        return true;
+    }
+
+    /**
+     * Rename tags starting with a '-' to work with tag exclusion search.
+     */
+    public function updateMethodRenameDashTags()
+    {
+        $linklist = $this->linkDB->filterSearch();
+        foreach ($linklist as $key => $link) {
+            $link['tags'] = preg_replace('/(^| )\-/', '$1', $link['tags']);
+            $link['tags'] = implode(' ', array_unique(LinkFilter::tagsStrToArray($link['tags'], true)));
+            $this->linkDB[$key] = $link;
+        }
+        $this->linkDB->save($this->conf->get('resource.page_cache'));
         return true;
     }
 


### PR DESCRIPTION
To access LinkDB items with its ArrayAccess implementation, the IDs must be consistent, which isn't the case before `updateMethodDatastoreIds()` execution. v0.6.4 method `updateMethodRenameDashTags()` was accessing it, so an upgrade <0.6.4 to >0.8.x was failing.

This just move the minor update `RenameDashTags` after the IDs update.

Note: This updater mechanism has its limit, and at some point, we'll probably have to ask users to export/import their data if they're using a very old version, otherwise it might become unmaintainable.