### PR TITLE
Link imports are now logged in `data/` folder, and can be debug using…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ Theming:
 - Add OpenSearch to feed templates
 - Add `campaign_` to the URL cleanup pattern list
 - Add an AUTHORS file and Makefile target to list authors from Git commit data
+- Link imports are now logged in `data/` folder, and can be debug using `dev.debug=true` setting.
 
 ### Changed
 - Docker: enable nginx URL rewriting for the REST API

--- a/application/NetscapeBookmarkUtils.php
+++ b/application/NetscapeBookmarkUtils.php
@@ -1,7 +1,12 @@
 <?php
 
+use Psr\Log\LogLevel;
+use Shaarli\NetscapeBookmarkParser\NetscapeBookmarkParser;
+use Katzgrau\KLogger\Logger;
+
 /**
  * Utilities to import and export bookmarks using the Netscape format
+ * TODO: Not static, use a container.
  */
 class NetscapeBookmarkUtils
 {
@@ -85,14 +90,14 @@ class NetscapeBookmarkUtils
     /**
      * Imports Web bookmarks from an uploaded Netscape bookmark dump
      *
-     * @param array  $post      Server $_POST parameters
-     * @param array  $files     Server $_FILES parameters
-     * @param LinkDB $linkDb    Loaded LinkDB instance
-     * @param string $pagecache Page cache
+     * @param array         $post      Server $_POST parameters
+     * @param array         $files     Server $_FILES parameters
+     * @param LinkDB        $linkDb    Loaded LinkDB instance
+     * @param ConfigManager $conf      instance
      *
      * @return string Summary of the bookmark import status
      */
-    public static function import($post, $files, $linkDb, $pagecache)
+    public static function import($post, $files, $linkDb, $conf)
     {
         $filename = $files['filetoupload']['name'];
         $filesize = $files['filetoupload']['size'];
@@ -119,10 +124,20 @@ class NetscapeBookmarkUtils
         $defaultPrivacy = 0;
 
         $parser = new NetscapeBookmarkParser(
-            true,                       // nested tag support
-            $defaultTags,               // additional user-specified tags
-            strval(1 - $defaultPrivacy) // defaultPub = 1 - defaultPrivacy
+            true,                           // nested tag support
+            $defaultTags,                   // additional user-specified tags
+            strval(1 - $defaultPrivacy),    // defaultPub = 1 - defaultPrivacy
+            $conf->get('resource.data_dir') // log path, will be overridden
         );
+        $logger = new Logger(
+            $conf->get('resource.data_dir'),
+            ! $conf->get('dev.debug') ? LogLevel::INFO : LogLevel::DEBUG,
+            [
+                'prefix' => 'import.',
+                'extension' => 'log',
+            ]
+        );
+        $parser->setLogger($logger);
         $bookmarks = $parser->parseString($data);
 
         $importCount = 0;
@@ -179,7 +194,7 @@ class NetscapeBookmarkUtils
             $importCount++;
         }
 
-        $linkDb->save($pagecache);
+        $linkDb->save($conf->get('resource.page_cache'));
         return self::importStatus(
             $filename,
             $filesize,

--- a/application/NetscapeBookmarkUtils.php
+++ b/application/NetscapeBookmarkUtils.php
@@ -1,6 +1,7 @@
 <?php
 
 use Psr\Log\LogLevel;
+use Shaarli\Config\ConfigManager;
 use Shaarli\NetscapeBookmarkParser\NetscapeBookmarkParser;
 use Katzgrau\KLogger\Logger;
 

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     "keywords": ["bookmark", "link", "share", "web"],
     "require": {
         "php": ">=5.5",
-        "shaarli/netscape-bookmark-parser": "1.*",
+        "shaarli/netscape-bookmark-parser": "^2.0",
         "erusev/parsedown": "1.6",
         "slim/slim": "^3.0",
         "pubsubhubbub/publisher": "dev-master"

--- a/index.php
+++ b/index.php
@@ -1528,7 +1528,7 @@ function renderPage($conf, $pluginManager, $LINKSDB)
             $_POST,
             $_FILES,
             $LINKSDB,
-            $conf->get('resource.page_cache')
+            $conf
         );
         echo '<script>alert("'.$status.'");document.location=\'?do='
              .Router::$PAGE_IMPORT .'\';</script>';

--- a/tests/NetscapeBookmarkUtils/BookmarkImportTest.php
+++ b/tests/NetscapeBookmarkUtils/BookmarkImportTest.php
@@ -2,6 +2,7 @@
 
 require_once 'application/NetscapeBookmarkUtils.php';
 
+use Shaarli\Config\ConfigManager;
 
 /**
  * Utility function to load a file's metadata in a $_FILES-like array

--- a/tests/NetscapeBookmarkUtils/BookmarkImportTest.php
+++ b/tests/NetscapeBookmarkUtils/BookmarkImportTest.php
@@ -43,6 +43,11 @@ class BookmarkImportTest extends PHPUnit_Framework_TestCase
     protected $pagecache = 'tests';
 
     /**
+     * @var ConfigManager instance.
+     */
+    protected $conf;
+
+    /**
      * @var string Save the current timezone.
      */
     protected static $defaultTimeZone;
@@ -65,6 +70,8 @@ class BookmarkImportTest extends PHPUnit_Framework_TestCase
         // start with an empty datastore
         file_put_contents(self::$testDatastore, '<?php /* S7QysKquBQA= */ ?>');
         $this->linkDb = new LinkDB(self::$testDatastore, true, false);
+        $this->conf = new ConfigManager('tests/utils/config/configJson');
+        $this->conf->set('resource.page_cache', $this->pagecache);
     }
 
     public static function tearDownAfterClass()
@@ -81,7 +88,7 @@ class BookmarkImportTest extends PHPUnit_Framework_TestCase
         $this->assertEquals(
             'File empty.htm (0 bytes) has an unknown file format.'
             .' Nothing was imported.',
-            NetscapeBookmarkUtils::import(NULL, $files, NULL, NULL)
+            NetscapeBookmarkUtils::import(NULL, $files, NULL, $this->conf)
         );
         $this->assertEquals(0, count($this->linkDb));
     }
