### PR TITLE
security: escape HTML entities when using Markdown

### DIFF
--- a/plugins/markdown/markdown.php
+++ b/plugins/markdown/markdown.php
@@ -218,7 +218,7 @@ function process_markdown($description)
     $processedDescription = reverse_space2nbsp($processedDescription);
     $processedDescription = unescape($processedDescription);
     $processedDescription = $parsedown
-        ->setMarkupEscaped(false)
+        ->setMarkupEscaped(true)
         ->setBreaksEnabled(true)
         ->text($processedDescription);
     $processedDescription = sanitize_html($processedDescription);

--- a/tests/plugins/PluginMarkdownTest.php
+++ b/tests/plugins/PluginMarkdownTest.php
@@ -149,4 +149,22 @@ class PluginMarkdownTest extends PHPUnit_Framework_TestCase
         $data = hook_markdown_render_daily($data);
         $this->assertEquals($str, $data['cols'][0][0]['formatedDescription']);
     }
+
+    /**
+     * Make sure that the HTML tags are escaped.
+     */
+    public function testMarkdownWithHtmlEscape()
+    {
+        $md = '**strong** <strong>strong</strong>';
+        $html = '<div class="markdown"><p><strong>strong</strong> &lt;strong&gt;strong&lt;/strong&gt;</p></div>';
+        $data = array(
+            'links' => array(
+                0 => array(
+                    'description' => $md,
+                ),
+            ),
+        );
+        $data = hook_markdown_render_linklist($data);
+        $this->assertEquals($html, $data['links'][0]['description']);
+    }
 }


### PR DESCRIPTION
Adapted from https://github.com/shaarli/Shaarli/pull/785