### PR TITLE
Modify database to allow for user-defined tag separators

### DIFF
--- a/application/FeedBuilder.php
+++ b/application/FeedBuilder.php
@@ -169,9 +169,9 @@ class FeedBuilder
             $this->latestDate = $upDate;
         }
 
-        $taglist = array_filter(explode(' ', $link['tags']), 'strlen');
-        uasort($taglist, 'strcasecmp');
-        $link['taglist'] = $taglist;
+        $tags = array_filter($link['tags'], 'strlen');
+        uasort($tags, 'strcasecmp');
+        $link['tags'] = $tags;
 
         return $link;
     }

--- a/application/LinkDB.php
+++ b/application/LinkDB.php
@@ -263,7 +263,7 @@ To learn how to use Shaarli, consult the link "Help/documentation" at the bottom
 You use the community supported version of the original Shaarli project, by Sebastien Sauvage.',
             'private'=>0,
             'created'=> new DateTime(),
-            'tags'=>'opensource software'
+            'tags'=> array('open source', 'software')
         );
         $link['shorturl'] = link_small_hash($link['created'], $link['id']);
         $this->links[1] = $link;
@@ -275,7 +275,7 @@ You use the community supported version of the original Shaarli project, by Seba
             'description'=>'Shhhh! I\'m a private link only YOU can see. You can delete me too.',
             'private'=>1,
             'created'=> new DateTime('1 minute ago'),
-            'tags'=>'secretstuff',
+            'tags'=> array('secret stuff'),
         );
         $link['shorturl'] = link_small_hash($link['created'], $link['id']);
         $this->links[0] = $link;
@@ -319,7 +319,11 @@ You use the community supported version of the original Shaarli project, by Seba
 
             // Remove private tags if the user is not logged in.
             if (! $this->loggedIn) {
-                $link['tags'] = preg_replace('/(^|\s+)\.[^($|\s)]+\s*/', ' ', $link['tags']);
+                foreach($link['tags'] as $id => $tag) {
+                    if (strlen($tag) > 0 && $tag[0] == '.') {
+                        unset($link['tags'][$id]);
+                    }
+                }
             }
 
             // Do not use the redirector for internal links (Shaarli note URL starting with a '?').
