### PR TITLE
Move config exception to dedicated classes with proper namespace

### DIFF
--- a/application/config/ConfigManager.php
+++ b/application/config/ConfigManager.php
@@ -1,6 +1,9 @@
 <?php
 namespace Shaarli\Config;
 
+use Shaarli\Config\Exception\MissingFieldConfigException;
+use Shaarli\Config\Exception\UnauthorizedConfigException;
+
 /**
  * Class ConfigManager
  *
@@ -356,38 +359,5 @@ class ConfigManager
     public function setConfigIO($configIO)
     {
         $this->configIO = $configIO;
-    }
-}
-
-/**
- * Exception used if a mandatory field is missing in given configuration.
- */
-class MissingFieldConfigException extends \Exception
-{
-    public $field;
-
-    /**
-     * Construct exception.
-     *
-     * @param string $field field name missing.
-     */
-    public function __construct($field)
-    {
-        $this->field = $field;
-        $this->message = 'Configuration value is required for '. $this->field;
-    }
-}
-
-/**
- * Exception used if an unauthorized attempt to edit configuration has been made.
- */
-class UnauthorizedConfigException extends \Exception
-{
-    /**
-     * Construct exception.
-     */
-    public function __construct()
-    {
-        $this->message = 'You are not authorized to alter config.';
     }
 }

--- a/application/config/exception/MissingFieldConfigException.php
+++ b/application/config/exception/MissingFieldConfigException.php
@@ -1,0 +1,23 @@
+<?php
+
+
+namespace Shaarli\Config\Exception;
+
+/**
+ * Exception used if a mandatory field is missing in given configuration.
+ */
+class MissingFieldConfigException extends \Exception
+{
+    public $field;
+
+    /**
+     * Construct exception.
+     *
+     * @param string $field field name missing.
+     */
+    public function __construct($field)
+    {
+        $this->field = $field;
+        $this->message = 'Configuration value is required for '. $this->field;
+    }
+}

--- a/application/config/exception/UnauthorizedConfigException.php
+++ b/application/config/exception/UnauthorizedConfigException.php
@@ -1,0 +1,18 @@
+<?php
+
+
+namespace Shaarli\Config\Exception;
+
+/**
+ * Exception used if an unauthorized attempt to edit configuration has been made.
+ */
+class UnauthorizedConfigException extends \Exception
+{
+    /**
+     * Construct exception.
+     */
+    public function __construct()
+    {
+        $this->message = 'You are not authorized to alter config.';
+    }
+}

--- a/tests/config/ConfigManagerTest.php
+++ b/tests/config/ConfigManagerTest.php
@@ -106,7 +106,7 @@ class ConfigManagerTest extends \PHPUnit_Framework_TestCase
     /**
      * Try to write the config without mandatory parameter (e.g. 'login').
      *
-     * @expectedException Shaarli\Config\MissingFieldConfigException
+     * @expectedException Shaarli\Config\Exception\MissingFieldConfigException
      */
     public function testWriteMissingParameter()
     {


### PR DESCRIPTION
General rule: all classes must be in a dedicated file ; file containing only functions shouldn't have a namespace.

This PR is based on #792, check only the last commit.