### PR TITLE
Use raw bytes for upload size hidden input

### DIFF
--- a/application/Utils.php
+++ b/application/Utils.php
@@ -414,23 +414,24 @@ function human_bytes($bytes)
         $bytes /= 1024;
     }
 
-    return $bytes . $units[$i];
+    return round($bytes) . $units[$i];
 }
 
 /**
  * Try to determine max file size for uploads (POST).
- * Returns an integer (in bytes)
+ * Returns an integer (in bytes) or formatted depending on $format.
  *
  * @param mixed $limitPost   post_max_size PHP setting
  * @param mixed $limitUpload upload_max_filesize PHP setting
+ * @param bool  $format      Format max upload size to human readable size
  *
- * @return int max upload file size in bytes.
+ * @return int|string max upload file size
  */
-function get_max_upload_size($limitPost, $limitUpload)
+function get_max_upload_size($limitPost, $limitUpload, $format = true)
 {
     $size1 = return_bytes($limitPost);
     $size2 = return_bytes($limitUpload);
     // Return the smaller of two:
     $maxsize = min($size1, $size2);
-    return human_bytes($maxsize);
+    return $format ? human_bytes($maxsize) : $maxsize;
 }

--- a/index.php
+++ b/index.php
@@ -1489,7 +1489,22 @@ function renderPage($conf, $pluginManager, $LINKSDB)
 
         if (! isset($_POST['token']) || ! isset($_FILES['filetoupload'])) {
             // Show import dialog
-            $PAGE->assign('maxfilesize', get_max_upload_size(ini_get('post_max_size'), ini_get('upload_max_filesize')));
+            $PAGE->assign(
+                'maxfilesize',
+                get_max_upload_size(
+                    ini_get('post_max_size'),
+                    ini_get('upload_max_filesize'),
+                    false
+                )
+            );
+            $PAGE->assign(
+                'maxfilesizeHuman',
+                get_max_upload_size(
+                    ini_get('post_max_size'),
+                    ini_get('upload_max_filesize'),
+                    true
+                )
+            );
             $PAGE->renderPage('import');
             exit;
         }

--- a/tests/UtilsTest.php
+++ b/tests/UtilsTest.php
@@ -392,18 +392,29 @@ class UtilsTest extends PHPUnit_Framework_TestCase
         $this->assertEquals('2GiB', human_bytes(strval(2 * (pow(1024, 3)))));
         $this->assertEquals('374B', human_bytes(374));
         $this->assertEquals('374B', human_bytes('374'));
+        $this->assertEquals('232kiB', human_bytes(237481));
         $this->assertEquals('Unlimited', human_bytes('0'));
         $this->assertEquals('Unlimited', human_bytes(0));
         $this->assertEquals('Setting not set', human_bytes(''));
     }
 
     /**
-     * Test get_max_upload_size
+     * Test get_max_upload_size with formatting
      */
     public function testGetMaxUploadSize()
     {
         $this->assertEquals('1MiB', get_max_upload_size(2097152, '1024k'));
         $this->assertEquals('1MiB', get_max_upload_size('1m', '2m'));
         $this->assertEquals('100B', get_max_upload_size(100, 100));
+    }
+
+    /**
+     * Test get_max_upload_size without formatting
+     */
+    public function testGetMaxUploadSizeRaw()
+    {
+        $this->assertEquals('1048576', get_max_upload_size(2097152, '1024k', false));
+        $this->assertEquals('1048576', get_max_upload_size('1m', '2m', false));
+        $this->assertEquals('100', get_max_upload_size(100, 100, false));
     }
 }

--- a/tpl/default/import.html
+++ b/tpl/default/import.html
@@ -18,6 +18,7 @@
       <div class="center" id="import-field">
         <input type="hidden" name="MAX_FILE_SIZE" value="{$maxfilesize}">
         <input type="file" name="filetoupload">
+        <p><br>Maximum size allowed: <strong>{$maxfilesizeHuman}</strong></p>
       </div>
 
       <div class="pure-g">


### PR DESCRIPTION
I forgot that the upload size is also handled by an hidden field, which doesn't support human readable values and is currently blocking any upload.