@@ -450,7 +454,7 @@ You use the community supported version of the original Shaarli project, by Seba
     public function filterSearch($filterRequest = array(), $casesensitive = false, $visibility = 'all')
     {
         // Filter link database according to parameters.
-        $searchtags = !empty($filterRequest['searchtags']) ? escape($filterRequest['searchtags']) : '';
+        $searchtags = !empty($filterRequest['searchtags']) ? $filterRequest['searchtags'] : array();
         $searchterm = !empty($filterRequest['searchterm']) ? escape($filterRequest['searchterm']) : '';
 
         // Search tags + fullsearch.
@@ -480,14 +484,14 @@ You use the community supported version of the original Shaarli project, by Seba
 
     /**
      * Returns the list of all tags
-     * Output: associative array key=tags, value=0
+     * Output: associative array key=tags, value=count
      */
     public function allTags()
     {
         $tags = array();
         $caseMapping = array();
         foreach ($this->links as $link) {
-            foreach (preg_split('/\s+/', $link['tags'], 0, PREG_SPLIT_NO_EMPTY) as $tag) {
+            foreach ($link['tags'] as $tag) {
                 if (empty($tag)) {
                     continue;
                 }

--- a/application/LinkFilter.php
+++ b/application/LinkFilter.php
@@ -242,7 +242,7 @@ class LinkFilter
      *
      * You can specify one or more tags, in an array
      *
-     * @param string $tags          list of tags (array)
+     * @param array  $tags          list of tags
      * @param bool   $casesensitive ignore case if false.
      * @param string $visibility    Optional: return only all/private/public links.
      *

--- a/application/LinkFilter.php
+++ b/application/LinkFilter.php
@@ -240,10 +240,9 @@ class LinkFilter
     /**
      * Returns the list of links associated with a given list of tags
      *
-     * You can specify one or more tags, separated by space or a comma, e.g.
-     *  print_r($mydb->filterTags('linux programming'));
+     * You can specify one or more tags, in an array
      *
-     * @param string $tags          list of tags separated by commas or blank spaces.
+     * @param string $tags          list of tags (array)
      * @param bool   $casesensitive ignore case if false.
      * @param string $visibility    Optional: return only all/private/public links.
      *
@@ -251,13 +250,12 @@ class LinkFilter
      */
     public function filterTags($tags, $casesensitive = false, $visibility = 'all')
     {
-        // Implode if array for clean up.
-        $tags = is_array($tags) ? trim(implode(' ', $tags)) : $tags;
         if (empty($tags)) {
             return $this->noFilter($visibility);
         }
 
-        $searchtags = self::tagsStrToArray($tags, $casesensitive);
+        $searchtags = $casesensitive ? $tags : self::lowerCase($tags);
+
         $filtered = array();
         if (empty($searchtags)) {
             return $filtered;
@@ -273,7 +271,7 @@ class LinkFilter
                 }
             }
 
-            $linktags = self::tagsStrToArray($link['tags'], $casesensitive);
+            $linktags = $casesensitive ? $link['tags'] : self::lowerCase($link['tags']);
 
             $found = true;
             for ($i = 0 ; $i < count($searchtags) && $found; $i++) {
@@ -347,22 +345,22 @@ class LinkFilter
     }
 
     /**
-     * Convert a list of tags (str) to an array. Also
-     * - handle case sensitivity.
-     * - accepts spaces commas as separator.
+     * Move tags to lower case.
      *
      * @param string $tags          string containing a list of tags.
-     * @param bool   $casesensitive will convert everything to lowercase if false.
      *
-     * @return array filtered tags string.
+     * @return array of lower case tags.
      */
-    public static function tagsStrToArray($tags, $casesensitive)
+    public static function lowerCase($tags)
     {
-        // We use UTF-8 conversion to handle various graphemes (i.e. cyrillic, or greek)
-        $tagsOut = $casesensitive ? $tags : mb_convert_case($tags, MB_CASE_LOWER, 'UTF-8');
-        $tagsOut = str_replace(',', ' ', $tagsOut);
-
-        return preg_split('/\s+/', $tagsOut, -1, PREG_SPLIT_NO_EMPTY);
+        $lowerCase = function($string) {
+            // We use UTF-8 conversion to handle various graphemes (i.e. cyrillic, or greek)
+            return mb_convert_case($string, MB_CASE_LOWER, 'UTF-8');
+        };
+        
+        $tagsOut = array_map($lowerCase, $tags);
+        
+        return array_values(array_filter($tagsOut, 'strlen'));
     }
 }
 

--- a/application/TagUtil.php
+++ b/application/TagUtil.php
@@ -12,11 +12,10 @@ class TagUtil
      * Creates a new tag utility object
      * 
      * @param string separators all separators
-     * @param string default_separator
      */
-    public function __construct($separators, $default_separator) {
+    public function __construct($separators) {
         $this->separators = $separators;
-        $this->default_separator = $default_separator;
+        $this->default_separator = substr($separators, 0, 1);
     }
     
     public function parseTags($tagString) {
@@ -41,5 +40,9 @@ class TagUtil
         return implode($this->default_separator.' ', $tags);
     }
     
+    public function getDefaultSeparator() {
+        return $this->default_separator;
+    }
+
 }
 ?>

--- a/application/TagUtil.php
+++ b/application/TagUtil.php
@@ -1,0 +1,45 @@
+<?php
+/**
+ *
+ */
+class TagUtil
+{
+    private $separators;
+    
+    private $default_separator;
+    
+    /** 
+     * Creates a new tag utility object
+     * 
+     * @param string separators all separators
+     * @param string default_separator
+     */
+    public function __construct($separators, $default_separator) {
+        $this->separators = $separators;
+        $this->default_separator = $default_separator;
+    }
+    
+    public function parseTags($tagString) {
+        // empty string means empty array of tags
+        if (empty($tagString))
+            return array();
+
+        $tagString = escape($tagString);
+        // Remove spaces and tag separators at beginning and end of string.
+        $tagString = trim($tagString, $this->separators." ");
+        // Remove multiple spaces.
+        $tagString = preg_replace('/\s\s+/', ' ', $tagString);
+        // Remove first '-' char in tags.
+        $tagString = preg_replace('/(^| )\-/', '$1', $tagString);
+        // Split and remove duplicates.
+        $tags = array_unique(preg_split('/\s*['.$this->separators.']+\s*/', $tagString, -1, PREG_SPLIT_NO_EMPTY));
+    
+        return $tags;
+    }
+
+    public function serializeTags($tags) {
+        return implode($this->default_separator.' ', $tags);
+    }
+    
+}
+?>

--- a/application/TagUtil.php
+++ b/application/TagUtil.php
@@ -39,7 +39,7 @@ class TagUtil
         // Remove first '-' char in tags.
         $tagString = preg_replace('/(^| )\-/', '$1', $tagString);
         // Split and remove duplicates.
-        $tags = array_unique(preg_split('/\s*['.$this->separators.']+\s*/', $tagString, -1, PREG_SPLIT_NO_EMPTY));
+        $tags = array_unique(preg_split('/\s*['.preg_quote($this->separators).']+\s*/', $tagString, -1, PREG_SPLIT_NO_EMPTY));
     
         return $tags;
     }

--- a/application/TagUtil.php
+++ b/application/TagUtil.php
@@ -18,10 +18,18 @@ class TagUtil
         $this->default_separator = substr($separators, 0, 1);
     }
     
+    /**
+     * Parse a string of tags and return an array
+     *
+     * @param string $tagString    string of tags separated by any of the allowed
+     *                             tag separators
+     *
+     * @return array the tags stored in an array
+     */
     public function parseTags($tagString) {
         // empty string means empty array of tags
         if (empty($tagString))
-            return array();
+            return [];
 
         $tagString = escape($tagString);
         // Remove spaces and tag separators at beginning and end of string.
@@ -36,10 +44,18 @@ class TagUtil
         return $tags;
     }
 
+    /**
+     * Convert an array of tags into a string, using the default separator.
+     *
+     * @param array $tags the tags you want listed as a string
+     */
     public function serializeTags($tags) {
         return implode($this->default_separator.' ', $tags);
     }
     
+    /**
+     * Give the default separator, being the first of the separators set in configuration
+     */
     public function getDefaultSeparator() {
         return $this->default_separator;
     }

--- a/application/Updater.php
+++ b/application/Updater.php
@@ -253,7 +253,7 @@ class Updater
         $linklist = $this->linkDB->filterSearch();
         foreach ($linklist as $key => $link) {
             $link['tags'] = preg_replace('/(^| )\-/', '$1', $link['tags']);
-            $link['tags'] = implode(' ', array_unique(LinkFilter::tagsStrToArray($link['tags'], true)));
+            $link['tags'] = array_unique(LinkFilter::lowerCase($link['tags']));
             $this->linkDB[$key] = $link;
         }
         $this->linkDB->save($this->conf->get('resource.page_cache'));

--- a/application/config/ConfigManager.php
+++ b/application/config/ConfigManager.php
@@ -194,7 +194,6 @@ class ConfigManager
             'general.title',
             'general.header_link',
             'general.separators',
-            'general.default_separator',
             'privacy.default_private_links',
             'redirector.url',
         );
@@ -318,7 +317,6 @@ class ConfigManager
         $this->setEmpty('general.links_per_page', 20);
         $this->setEmpty('general.enabled_plugins', self::$DEFAULT_PLUGINS);
         $this->setEmpty('general.separators', ', ');
-        $this->setEmpty('general.default_separator', ' ');
 
         $this->setEmpty('updates.check_updates', false);
         $this->setEmpty('updates.check_updates_branch', 'stable');

--- a/application/config/ConfigManager.php
+++ b/application/config/ConfigManager.php
@@ -193,6 +193,8 @@ class ConfigManager
             'general.timezone',
             'general.title',
             'general.header_link',
+            'general.separators',
+            'general.default_separator',
             'privacy.default_private_links',
             'redirector.url',
         );
