### PR TITLE
Add markdown_escape setting

### DIFF
--- a/application/Updater.php
+++ b/application/Updater.php
@@ -336,6 +336,29 @@ class Updater
         }
         $this->conf->set('resource.theme', 'vintage');
         $this->conf->write($this->isLoggedIn);
+
+        return true;
+    }
+
+    /**
+     * * `markdown_escape` is a new setting, set to true as default.
+     *
+     * If the markdown plugin was already enabled, escaping is disabled to avoid
+     * breaking existing entries.
+     */
+    public function updateMethodEscapeMarkdown()
+    {
+        if ($this->conf->exists('security.markdown_escape')) {
+            return true;
+        }
+
+        if (in_array('markdown', $this->conf->get('general.enabled_plugins'))) {
+            $this->conf->set('security.markdown_escape', false);
+        } else {
+            $this->conf->set('security.markdown_escape', true);
+        }
+        $this->conf->write($this->isLoggedIn);
+
         return true;
     }
 }

--- a/plugins/markdown/README.md
+++ b/plugins/markdown/README.md
@@ -50,9 +50,20 @@ If the tag `nomarkdown` is set for a shaare, it won't be converted to Markdown s
  
 > Note: this is a special tag, so it won't be displayed in link list.
 
-### HTML rendering
+### HTML escape
 
-Markdown support HTML tags. For example:
+By default, HTML tags are escaped. You can enable HTML tags rendering
+by setting `security.markdwon_escape` to `false` in `data/config.json.php`:
+
+```json
+{
+  "security": {
+    "markdown_escape": false
+  }
+}
+```
+
+With this setting, Markdown support HTML tags. For example:
 
     > <strong>strong</strong><strike>strike</strike>
    
@@ -60,12 +71,14 @@ Will render as:
 
 > <strong>strong</strong><strike>strike</strike>
 
-If you want to shaare HTML code, it is necessary to use inline code or code blocks.
-  
-**If your shaared descriptions containing HTML tags before enabling the markdown plugin, 
-enabling it might break your page.**
 
-> Note: HTML tags such as script, iframe, etc. are disabled for security reasons.
+**Warning:**
+
+  * This setting might present **security risks** (XSS) on shared instances, even though tags 
+  such as script, iframe, etc should be disabled.
+  * If you want to shaare HTML code, it is necessary to use inline code or code blocks.
+  * If your shaared descriptions contained HTML tags before enabling the markdown plugin, 
+enabling it might break your page.
 
 ### Known issue
 

--- a/plugins/markdown/markdown.php
+++ b/plugins/markdown/markdown.php
@@ -14,18 +14,19 @@ define('NO_MD_TAG', 'nomarkdown');
 /**
  * Parse linklist descriptions.
  *
- * @param array $data linklist data.
+ * @param array         $data linklist data.
+ * @param ConfigManager $conf instance.
  *
  * @return mixed linklist data parsed in markdown (and converted to HTML).
  */
-function hook_markdown_render_linklist($data)
+function hook_markdown_render_linklist($data, $conf)
 {
     foreach ($data['links'] as &$value) {
         if (!empty($value['tags']) && noMarkdownTag($value['tags'])) {
             $value = stripNoMarkdownTag($value);
             continue;
         }
-        $value['description'] = process_markdown($value['description']);
+        $value['description'] = process_markdown($value['description'], $conf->get('security.markdown_escape', true));
     }
     return $data;
 }
@@ -34,17 +35,18 @@ function hook_markdown_render_linklist($data)
  * Parse feed linklist descriptions.
  *
  * @param array $data linklist data.
+ * @param ConfigManager $conf instance.
  *
  * @return mixed linklist data parsed in markdown (and converted to HTML).
  */