@@ -94,7 +101,7 @@ class BookmarkImportTest extends PHPUnit_Framework_TestCase
         $files = file2array('no_doctype.htm');
         $this->assertEquals(
             'File no_doctype.htm (350 bytes) has an unknown file format. Nothing was imported.',
-            NetscapeBookmarkUtils::import(NULL, $files, NULL, NULL)
+            NetscapeBookmarkUtils::import(NULL, $files, NULL, $this->conf)
         );
         $this->assertEquals(0, count($this->linkDb));
     }
@@ -108,7 +115,7 @@ class BookmarkImportTest extends PHPUnit_Framework_TestCase
         $this->assertEquals(
             'File internet_explorer_encoding.htm (356 bytes) was successfully processed:'
             .' 1 links imported, 0 links overwritten, 0 links skipped.',
-            NetscapeBookmarkUtils::import(array(), $files, $this->linkDb, $this->pagecache)
+            NetscapeBookmarkUtils::import(array(), $files, $this->linkDb, $this->conf)
         );
         $this->assertEquals(1, count($this->linkDb));
         $this->assertEquals(0, count_private($this->linkDb));
@@ -137,7 +144,7 @@ class BookmarkImportTest extends PHPUnit_Framework_TestCase
         $this->assertEquals(
             'File netscape_nested.htm (1337 bytes) was successfully processed:'
             .' 8 links imported, 0 links overwritten, 0 links skipped.',
-            NetscapeBookmarkUtils::import(array(), $files, $this->linkDb, $this->pagecache)
+            NetscapeBookmarkUtils::import(array(), $files, $this->linkDb, $this->conf)
         );
         $this->assertEquals(8, count($this->linkDb));
         $this->assertEquals(2, count_private($this->linkDb));
