### PR TITLE
Removes spaces before bookmarklet's name

### DIFF
--- a/tpl/default/tools.html
+++ b/tpl/default/tools.html
@@ -30,9 +30,7 @@
 					'&amp;source=bookmarklet','_blank','menubar=no,height=390,width=600,toolbar=no,scrollbars=no,status=no,dialog=1'
 				);
 			}
-		)();">
-			<b>✚Shaare link</b>
-		</a>
+		)();"><b>✚Shaare link</b></a>
 		<a href="#" onclick="return alertBookmarklet();">
 			<span>
 				&#x21D0; Drag this link to your bookmarks toolbar (or right-click it and choose Bookmark This Link....).<br>
@@ -41,9 +39,7 @@
 		</a><br><br>
 		<a class="smallbutton"
 		   	onclick="return alertBookmarklet();"
-		   	href="?private=1&amp;post=">
-			<b>✚Add Note</b>
-		</a>
+		   	href="?private=1&amp;post="><b>✚Add Note</b></a>
 		<a href="#" onclick="return alertBookmarklet();">
 			<span>
 				&#x21D0; Drag this link to your bookmarks toolbar (or right-click it and choose Bookmark This Link....).<br>
@@ -52,9 +48,7 @@
 		</a><br><br>
 
 		{if="$sslenabled"}
-		<a class="smallbutton" onclick="activateFirefoxSocial(this)">
-			<b>✚Add to Firefox social</b>
-		</a>
+		<a class="smallbutton" onclick="activateFirefoxSocial(this)"><b>✚Add to Firefox social</b></a>
 		<a href="#">
 			<span>&#x21D0; Click on this button to add Shaarli to the "Share this page" button in Firefox.</span>
 		</a><br><br>


### PR DESCRIPTION
Carriage returns turns into space in some cases. The name of the bookmarklet, once in the browser bookmarks, is preceded by a space.