-function hook_markdown_render_feed($data)
+function hook_markdown_render_feed($data, $conf)
 {
     foreach ($data['links'] as &$value) {
         if (!empty($value['tags']) && noMarkdownTag($value['tags'])) {
             $value = stripNoMarkdownTag($value);
             continue;
         }
-        $value['description'] = process_markdown($value['description']);
+        $value['description'] = process_markdown($value['description'], $conf->get('security.markdown_escape', true));
     }
 
     return $data;
@@ -53,11 +55,12 @@ function hook_markdown_render_feed($data)
 /**
  * Parse daily descriptions.
  *
- * @param array $data daily data.
+ * @param array         $data daily data.
+ * @param ConfigManager $conf instance.
  *
  * @return mixed daily data parsed in markdown (and converted to HTML).
  */
-function hook_markdown_render_daily($data)
+function hook_markdown_render_daily($data, $conf)
 {
     // Manipulate columns data
     foreach ($data['cols'] as &$value) {
@@ -66,7 +69,10 @@ function hook_markdown_render_daily($data)
                 $value2 = stripNoMarkdownTag($value2);
                 continue;
             }
-            $value2['formatedDescription'] = process_markdown($value2['formatedDescription']);
+            $value2['formatedDescription'] = process_markdown(
+                $value2['formatedDescription'],
+                $conf->get('security.markdown_escape', true)
+            );
         }
     }
 
@@ -250,7 +256,7 @@ function sanitize_html($description)
             $description);
     }
     $description = preg_replace(
-        '#(<[^>]+)on[a-z]*="[^"]*"#is',
+        '#(<[^>]+)on[a-z]*="?[^ "]*"?#is',
         '$1',
         $description);
     return $description;
@@ -265,10 +271,11 @@ function sanitize_html($description)
  *   5. Wrap description in 'markdown' CSS class.
  *
  * @param string $description input description text.
+ * @param bool   $escape      escape HTML entities
  *
  * @return string HTML processed $description.
  */
-function process_markdown($description)
+function process_markdown($description, $escape = true)
 {
     $parsedown = new Parsedown();
 
@@ -278,7 +285,7 @@ function process_markdown($description)
     $processedDescription = reverse_text2clickable($processedDescription);
     $processedDescription = unescape($processedDescription);
     $processedDescription = $parsedown
-        ->setMarkupEscaped(false)
+        ->setMarkupEscaped($escape)
         ->setBreaksEnabled(true)
         ->text($processedDescription);
     $processedDescription = sanitize_html($processedDescription);

--- a/tests/Updater/UpdaterTest.php
+++ b/tests/Updater/UpdaterTest.php
@@ -506,4 +506,70 @@ $GLOBALS[\'privateLinkByDefault\'] = true;';
         $this->conf = new ConfigManager($sandboxConf);
         $this->assertEquals($theme, $this->conf->get('resource.theme'));
     }
+
+    /**
+     * Test updateMethodEscapeMarkdown with markdown plugin enabled
+     * => setting markdown_escape set to false.
+     */
+    public function testEscapeMarkdownSettingToFalse()
+    {
+        $sandboxConf = 'sandbox/config';
+        copy(self::$configFile . '.json.php', $sandboxConf . '.json.php');
+        $this->conf = new ConfigManager($sandboxConf);
+
+        $this->conf->set('general.enabled_plugins', ['markdown']);
+        $updater = new Updater([], [], $this->conf, true);
+        $this->assertTrue($updater->updateMethodEscapeMarkdown());
+        $this->assertFalse($this->conf->get('security.markdown_escape'));
+
+        // reload from file
+        $this->conf = new ConfigManager($sandboxConf);
+        $this->assertFalse($this->conf->get('security.markdown_escape'));
+    }
+
+
+    /**
+     * Test updateMethodEscapeMarkdown with markdown plugin disabled
+     * => setting markdown_escape set to true.
+     */
+    public function testEscapeMarkdownSettingToTrue()
+    {
+        $sandboxConf = 'sandbox/config';
+        copy(self::$configFile . '.json.php', $sandboxConf . '.json.php');
+        $this->conf = new ConfigManager($sandboxConf);
+
+        $this->conf->set('general.enabled_plugins', []);
+        $updater = new Updater([], [], $this->conf, true);
+        $this->assertTrue($updater->updateMethodEscapeMarkdown());
+        $this->assertTrue($this->conf->get('security.markdown_escape'));
+
+        // reload from file
+        $this->conf = new ConfigManager($sandboxConf);
+        $this->assertTrue($this->conf->get('security.markdown_escape'));
+    }
+
+    /**
+     * Test updateMethodEscapeMarkdown with nothing to do (setting already enabled)
+     */
+    public function testEscapeMarkdownSettingNothingToDoEnabled()
+    {
+        $sandboxConf = 'sandbox/config';
+        copy(self::$configFile . '.json.php', $sandboxConf . '.json.php');
+        $this->conf = new ConfigManager($sandboxConf);
+        $this->conf->set('security.markdown_escape', true);
+        $updater = new Updater([], [], $this->conf, true);
+        $this->assertTrue($updater->updateMethodEscapeMarkdown());
+        $this->assertTrue($this->conf->get('security.markdown_escape'));
+    }
+
+    /**
+     * Test updateMethodEscapeMarkdown with nothing to do (setting already disabled)
+     */
+    public function testEscapeMarkdownSettingNothingToDoDisabled()
+    {
+        $this->conf->set('security.markdown_escape', false);
+        $updater = new Updater([], [], $this->conf, true);
+        $this->assertTrue($updater->updateMethodEscapeMarkdown());
+        $this->assertFalse($this->conf->get('security.markdown_escape'));
+    }
 }