@@ -259,7 +266,7 @@ class BookmarkImportTest extends PHPUnit_Framework_TestCase
         $this->assertEquals(
             'File netscape_basic.htm (482 bytes) was successfully processed:'
             .' 2 links imported, 0 links overwritten, 0 links skipped.',
-            NetscapeBookmarkUtils::import(array(), $files, $this->linkDb, $this->pagecache)
+            NetscapeBookmarkUtils::import(array(), $files, $this->linkDb, $this->conf)
         );
 
         $this->assertEquals(2, count($this->linkDb));
@@ -304,7 +311,7 @@ class BookmarkImportTest extends PHPUnit_Framework_TestCase
         $this->assertEquals(
             'File netscape_basic.htm (482 bytes) was successfully processed:'
             .' 2 links imported, 0 links overwritten, 0 links skipped.',
-            NetscapeBookmarkUtils::import($post, $files, $this->linkDb, $this->pagecache)
+            NetscapeBookmarkUtils::import($post, $files, $this->linkDb, $this->conf)
         );
         $this->assertEquals(2, count($this->linkDb));
         $this->assertEquals(1, count_private($this->linkDb));
@@ -348,7 +355,7 @@ class BookmarkImportTest extends PHPUnit_Framework_TestCase
         $this->assertEquals(
             'File netscape_basic.htm (482 bytes) was successfully processed:'
             .' 2 links imported, 0 links overwritten, 0 links skipped.',
-            NetscapeBookmarkUtils::import($post, $files, $this->linkDb, $this->pagecache)
+            NetscapeBookmarkUtils::import($post, $files, $this->linkDb, $this->conf)
         );
         $this->assertEquals(2, count($this->linkDb));
         $this->assertEquals(0, count_private($this->linkDb));
@@ -372,7 +379,7 @@ class BookmarkImportTest extends PHPUnit_Framework_TestCase
         $this->assertEquals(
             'File netscape_basic.htm (482 bytes) was successfully processed:'
             .' 2 links imported, 0 links overwritten, 0 links skipped.',
-            NetscapeBookmarkUtils::import($post, $files, $this->linkDb, $this->pagecache)
+            NetscapeBookmarkUtils::import($post, $files, $this->linkDb, $this->conf)
         );
         $this->assertEquals(2, count($this->linkDb));
         $this->assertEquals(2, count_private($this->linkDb));
@@ -398,7 +405,7 @@ class BookmarkImportTest extends PHPUnit_Framework_TestCase
         $this->assertEquals(
             'File netscape_basic.htm (482 bytes) was successfully processed:'
             .' 2 links imported, 0 links overwritten, 0 links skipped.',
-            NetscapeBookmarkUtils::import($post, $files, $this->linkDb, $this->pagecache)
+            NetscapeBookmarkUtils::import($post, $files, $this->linkDb, $this->conf)
         );
         $this->assertEquals(2, count($this->linkDb));
         $this->assertEquals(2, count_private($this->linkDb));
@@ -418,7 +425,7 @@ class BookmarkImportTest extends PHPUnit_Framework_TestCase
         $this->assertEquals(
             'File netscape_basic.htm (482 bytes) was successfully processed:'
             .' 2 links imported, 2 links overwritten, 0 links skipped.',
-            NetscapeBookmarkUtils::import($post, $files, $this->linkDb, $this->pagecache)
+            NetscapeBookmarkUtils::import($post, $files, $this->linkDb, $this->conf)
         );
         $this->assertEquals(2, count($this->linkDb));
         $this->assertEquals(0, count_private($this->linkDb));
@@ -444,7 +451,7 @@ class BookmarkImportTest extends PHPUnit_Framework_TestCase
         $this->assertEquals(
             'File netscape_basic.htm (482 bytes) was successfully processed:'
             .' 2 links imported, 0 links overwritten, 0 links skipped.',
-            NetscapeBookmarkUtils::import($post, $files, $this->linkDb, $this->pagecache)
+            NetscapeBookmarkUtils::import($post, $files, $this->linkDb, $this->conf)
         );
         $this->assertEquals(2, count($this->linkDb));
         $this->assertEquals(0, count_private($this->linkDb));