@@ -315,6 +317,8 @@ class ConfigManager
         $this->setEmpty('general.header_link', '?');
         $this->setEmpty('general.links_per_page', 20);
         $this->setEmpty('general.enabled_plugins', self::$DEFAULT_PLUGINS);
+        $this->setEmpty('general.separators', ', ');
+        $this->setEmpty('general.default_separator', ' ');
 
         $this->setEmpty('updates.check_updates', false);
         $this->setEmpty('updates.check_updates_branch', 'stable');

--- a/index.php
+++ b/index.php
@@ -1121,7 +1121,7 @@ function renderPage($conf, $pluginManager, $LINKSDB, $tagUtil)
             $conf->set('general.header_link', escape($_POST['titleLink']));
             $conf->set('resource.theme', escape($_POST['theme']));
             $conf->set('redirector.url', escape($_POST['redirector']));
-            $conf->set('general.separators', escape($_POST['separators']));
+            $conf->set('general.separators', $_POST['separators']);
             $conf->set('security.session_protection_disabled', !empty($_POST['disablesessionprotection']));
             $conf->set('privacy.default_private_links', !empty($_POST['privateLinkByDefault']));
             $conf->set('feed.rss_permalinks', !empty($_POST['enableRssPermalinks']));

--- a/index.php
+++ b/index.php
@@ -128,7 +128,7 @@ RainTPL::$cache_dir = $conf->get('resource.raintpl_tmp'); // cache directory
 
 // Instance of the TagUtil class used to parse and serialize tag lists,
 // respectively from forms and for display.
