### PR TITLE
Proper error if the conf file is invalid instead of fatal error

### DIFF
--- a/application/config/ConfigJson.php
+++ b/application/config/ConfigJson.php
@@ -21,8 +21,14 @@ class ConfigJson implements ConfigIO
         $data = str_replace(self::getPhpSuffix(), '', $data);
         $data = json_decode($data, true);
         if ($data === null) {
-            $error = json_last_error();
-            throw new \Exception('An error occurred while parsing JSON file: error code #'. $error);
+            $errorCode = json_last_error();
+            $error  = 'An error occurred while parsing JSON configuration file ('. $filepath .'): error code #';
+            $error .= $errorCode. '<br>➜ <code>' . json_last_error_msg() .'</code>';
+            if ($errorCode === JSON_ERROR_SYNTAX) {
+                $error .= '<br>Please check your JSON syntax (without PHP comment tags) using a JSON lint tool such as ';
+                $error .= '<a href="http://jsonlint.com/">jsonlint.com</a>.';
+            }
+            throw new \Exception($error);
         }
         return $data;
     }

--- a/application/config/ConfigManager.php
+++ b/application/config/ConfigManager.php
@@ -81,7 +81,11 @@ class ConfigManager
      */
     protected function load()
     {
-        $this->loadedConfig = $this->configIO->read($this->getConfigFileExt());
+        try {
+            $this->loadedConfig = $this->configIO->read($this->getConfigFileExt());
+        } catch (\Exception $e) {
+            die($e->getMessage());
+        }
         $this->setDefaultValues();
     }
 

--- a/tests/config/ConfigJsonTest.php
+++ b/tests/config/ConfigJsonTest.php
@@ -40,7 +40,7 @@ class ConfigJsonTest extends \PHPUnit_Framework_TestCase
      * Read a non existent config file -> empty array.
      *
      * @expectedException \Exception
-     * @expectedExceptionMessage An error occurred while parsing JSON file: error code #4
+     * @expectedExceptionMessageRegExp  /An error occurred while parsing JSON configuration file \([\w\/\.]+\): error code #4/
      */
     public function testReadInvalidJson()
     {


### PR DESCRIPTION
PHP 5.5 allow us to use `json_last_error_msg()` instead of a cryptic ID.

Error:

An error occurred while parsing configuration JSON file (data/config.json.php): error code #4
➜ Syntax error
Please check your JSON syntax (without PHP comment tags) using a JSON lint tool such as [jsonlint.com](http://jsonlint.com).