@@ -465,7 +472,7 @@ class BookmarkImportTest extends PHPUnit_Framework_TestCase
         $this->assertEquals(
             'File netscape_basic.htm (482 bytes) was successfully processed:'
             .' 2 links imported, 2 links overwritten, 0 links skipped.',
-            NetscapeBookmarkUtils::import($post, $files, $this->linkDb, $this->pagecache)
+            NetscapeBookmarkUtils::import($post, $files, $this->linkDb, $this->conf)
         );
         $this->assertEquals(2, count($this->linkDb));
         $this->assertEquals(2, count_private($this->linkDb));
@@ -489,7 +496,7 @@ class BookmarkImportTest extends PHPUnit_Framework_TestCase
         $this->assertEquals(
             'File netscape_basic.htm (482 bytes) was successfully processed:'
             .' 2 links imported, 0 links overwritten, 0 links skipped.',
-            NetscapeBookmarkUtils::import($post, $files, $this->linkDb, $this->pagecache)
+            NetscapeBookmarkUtils::import($post, $files, $this->linkDb, $this->conf)
         );
         $this->assertEquals(2, count($this->linkDb));
         $this->assertEquals(0, count_private($this->linkDb));
@@ -499,7 +506,7 @@ class BookmarkImportTest extends PHPUnit_Framework_TestCase
         $this->assertEquals(
             'File netscape_basic.htm (482 bytes) was successfully processed:'
             .' 0 links imported, 0 links overwritten, 2 links skipped.',
-            NetscapeBookmarkUtils::import($post, $files, $this->linkDb, $this->pagecache)
+            NetscapeBookmarkUtils::import($post, $files, $this->linkDb, $this->conf)
         );
         $this->assertEquals(2, count($this->linkDb));
         $this->assertEquals(0, count_private($this->linkDb));
@@ -518,7 +525,7 @@ class BookmarkImportTest extends PHPUnit_Framework_TestCase
         $this->assertEquals(
             'File netscape_basic.htm (482 bytes) was successfully processed:'
             .' 2 links imported, 0 links overwritten, 0 links skipped.',
-            NetscapeBookmarkUtils::import($post, $files, $this->linkDb, $this->pagecache)
+            NetscapeBookmarkUtils::import($post, $files, $this->linkDb, $this->conf)
         );
         $this->assertEquals(2, count($this->linkDb));
         $this->assertEquals(0, count_private($this->linkDb));
@@ -545,7 +552,7 @@ class BookmarkImportTest extends PHPUnit_Framework_TestCase
         $this->assertEquals(
             'File netscape_basic.htm (482 bytes) was successfully processed:'
             .' 2 links imported, 0 links overwritten, 0 links skipped.',
-            NetscapeBookmarkUtils::import($post, $files, $this->linkDb, $this->pagecache)
+            NetscapeBookmarkUtils::import($post, $files, $this->linkDb, $this->conf)
         );
         $this->assertEquals(2, count($this->linkDb));
         $this->assertEquals(0, count_private($this->linkDb));
@@ -570,7 +577,7 @@ class BookmarkImportTest extends PHPUnit_Framework_TestCase
         $this->assertEquals(
             'File same_date.htm (453 bytes) was successfully processed:'
             .' 3 links imported, 0 links overwritten, 0 links skipped.',
-            NetscapeBookmarkUtils::import(array(), $files, $this->linkDb, $this->pagecache)
+            NetscapeBookmarkUtils::import(array(), $files, $this->linkDb, $this->conf)
         );
         $this->assertEquals(3, count($this->linkDb));
         $this->assertEquals(0, count_private($this->linkDb));

--- a/tests/utils/config/configJson.json.php
+++ b/tests/utils/config/configJson.json.php
@@ -24,7 +24,7 @@
     },
     "resource": {
         "datastore": "tests\/utils\/config\/datastore.php",
-        "data_dir": "tests\/utils\/config",
+        "data_dir": "sandbox/",
         "raintpl_tpl": "tpl/"
     },
     "plugins": {


### PR DESCRIPTION
… `dev.debug=true` setting

related to #741 and #681