### PR TITLE
application: introduce the Shaarli\Config namespace

### DIFF
--- a/application/Updater.php
+++ b/application/Updater.php
@@ -1,4 +1,6 @@
 <?php
+use Shaarli\Config\ConfigJson;
+use Shaarli\Config\ConfigPhp;
 
 /**
  * Class Updater.

--- a/application/api/ApiMiddleware.php
+++ b/application/api/ApiMiddleware.php
@@ -1,9 +1,9 @@
 <?php
-
 namespace Shaarli\Api;
 
 use Shaarli\Api\Exceptions\ApiException;
 use Shaarli\Api\Exceptions\ApiAuthorizationException;
+
 use Slim\Container;
 use Slim\Http\Request;
 use Slim\Http\Response;

--- a/application/config/ConfigIO.php
+++ b/application/config/ConfigIO.php
@@ -1,4 +1,5 @@
 <?php
+namespace Shaarli\Config;
 
 /**
  * Interface ConfigIO

--- a/application/config/ConfigJson.php
+++ b/application/config/ConfigJson.php
@@ -1,4 +1,5 @@
 <?php
+namespace Shaarli\Config;
 
 /**
  * Class ConfigJson (ConfigIO implementation)
@@ -21,7 +22,7 @@ class ConfigJson implements ConfigIO
         $data = json_decode($data, true);
         if ($data === null) {
             $error = json_last_error();
-            throw new Exception('An error occurred while parsing JSON file: error code #'. $error);
+            throw new \Exception('An error occurred while parsing JSON file: error code #'. $error);
         }
         return $data;
     }
@@ -35,7 +36,7 @@ class ConfigJson implements ConfigIO
         $print = defined('JSON_PRETTY_PRINT') ? JSON_PRETTY_PRINT : 0;
         $data = self::getPhpHeaders() . json_encode($conf, $print) . self::getPhpSuffix();
         if (!file_put_contents($filepath, $data)) {
-            throw new IOException(
+            throw new \IOException(
                 $filepath,
                 'Shaarli could not create the config file.
                 Please make sure Shaarli has the right to write in the folder is it installed in.'

--- a/application/config/ConfigManager.php
+++ b/application/config/ConfigManager.php
@@ -1,9 +1,5 @@
 <?php
-
-// FIXME! Namespaces...
-require_once 'ConfigIO.php';
-require_once 'ConfigJson.php';
-require_once 'ConfigPhp.php';
+namespace Shaarli\Config;
 
 /**
  * Class ConfigManager
@@ -124,12 +120,12 @@ class ConfigManager
      * @param bool   $write      Write the new setting in the config file, default false.
      * @param bool   $isLoggedIn User login state, default false.
      *
-     * @throws Exception Invalid
+     * @throws \Exception Invalid
      */
     public function set($setting, $value, $write = false, $isLoggedIn = false)
     {
         if (empty($setting) || ! is_string($setting)) {
-            throw new Exception('Invalid setting key parameter. String expected, got: '. gettype($setting));
+            throw new \Exception('Invalid setting key parameter. String expected, got: '. gettype($setting));
         }
 
         // During the ConfigIO transition, map legacy settings to the new ones.
@@ -177,7 +173,7 @@ class ConfigManager
      *
      * @throws MissingFieldConfigException: a mandatory field has not been provided in $conf.
      * @throws UnauthorizedConfigException: user is not authorize to change configuration.
-     * @throws IOException: an error occurred while writing the new config file.
+     * @throws \IOException: an error occurred while writing the new config file.
      */
     public function write($isLoggedIn)
     {
@@ -366,7 +362,7 @@ class ConfigManager
 /**
  * Exception used if a mandatory field is missing in given configuration.
  */
-class MissingFieldConfigException extends Exception
+class MissingFieldConfigException extends \Exception
 {
     public $field;
 
@@ -385,7 +381,7 @@ class MissingFieldConfigException extends Exception
 /**
  * Exception used if an unauthorized attempt to edit configuration has been made.
  */
-class UnauthorizedConfigException extends Exception
+class UnauthorizedConfigException extends \Exception
 {
     /**
      * Construct exception.

--- a/application/config/ConfigPhp.php
+++ b/application/config/ConfigPhp.php
@@ -1,4 +1,5 @@
 <?php
+namespace Shaarli\Config;
 
 /**
  * Class ConfigPhp (ConfigIO implementation)
@@ -115,7 +116,7 @@ class ConfigPhp implements ConfigIO
         if (!file_put_contents($filepath, $configStr)
             || strcmp(file_get_contents($filepath), $configStr) != 0
         ) {
-            throw new IOException(
+            throw new \IOException(
                 $filepath,
                 'Shaarli could not create the config file.
                 Please make sure Shaarli has the right to write in the folder is it installed in.'

--- a/application/config/ConfigPlugin.php
+++ b/application/config/ConfigPlugin.php
@@ -1,4 +1,6 @@
 <?php
+namespace Shaarli\Config;
+
 /**
  * Plugin configuration helper functions.
  *
@@ -112,7 +114,7 @@ function load_plugin_parameter_values($plugins, $conf)
 /**
  * Exception used if an error occur while saving plugin configuration.
  */
-class PluginConfigOrderException extends Exception
+class PluginConfigOrderException extends \Exception
 {
     /**
      * Construct exception.

--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,8 @@
             "Shaarli\\": "application",
             "Shaarli\\Api\\": "application/api/",
             "Shaarli\\Api\\Controllers\\": "application/api/controllers",
-            "Shaarli\\Api\\Exceptions\\": "application/api/exceptions"
+            "Shaarli\\Api\\Exceptions\\": "application/api/exceptions",
+            "Shaarli\\Config\\": "application/config/"
         }
     }
 }

--- a/index.php
+++ b/index.php
@@ -62,8 +62,6 @@ require_once __DIR__ . '/vendor/autoload.php';
 require_once 'application/ApplicationUtils.php';
 require_once 'application/Cache.php';
 require_once 'application/CachedPage.php';
-require_once 'application/config/ConfigManager.php';
-require_once 'application/config/ConfigPlugin.php';
 require_once 'application/FeedBuilder.php';
 require_once 'application/FileUtils.php';
 require_once 'application/HttpUtils.php';
@@ -80,6 +78,7 @@ require_once 'application/PluginManager.php';
 require_once 'application/Router.php';
 require_once 'application/Updater.php';
 use \Shaarli\ThemeUtils;
+use \Shaarli\Config\ConfigManager;
 
 // Ensure the PHP version is supported
 try {

--- a/tests/ApplicationUtilsTest.php
+++ b/tests/ApplicationUtilsTest.php
@@ -1,9 +1,10 @@
 <?php
+use Shaarli\Config\ConfigManager;
+
 /**
  * ApplicationUtils' tests
  */
 
-require_once 'application/config/ConfigManager.php';
 require_once 'application/ApplicationUtils.php';
 
 /**

--- a/tests/PluginManagerTest.php
+++ b/tests/PluginManagerTest.php
@@ -1,4 +1,5 @@
 <?php
+use Shaarli\Config\ConfigManager;
 
 /**
  * Plugin Manager tests

--- a/tests/Updater/UpdaterTest.php
+++ b/tests/Updater/UpdaterTest.php
@@ -1,6 +1,8 @@
 <?php
+use Shaarli\Config\ConfigJson;
+use Shaarli\Config\ConfigManager;
+use Shaarli\Config\ConfigPhp;
 
-require_once 'application/config/ConfigManager.php';
 require_once 'tests/Updater/DummyUpdater.php';
 require_once 'inc/rain.tpl.class.php';
 

--- a/tests/api/ApiMiddlewareTest.php
+++ b/tests/api/ApiMiddlewareTest.php
@@ -1,6 +1,7 @@
 <?php
-
 namespace Shaarli\Api;
+
+use Shaarli\Config\ConfigManager;
 
 use Slim\Container;
 use Slim\Http\Environment;
@@ -44,7 +45,7 @@ class ApiMiddlewareTest extends \PHPUnit_Framework_TestCase
      */
     public function setUp()
     {
-        $this->conf = new \ConfigManager('tests/utils/config/configJson.json.php');
+        $this->conf = new ConfigManager('tests/utils/config/configJson.json.php');
         $this->conf->set('api.secret', 'NapoleonWasALizard');
 
         $this->refDB = new \ReferenceLinkDB();

--- a/tests/api/controllers/GetLinkIdTest.php
+++ b/tests/api/controllers/GetLinkIdTest.php
@@ -2,6 +2,7 @@
 
 namespace Shaarli\Api\Controllers;
 
+use Shaarli\Config\ConfigManager;
 
 use Slim\Container;
 use Slim\Http\Environment;
@@ -25,7 +26,7 @@ class GetLinkIdTest extends \PHPUnit_Framework_TestCase
     protected static $testDatastore = 'sandbox/datastore.php';
 
     /**
-     * @var \ConfigManager instance
+     * @var ConfigManager instance
      */
     protected $conf;
 
@@ -54,7 +55,7 @@ class GetLinkIdTest extends \PHPUnit_Framework_TestCase
      */
     public function setUp()
     {
-        $this->conf = new \ConfigManager('tests/utils/config/configJson');
+        $this->conf = new ConfigManager('tests/utils/config/configJson');
         $this->refDB = new \ReferenceLinkDB();
         $this->refDB->write(self::$testDatastore);
 

--- a/tests/api/controllers/GetLinksTest.php
+++ b/tests/api/controllers/GetLinksTest.php
@@ -1,7 +1,7 @@
 <?php
-
 namespace Shaarli\Api\Controllers;
 
+use Shaarli\Config\ConfigManager;
 
 use Slim\Container;
 use Slim\Http\Environment;
@@ -25,7 +25,7 @@ class GetLinksTest extends \PHPUnit_Framework_TestCase
     protected static $testDatastore = 'sandbox/datastore.php';
 
     /**
-     * @var \ConfigManager instance
+     * @var ConfigManager instance
      */
     protected $conf;
 
@@ -54,7 +54,7 @@ class GetLinksTest extends \PHPUnit_Framework_TestCase
      */
     public function setUp()
     {
-        $this->conf = new \ConfigManager('tests/utils/config/configJson');
+        $this->conf = new ConfigManager('tests/utils/config/configJson');
         $this->refDB = new \ReferenceLinkDB();
         $this->refDB->write(self::$testDatastore);
 

--- a/tests/api/controllers/InfoTest.php
+++ b/tests/api/controllers/InfoTest.php
@@ -1,6 +1,7 @@
 <?php
-
 namespace Shaarli\Api\Controllers;
+
+use Shaarli\Config\ConfigManager;
 
 use Slim\Container;
 use Slim\Http\Environment;
@@ -22,7 +23,7 @@ class InfoTest extends \PHPUnit_Framework_TestCase
     protected static $testDatastore = 'sandbox/datastore.php';
 
     /**
-     * @var \ConfigManager instance
+     * @var ConfigManager instance
      */
     protected $conf;
 
@@ -46,7 +47,7 @@ class InfoTest extends \PHPUnit_Framework_TestCase
      */
     public function setUp()
     {
-        $this->conf = new \ConfigManager('tests/utils/config/configJson.json.php');
+        $this->conf = new ConfigManager('tests/utils/config/configJson.json.php');
         $this->refDB = new \ReferenceLinkDB();
         $this->refDB->write(self::$testDatastore);
 
@@ -84,7 +85,7 @@ class InfoTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('Shaarli', $data['settings']['title']);
         $this->assertEquals('?', $data['settings']['header_link']);
         $this->assertEquals('UTC', $data['settings']['timezone']);
-        $this->assertEquals(\ConfigManager::$DEFAULT_PLUGINS, $data['settings']['enabled_plugins']);
+        $this->assertEquals(ConfigManager::$DEFAULT_PLUGINS, $data['settings']['enabled_plugins']);
         $this->assertEquals(false, $data['settings']['default_private_links']);
 
         $title = 'My links';

--- a/tests/config/ConfigJsonTest.php
+++ b/tests/config/ConfigJsonTest.php
@@ -1,11 +1,10 @@
 <?php
-
-require_once 'application/config/ConfigJson.php';
+namespace Shaarli\Config;
 
 /**
  * Class ConfigJsonTest
  */
-class ConfigJsonTest extends PHPUnit_Framework_TestCase
+class ConfigJsonTest extends \PHPUnit_Framework_TestCase
 {
     /**
      * @var ConfigJson
@@ -40,7 +39,7 @@ class ConfigJsonTest extends PHPUnit_Framework_TestCase
     /**
      * Read a non existent config file -> empty array.
      *
-     * @expectedException Exception
+     * @expectedException \Exception
      * @expectedExceptionMessage An error occurred while parsing JSON file: error code #4
      */
     public function testReadInvalidJson()
@@ -112,7 +111,7 @@ class ConfigJsonTest extends PHPUnit_Framework_TestCase
     /**
      * Write to invalid path.
      *
-     * @expectedException IOException
+     * @expectedException \IOException
      */
     public function testWriteInvalidArray()
     {
@@ -123,7 +122,7 @@ class ConfigJsonTest extends PHPUnit_Framework_TestCase
     /**
      * Write to invalid path.
      *
-     * @expectedException IOException
+     * @expectedException \IOException
      */
     public function testWriteInvalidBlank()
     {

--- a/tests/config/ConfigManagerTest.php
+++ b/tests/config/ConfigManagerTest.php
@@ -1,4 +1,5 @@
 <?php
+namespace Shaarli\Config;
 
 /**
  * Unit tests for Class ConfigManagerTest
@@ -6,7 +7,7 @@
  * Note: it only test the manager with ConfigJson,
  *  ConfigPhp is only a workaround to handle the transition to JSON type.
  */
-class ConfigManagerTest extends PHPUnit_Framework_TestCase
+class ConfigManagerTest extends \PHPUnit_Framework_TestCase
 {
     /**
      * @var ConfigManager
@@ -83,7 +84,7 @@ class ConfigManagerTest extends PHPUnit_Framework_TestCase
     /**
      * Set with an empty key.
      *
-     * @expectedException Exception
+     * @expectedException \Exception
      * @expectedExceptionMessageRegExp #^Invalid setting key parameter. String expected, got.*#
      */
     public function testSetEmptyKey()
@@ -94,7 +95,7 @@ class ConfigManagerTest extends PHPUnit_Framework_TestCase
     /**
      * Set with an array key.
      *
-     * @expectedException Exception
+     * @expectedException \Exception
      * @expectedExceptionMessageRegExp #^Invalid setting key parameter. String expected, got.*#
      */
     public function testSetArrayKey()
@@ -105,7 +106,7 @@ class ConfigManagerTest extends PHPUnit_Framework_TestCase
     /**
      * Try to write the config without mandatory parameter (e.g. 'login').
      *
-     * @expectedException MissingFieldConfigException
+     * @expectedException Shaarli\Config\MissingFieldConfigException
      */
     public function testWriteMissingParameter()
     {

--- a/tests/config/ConfigPhpTest.php
+++ b/tests/config/ConfigPhpTest.php
@@ -1,11 +1,10 @@
 <?php
-
-require_once 'application/config/ConfigPhp.php';
+namespace Shaarli\Config;
 
 /**
  * Class ConfigPhpTest
  */
-class ConfigPhpTest extends PHPUnit_Framework_TestCase
+class ConfigPhpTest extends \PHPUnit_Framework_TestCase
 {
     /**
      * @var ConfigPhp

--- a/tests/config/ConfigPluginTest.php
+++ b/tests/config/ConfigPluginTest.php
@@ -1,4 +1,6 @@
 <?php
+namespace Shaarli\Config;
+
 /**
  * Config' tests
  */
@@ -8,7 +10,7 @@ require_once 'application/config/ConfigPlugin.php';
 /**
  * Unitary tests for Shaarli config related functions
  */
-class ConfigPluginTest extends PHPUnit_Framework_TestCase
+class ConfigPluginTest extends \PHPUnit_Framework_TestCase
 {
     /**
      * Test save_plugin_config with valid data.
@@ -39,7 +41,7 @@ class ConfigPluginTest extends PHPUnit_Framework_TestCase
     /**
      * Test save_plugin_config with invalid data.
      *
-     * @expectedException              PluginConfigOrderException
+     * @expectedException Shaarli\Config\PluginConfigOrderException
      */
     public function testSavePluginConfigInvalid()
     {

--- a/tests/plugins/PluginIssoTest.php
+++ b/tests/plugins/PluginIssoTest.php
@@ -1,4 +1,5 @@
 <?php
+use Shaarli\Config\ConfigManager;
 
 require_once 'plugins/isso/isso.php';
 

--- a/tests/plugins/PluginMarkdownTest.php
+++ b/tests/plugins/PluginMarkdownTest.php
@@ -1,4 +1,5 @@
 <?php
+use Shaarli\Config\ConfigManager;
 
 /**
  * PluginMarkdownTest.php

--- a/tests/plugins/PluginPubsubhubbubTest.php
+++ b/tests/plugins/PluginPubsubhubbubTest.php
@@ -1,4 +1,5 @@
 <?php
+use Shaarli\Config\ConfigManager;
 
 require_once 'plugins/pubsubhubbub/pubsubhubbub.php';
 require_once 'application/Router.php';

--- a/tests/plugins/PluginQrcodeTest.php
+++ b/tests/plugins/PluginQrcodeTest.php
@@ -1,5 +1,4 @@
 <?php
-
 /**
  * PluginQrcodeTest.php
  */

--- a/tests/plugins/PluginReadityourselfTest.php
+++ b/tests/plugins/PluginReadityourselfTest.php
@@ -1,4 +1,5 @@
 <?php
+use Shaarli\Config\ConfigManager;
 
 /**
  * PluginReadityourselfTest.php.php

--- a/tests/plugins/PluginWallabagTest.php
+++ b/tests/plugins/PluginWallabagTest.php
@@ -1,4 +1,5 @@
 <?php
+use Shaarli\Config\ConfigManager;
 
 /**
  * PluginWallabagTest.php.php


### PR DESCRIPTION
Namespaces have been introduced with the REST API, and should be generalized
to the whole codebase to manage object scope and benefit from autoloading.

See:
- https://secure.php.net/manual/en/language.namespaces.php
- http://www.php-fig.org/psr/psr-4/