--- a/tests/plugins/resources/markdown.html
+++ b/tests/plugins/resources/markdown.html
@@ -12,11 +12,11 @@
 <li><a href="http://link.tld">two</a></li>
 <li><a href="http://link.tld">three</a></li>
 <li><a href="http://link.tld">four</a></li>
-<li>foo <a href="?addtag=foobar" title="Hashtag foobar">#foobar</a></li>
+<li>foo &lt;a href=&quot;?addtag=foobar&quot; title=&quot;Hashtag foobar&quot;&gt;#foobar&lt;/a&gt;</li>
 </ol></li>
 </ol>
-<p><a href="?addtag=foobar" title="Hashtag foobar">#foobar</a> foo <code>lol #foo</code> <a href="?addtag=bar" title="Hashtag bar">#bar</a></p>
-<p>fsdfs <a href="http://link.tld">http://link.tld</a> <a href="?addtag=foobar" title="Hashtag foobar">#foobar</a> <code>http://link.tld</code></p>
+<p>&lt;a href=&quot;?addtag=foobar&quot; title=&quot;Hashtag foobar&quot;&gt;#foobar&lt;/a&gt; foo <code>lol #foo</code> &lt;a href=&quot;?addtag=bar&quot; title=&quot;Hashtag bar&quot;&gt;#bar&lt;/a&gt;</p>
+<p>fsdfs <a href="http://link.tld">http://link.tld</a> &lt;a href=&quot;?addtag=foobar&quot; title=&quot;Hashtag foobar&quot;&gt;#foobar&lt;/a&gt; <code>http://link.tld</code></p>
 <pre><code>http://link.tld #foobar
 next #foo</code></pre>
 <p>Block:</p>


### PR DESCRIPTION
This setting allows to escape HTML in markdown rendering or not.
The goal behind it is to avoid XSS issue in shared instances.

More info:

  * the setting is set to true by default
  * it is set to false for anyone who already have the plugin enabled
  (avoid breaking existing entries)
  * improve the HTML sanitization when the setting is set to false - but don't consider it XSS proof
  * mention the setting in the plugin README

This need to be backported and released in v0.7.x and v0.8.x.

This PR is high priority.