-$tagUtil = new TagUtil($conf->get('general.separators'), $conf->get('general.default_separator'));
+$tagUtil = new TagUtil($conf->get('general.separators'));
 
 $pluginManager = new PluginManager($conf);
 $pluginManager->load($conf->get('general.enabled_plugins'));
@@ -1122,11 +1122,6 @@ function renderPage($conf, $pluginManager, $LINKSDB, $tagUtil)
             $conf->set('resource.theme', escape($_POST['theme']));
             $conf->set('redirector.url', escape($_POST['redirector']));
             $conf->set('general.separators', escape($_POST['separators']));
-            // TODO: inform the user if she chose a default separator that is not
-            //       already defined as a separator (in which case it is ignored)
-            if (!empty($_POST['defaultSeparator'])
-                && strpos($conf->get('general.separators'), $_POST['defaultSeparator']) !== false)
-                    $conf->set('general.default_separator', $_POST['defaultSeparator']);
             $conf->set('security.session_protection_disabled', !empty($_POST['disablesessionprotection']));
             $conf->set('privacy.default_private_links', !empty($_POST['privateLinkByDefault']));
             $conf->set('feed.rss_permalinks', !empty($_POST['enableRssPermalinks']));
@@ -1159,7 +1154,6 @@ function renderPage($conf, $pluginManager, $LINKSDB, $tagUtil)
             $PAGE->assign('redirector', $conf->get('redirector.url'));
             list($timezone_form, $timezone_js) = generateTimeZoneForm($conf->get('general.timezone'));
             $PAGE->assign('separators', $conf->get('general.separators'));
-            $PAGE->assign('defaultSeparator', $conf->get('general.default_separator'));
             $PAGE->assign('timezone_form', $timezone_form);
             $PAGE->assign('timezone_js',$timezone_js);
             $PAGE->assign('private_links_default', $conf->get('privacy.default_private_links', false));
@@ -1363,7 +1357,7 @@ function renderPage($conf, $pluginManager, $LINKSDB, $tagUtil)
         if (!$link) { header('Location: ?'); exit; } // Link not found in database.
         $link['linkdate'] = $link['created']->format(LinkDB::LINK_DATE_FORMAT);
         $data = array(
-            'default_separator' => $conf->get('general.default_separator'),
+            'default_separator' => $tagUtil->getDefaultSeparator(),
             'link' => $link,
             'link_is_new' => false,
             'http_referer' => (isset($_SERVER['HTTP_REFERER']) ? escape($_SERVER['HTTP_REFERER']) : ''),
@@ -1432,7 +1426,7 @@ function renderPage($conf, $pluginManager, $LINKSDB, $tagUtil)
         }
 
         $data = array(
-            'default_separator' => $conf->get('general.default_separator'),
+            'default_separator' => $tagUtil->getDefaultSeparator(),
             'link' => $link,
             'link_is_new' => $link_is_new,
             'http_referer' => (isset($_SERVER['HTTP_REFERER']) ? escape($_SERVER['HTTP_REFERER']) : ''),
@@ -1682,8 +1676,7 @@ function buildLinkList($PAGE,$LINKSDB, $conf, $tagUtil, $pluginManager)
         'search_tags_list' => $searchtagslist,
         'redirector' => $conf->get('redirector.url'),  // Optional redirector URL.
         'links' => $linkDisp,
-        'separators' => $conf->get('general.separators'),
-        'default_separator' => $conf->get('general.default_separator'), // TODO: fix auto-completion for custom separator
+        'separators' => $conf->get('general.separators'),// TODO: fix auto-completion for custom separator
         'tags' => $LINKSDB->allTags(),
     );
 

--- a/index.php
+++ b/index.php
@@ -1589,7 +1589,7 @@ function renderPage($conf, $pluginManager, $LINKSDB, $tagUtil)
 function buildLinkList($PAGE,$LINKSDB, $conf, $tagUtil, $pluginManager)
 {
     // Used in templates
-    $searchtags = !empty($_GET['searchtags']) ? $tagUtil->parseTags(escape($_GET['searchtags'])) : array();
+    $searchtags = !empty($_GET['searchtags']) ? $tagUtil->parseTags(escape($_GET['searchtags'])) : [];
     $searchtagslist = $tagUtil->serializeTags($searchtags);
     $searchterm = !empty($_GET['searchterm']) ? escape(normalize_spaces($_GET['searchterm'])) : '';
 

--- a/plugins/markdown/markdown.php
+++ b/plugins/markdown/markdown.php
@@ -82,13 +82,13 @@ function hook_markdown_render_daily($data, $conf)
 /**
  * Check if noMarkdown is set in tags.
  *
- * @param string $tags tag list
+ * @param array $tags tag list
  *
  * @return bool true if markdown should be disabled on this link.
  */
 function noMarkdownTag($tags)
 {
-    return preg_match('/(^|\s)'. NO_MD_TAG .'(\s|$)/', $tags);
+    return in_array(NO_MD_TAG, $tags);
 }
 
 /**
@@ -108,7 +108,10 @@ function stripNoMarkdownTag($link)
     }
 
     if (!empty($link['tags'])) {
-        str_replace(NO_MD_TAG, '', $link['tags']);
+        $offset = array_search(NO_MD_TAG, $link['tags']);
+        if ($offset !== false) {
+            unset($link['tags'][$offset]);
+        }
     }
 
     return $link;

--- a/tpl/default/configure.html
+++ b/tpl/default/configure.html
@@ -102,6 +102,36 @@
       </div>
       <div class="clear"></div>
       <div class="pure-g">
+        <div class="pure-u-lg-{$ratioLabel} pure-u-1 ">
+          <div class="form-label">
+            <label for="separators">
+              <span class="label-name">{'Tag separators'|t}</span><br>
+              <span class="label-desc">{'You can add multiple separators, e.g.'|t} "<em>,;</em>"</span>
+            </label>
+          </div>
+        </div>
+        <div class="pure-u-lg-{$ratioInput} pure-u-1 ">
+          <div class="form-input">
+            <input type="text" name="separators" id="separators" size="50" value="{$separators}">
+          </div>
+        </div>
+      </div>
+      <div class="pure-g">
+        <div class="pure-u-lg-{$ratioLabel} pure-u-1 ">
+          <div class="form-label">
+            <label for="defaultSeparator">
+              <span class="label-name">{'Default tag separator'|t}</span><br>
+              <span class="label-desc">{'Used for display. It must be one the separators above, e.g.'|t} "<em>;</em>"</span>
+            </label>
+          </div>
+        </div>
+        <div class="pure-u-lg-{$ratioInput} pure-u-1 ">
+          <div class="form-input">
+            <input type="text" name="defaultSeparator" id="defaultSeparator" size="50" value="{$defaultSeparator}">
+          </div>
+        </div>
+      </div>
+      <div class="pure-g">
         <div class="pure-u-lg-{$ratioLabel} pure-u-{$ratioLabelMobile} ">
           <div class="form-label">
             <label for="disablesessionprotection">

--- a/tpl/default/configure.html
+++ b/tpl/default/configure.html
@@ -117,21 +117,6 @@
         </div>
       </div>
       <div class="pure-g">
-        <div class="pure-u-lg-{$ratioLabel} pure-u-1 ">
-          <div class="form-label">
-            <label for="defaultSeparator">
-              <span class="label-name">{'Default tag separator'|t}</span><br>
-              <span class="label-desc">{'Used for display. It must be one the separators above, e.g.'|t} "<em>;</em>"</span>
-            </label>
-          </div>
-        </div>
-        <div class="pure-u-lg-{$ratioInput} pure-u-1 ">
-          <div class="form-input">
-            <input type="text" name="defaultSeparator" id="defaultSeparator" size="50" value="{$defaultSeparator}">
-          </div>
-        </div>
-      </div>
-      <div class="pure-g">
         <div class="pure-u-lg-{$ratioLabel} pure-u-{$ratioLabelMobile} ">
           <div class="form-label">
             <label for="disablesessionprotection">

--- a/tpl/default/daily.html
+++ b/tpl/default/daily.html
@@ -76,7 +76,7 @@
                   <div class="daily-entry-description">{$link.formatedDescription}</div>
                   {if="$link.tags"}
                     <div class="daily-entry-tags center">
-                      {loop="link.taglist"}
+                      {loop="link.tags"}
                         <span class="label label-tag" title="Add tag">
                           {$value}
                         </span>

--- a/tpl/default/editlink.html
+++ b/tpl/default/editlink.html
@@ -35,7 +35,8 @@
         <label for="lf_tags">{'Tags'|t}</label>
       </div>
       <div>
-        <input type="text" name="lf_tags" id="lf_tags" value="{$link.tags}" class="lf_input autofocus"
+        <input type="text" name="lf_tags" id="lf_tags" class="lf_input autofocus"
+          value="{loop="$link.tags"}{$value}{$default_separator} {/loop}"
           data-list="{loop="$tags"}{$key}, {/loop}" data-multiple data-autofirst autocomplete="off" >
       </div>
 

--- a/tpl/default/export.bookmarks.html
+++ b/tpl/default/export.bookmarks.html
@@ -6,5 +6,5 @@
 <TITLE>{$pagetitle}</TITLE>
 <H1>Shaarli export of {$selection} bookmarks on {$date}</H1>
 <DL><p>{loop="links"}
-<DT><A HREF="{$value.url}" ADD_DATE="{$value.timestamp}" PRIVATE="{$value.private}" TAGS="{$value.taglist}">{$value.title}</A>{if="$value.description"}{$eol}<DD>{$value.description}{/if}{/loop}
+<DT><A HREF="{$value.url}" ADD_DATE="{$value.timestamp}" PRIVATE="{$value.private}" TAGS="{$value.tags}">{$value.title}</A>{if="$value.description"}{$eol}<DD>{$value.description}{/if}{/loop}
 </DL><p>

--- a/tpl/default/feed.atom.html
+++ b/tpl/default/feed.atom.html
@@ -29,7 +29,7 @@
         <updated>{$value.up_iso_date}</updated>
       {/if}
       <content type="html" xml:lang="{$language}"><![CDATA[{$value.description}]]></content>
-      {loop="$value.taglist"}
+      {loop="$value.tags"}
         <category scheme="{$index_url}?searchtags=" term="{$value|strtolower}" label="{$value}" />
       {/loop}
       {loop="$value.feed_plugins"}

--- a/tpl/default/feed.rss.html
+++ b/tpl/default/feed.rss.html
@@ -25,7 +25,7 @@
           <atom:modified>{$value.up_iso_date}</atom:modified>
         {/if}
         <description><![CDATA[{$value.description}]]></description>
-        {loop="$value.taglist"}
+        {loop="$value.tags"}
           <category domain="{$index_url}?searchtags=">{$value}</category>
         {/loop}
         {loop="$value.feed_plugins"}

--- a/tpl/default/linklist.html
+++ b/tpl/default/linklist.html
@@ -249,7 +249,6 @@
 
 <script>
     var separators = "{$separators}";
-    var defaultSpearator = "{$default_separator}";
 </script>
 {include="page.footer"}
 

--- a/tpl/default/linklist.html
+++ b/tpl/default/linklist.html
@@ -31,8 +31,8 @@
     <div class="pure-u-1 pure-u-lg-1-2">
       <form method="GET" class="tagfilter" name="tagfilter">
         <input type="text" tabindex="2" name="searchtags" placeholder="{'Filter by tag'|t}"
-               {if="!empty($search_tags)"}
-               value="{$search_tags}"
+               {if="!empty($search_tags_list)"}
+               value="{$search_tags_list}"
                {/if}
         autocomplete="off" data-multiple data-autofirst data-minChars="1"
         data-list="{loop="$tags"}{$key}, {/loop}"
@@ -98,9 +98,8 @@
           {'for'|t} <em><strong>{$search_term}</strong></em>
         {/if}
         {if="!empty($search_tags)"}
-          {$exploded_tags=explode(' ', $search_tags)}
           {'tagged'|t}
-          {loop="$exploded_tags"}
+          {loop="$search_tags"}
               <span class="label label-tag" title="{'Remove tag'|t}">
                 <a href="?removetag={function="urlencode($value)"}">{$value}<span class="remove"><i class="fa fa-times"></i></span></a>
               </span>
@@ -163,8 +162,8 @@
             {if="$value.tags"}
               <div class="linklist-item-tags">
                 <i class="fa fa-tags"></i>
-                {$tag_counter=count($value.taglist)}
-                {loop="value.taglist"}
+                {$tag_counter=count($value.tags)}
+                {loop="value.tags"}
                   <span class="label label-tag" title="Add tag">
                     <a href="?addtag={$value|urlencode}">{$value}</a>
                   </span>
@@ -248,6 +247,11 @@
   </div>
 </div>
 
+<script>
+    var separators = "{$separators}";
+    var defaultSpearator = "{$default_separator}";
+</script>
 {include="page.footer"}
+
 </body>
 </html>

--- a/tpl/vintage/configure.html
+++ b/tpl/vintage/configure.html
@@ -55,14 +55,6 @@
       </tr>
 
       <tr>
-        <td><b>Default tag separator</b></td>
-        <td>
-          <input type="text" name="defaultSeparator" id="defaultSeparator" size="50" value="{$defaultSeparator}"><br>
-          (used for display; must be one of the separators above e.g. '<i>;</i>')
-        </td>
-      </tr>
-
-      <tr>
         <td><b>Security:</b></td>
         <td>
           <input type="checkbox" name="disablesessionprotection" id="disablesessionprotection"

--- a/tpl/vintage/configure.html
+++ b/tpl/vintage/configure.html
@@ -47,6 +47,22 @@
       </tr>
 
       <tr>
+        <td><b>Tag separators</b></td>
+        <td>
+          <input type="text" name="separators" id="separators" size="50" value="{$separators}"><br>
+          (can be several separators e.g. '<i>,;</i>')
+        </td>
+      </tr>
+
+      <tr>
+        <td><b>Default tag separator</b></td>
+        <td>
+          <input type="text" name="defaultSeparator" id="defaultSeparator" size="50" value="{$defaultSeparator}"><br>
+          (used for display; must be one of the separators above e.g. '<i>;</i>')
+        </td>
+      </tr>
+
+      <tr>
         <td><b>Security:</b></td>
         <td>
           <input type="checkbox" name="disablesessionprotection" id="disablesessionprotection"

--- a/tpl/vintage/daily.html
+++ b/tpl/vintage/daily.html
@@ -60,7 +60,7 @@
                         {/if}
                         {if="$link.tags"}
                             <div class="dailyEntryTags">
-                                {loop="$link.taglist"}
+                                {loop="$link.tags"}
                                     {$value} -
                                 {/loop}
                             </div>

--- a/tpl/vintage/editlink.html
+++ b/tpl/vintage/editlink.html
@@ -23,7 +23,7 @@
             <label for="lf_title"><i>Title</i></label><br><input type="text" name="lf_title" id="lf_title" value="{$link.title}" class="lf_input"><br>
             <label for="lf_description"><i>Description</i></label><br><textarea name="lf_description" id="lf_description" rows="4" cols="25">{$link.description}</textarea><br>
             <label for="lf_tags"><i>Tags</i></label><br>
-            <input type="text" name="lf_tags" id="lf_tags" value="{$link.tags}" class="lf_input"
+            <input type="text" name="lf_tags" id="lf_tags" value="{loop="$link.tags"}{$value}{$default_separator} {/loop}" class="lf_input"
                 data-list="{loop="$tags"}{$key}, {/loop}" data-multiple autocomplete="off" ><br>
 
             {loop="$edit_link_plugin"}

--- a/tpl/vintage/export.bookmarks.html
+++ b/tpl/vintage/export.bookmarks.html
@@ -6,5 +6,5 @@
 <TITLE>{$pagetitle}</TITLE>
 <H1>Shaarli export of {$selection} bookmarks on {$date}</H1>
 <DL><p>{loop="$links"}
-<DT><A HREF="{$value.url}" ADD_DATE="{$value.timestamp}" PRIVATE="{$value.private}" TAGS="{$value.taglist}">{$value.title}</A>{if="$value.description"}{$eol}<DD>{$value.description}{/if}{/loop}
+<DT><A HREF="{$value.url}" ADD_DATE="{$value.timestamp}" PRIVATE="{$value.private}" TAGS="{$value.tags}">{$value.title}</A>{if="$value.description"}{$eol}<DD>{$value.description}{/if}{/loop}
 </DL><p>

--- a/tpl/vintage/feed.atom.html
+++ b/tpl/vintage/feed.atom.html
@@ -31,7 +31,7 @@
         <updated>{$value.up_iso_date}</updated>
       {/if}
       <content type="html" xml:lang="{$language}"><![CDATA[{$value.description}]]></content>
-      {loop="$value.taglist"}
+      {loop="$value.tags"}
         <category scheme="{$index_url}?searchtags=" term="{$value|strtolower}" label="{$value}" />
       {/loop}
       {loop="$value.feed_plugins"}

--- a/tpl/vintage/feed.rss.html
+++ b/tpl/vintage/feed.rss.html
@@ -27,7 +27,7 @@
           <atom:modified>{$value.up_iso_date}</atom:modified>
         {/if}
         <description><![CDATA[{$value.description}]]></description>
-        {loop="$value.taglist"}
+        {loop="$value.tags"}
           <category domain="{$index_url}?searchtags=">{$value}</category>
         {/loop}
         {loop="$value.feed_plugins"}

--- a/tpl/vintage/linklist.html
+++ b/tpl/vintage/linklist.html
@@ -19,8 +19,8 @@
         </form>
         <form method="GET" class="tagfilter" name="tagfilter">
             <input type="text" tabindex="2" name="searchtags" id="tagfilter_value" placeholder="Filter by tag"
-                {if="!empty($search_tags)"}
-                    value="{$search_tags}"
+                {if="!empty($search_tags_list)"}
+                    value="{$search_tags_list}"
                 {/if}
                 autocomplete="off" class="awesomplete" data-multiple data-minChars="1"
                 data-list="{loop="$tags"}{$key}, {/loop}"
@@ -62,9 +62,8 @@
                 for <em>{$search_term}</em>
             {/if}
             {if="!empty($search_tags)"}
-                {$exploded_tags=explode(' ', $search_tags)}
                 tagged
-                {loop="$exploded_tags"}
+                {loop="$search_tags"}
                     <span class="linktag" title="Remove tag">
                         <a href="?removetag={function="urlencode($value)"}">{$value} <span class="remove">x</span></a>
                     </span>
@@ -120,7 +119,7 @@
                 <a href="{$value.real_url}"><span class="linkurl" title="Short link">{$value.url}</span></a><br>
                 {if="$value.tags"}
                     <div class="linktaglist">
-                    {loop="$value.taglist"}<span class="linktag" title="Add tag"><a href="?addtag={$value|urlencode}">{$value}</a></span> {/loop}
+                    {loop="$value.tags"}<span class="linktag" title="Add tag"><a href="?addtag={$value|urlencode}">{$value}</a></span> {/loop}
                     </div>
                 {/if}
 
@@ -142,6 +141,10 @@
 
     {include="page.footer"}
 
+<script>
+	 var separators = "{$separators}";
+	 var defaultSpearator = "{$default_separator}";
+</script>
 <script src="inc/awesomplete.min.js#"></script>
 <script src="inc/awesomplete-multiple-tags.js#"></script>
 <script>

--- a/tpl/vintage/linklist.html
+++ b/tpl/vintage/linklist.html
@@ -143,7 +143,6 @@
 
 <script>
 	 var separators = "{$separators}";
-	 var defaultSpearator = "{$default_separator}";
 </script>
 <script src="inc/awesomplete.min.js#"></script>
 <script src="inc/awesomplete-multiple-tags.js#"></script>


### PR DESCRIPTION
This aims at solving #594. However, it is based on an old version of Shaarli and I don't know exactly how I should rebase it on the current version. Any help is welcome.

Changes:
- tags are stored in the database in arrays instead of strings (allow for abstraction of the separator used)
- the user can change the tag separators and the default separator (the one used to display tags in edit form)

Missing changes:
- test code
- tool to upgrade database
- manage custom separators in auto-completion (awesomeplete)