### PR TITLE
Add history entries for API endpoint

### DIFF
--- a/application/FileUtils.php
+++ b/application/FileUtils.php
@@ -26,7 +26,7 @@ class FileUtils
      * The file will be created if it doesn't exist.
      *
      * @param string $file    File path.
-     * @param string $content Content to write.
+     * @param mixed  $content Content to write.
      *
      * @return int|bool Number of bytes written or false if it fails.
      *

--- a/application/History.php
+++ b/application/History.php
@@ -135,7 +135,7 @@ class History
 
         $item = [
             'event' => $status,
-            'datetime' => (new DateTime())->format(DateTime::ATOM),
+            'datetime' => new DateTime(),
             'id' => $id !== null ? $id : '',
         ];
         $this->history = array_merge([$item], $this->history);
@@ -177,7 +177,7 @@ class History
     {
         $comparaison = new DateTime('-'. $this->retentionTime . ' seconds');
         foreach ($this->history as $key => $value) {
-            if (DateTime::createFromFormat(DateTime::ATOM, $value['datetime']) < $comparaison) {
+            if ($value['datetime'] < $comparaison) {
                 unset($this->history[$key]);
             }
         }

--- a/application/Updater.php
+++ b/application/Updater.php
@@ -440,6 +440,17 @@ class Updater
         $this->conf->write($this->isLoggedIn);
         return true;
     }
+
+    /**
+     * Reset history store file due to date format change.
+     */
+    public function updateMethodResetHistoryFile()
+    {
+        if (is_file($this->conf->get('resource.history'))) {
+            unlink($this->conf->get('resource.history'));
+        }
+        return true;
+    }
 }
 
 /**

--- a/application/api/ApiMiddleware.php
+++ b/application/api/ApiMiddleware.php
@@ -4,6 +4,7 @@ namespace Shaarli\Api;
 use Shaarli\Api\Exceptions\ApiException;
 use Shaarli\Api\Exceptions\ApiAuthorizationException;
 
+use Shaarli\Config\ConfigManager;
 use Slim\Container;
 use Slim\Http\Request;
 use Slim\Http\Response;
@@ -31,7 +32,7 @@ class ApiMiddleware
     protected $container;
 
     /**
-     * @var \ConfigManager instance.
+     * @var ConfigManager instance.
      */
     protected $conf;
 
@@ -121,7 +122,7 @@ class ApiMiddleware
      *
      * FIXME! LinkDB could use a refactoring to avoid this trick.
      *
-     * @param \ConfigManager $conf instance.
+     * @param ConfigManager $conf instance.
      */
     protected function setLinkDb($conf)
     {

--- a/application/api/controllers/ApiController.php
+++ b/application/api/controllers/ApiController.php
@@ -2,6 +2,7 @@
 
 namespace Shaarli\Api\Controllers;
 
+use Shaarli\Config\ConfigManager;
 use \Slim\Container;
 
 /**
@@ -19,7 +20,7 @@ abstract class ApiController
     protected $ci;
 
     /**
-     * @var \ConfigManager
+     * @var ConfigManager
      */
     protected $conf;
 
@@ -27,6 +28,11 @@ abstract class ApiController
      * @var \LinkDB
      */
     protected $linkDb;
+
+    /**
+     * @var \History
+     */
+    protected $history;
 
     /**
      * @var int|null JSON style option.
@@ -45,6 +51,7 @@ abstract class ApiController
         $this->ci = $ci;
         $this->conf = $ci->get('conf');
         $this->linkDb = $ci->get('db');
+        $this->history = $ci->get('history');
         if ($this->conf->get('dev.debug', false)) {
             $this->jsonStyle = JSON_PRETTY_PRINT;
         } else {

--- a/application/api/controllers/History.php
+++ b/application/api/controllers/History.php
@@ -28,7 +28,7 @@ class History extends ApiController
      */
     public function getHistory($request, $response)
     {
-        $history = (new \History($this->conf->get('resource.history')))->getHistory();
+        $history = $this->history->getHistory();
         $history = array_reverse($history);
 
         // Return history operations from the {offset}th, starting from {since}.

--- a/application/api/controllers/History.php
+++ b/application/api/controllers/History.php
@@ -29,7 +29,6 @@ class History extends ApiController
     public function getHistory($request, $response)
     {
         $history = $this->history->getHistory();
-        $history = array_reverse($history);
 
         // Return history operations from the {offset}th, starting from {since}.
         $since = \DateTime::createFromFormat(\DateTime::ATOM, $request->getParam('since'));

--- a/application/api/controllers/Links.php
+++ b/application/api/controllers/Links.php
@@ -141,6 +141,7 @@ class Links extends ApiController
 
         $this->linkDb[$link['id']] = $link;
         $this->linkDb->save($this->conf->get('resource.page_cache'));
+        $this->history->addLink($link);
         $out = ApiUtils::formatLink($link, index_url($this->ci['environment']));
         $redirect = $this->ci->router->relativePathFor('getLink', ['id' => $link['id']]);
         return $response->withAddedHeader('Location', $redirect)
@@ -184,6 +185,7 @@ class Links extends ApiController
         $responseLink = ApiUtils::updateLink($responseLink, $requestLink);
         $this->linkDb[$responseLink['id']] = $responseLink;
         $this->linkDb->save($this->conf->get('resource.page_cache'));
+        $this->history->updateLink($responseLink);
 
         $out = ApiUtils::formatLink($responseLink, $index);
         return $response->withJson($out, 200, $this->jsonStyle);
@@ -205,9 +207,10 @@ class Links extends ApiController
         if (! isset($this->linkDb[$args['id']])) {
             throw new ApiLinkNotFoundException();
         }
-
+        $link = $this->linkDb[$args['id']];
         unset($this->linkDb[(int) $args['id']]);
         $this->linkDb->save($this->conf->get('resource.page_cache'));
+        $this->history->deleteLink($link);
 
         return $response->withStatus(204);
     }

--- a/index.php
+++ b/index.php
@@ -707,7 +707,7 @@ function showLinkList($PAGE, $LINKSDB, $conf, $pluginManager) {
  * @param PluginManager $pluginManager Plugin Manager instance,
  * @param LinkDB        $LINKSDB
  */
-function renderPage($conf, $pluginManager, $LINKSDB)
+function renderPage($conf, $pluginManager, $LINKSDB, $history)
 {
     $updater = new Updater(
         read_updates_file($conf->get('resource.updates')),
@@ -725,12 +725,6 @@ function renderPage($conf, $pluginManager, $LINKSDB)
         }
     }
     catch(Exception $e) {
-        die($e->getMessage());
-    }
-
-    try {
-        $history = new History($conf->get('resource.history'));
-    } catch(Exception $e) {
         die($e->getMessage());
     }
 
@@ -2240,9 +2234,16 @@ $linkDb = new LinkDB(
     $conf->get('redirector.encode_url')
 );
 
+try {
+    $history = new History($conf->get('resource.history'));
+} catch(Exception $e) {
+    die($e->getMessage());
+}
+
 $container = new \Slim\Container();
 $container['conf'] = $conf;
 $container['plugins'] = $pluginManager;
+$container['history'] = $history;
 $app = new \Slim\App($container);
 
 // REST API routes
@@ -2262,7 +2263,7 @@ $response = $app->run(true);
 if ($response->getStatusCode() == 404 && strpos($_SERVER['REQUEST_URI'], '/api/v1') === false) {
     // We use UTF-8 for proper international characters handling.
     header('Content-Type: text/html; charset=utf-8');
-    renderPage($conf, $pluginManager, $linkDb);
+    renderPage($conf, $pluginManager, $linkDb, $history);
 } else {
     $app->respond($response);
 }

--- a/index.php
+++ b/index.php
@@ -1161,7 +1161,6 @@ function renderPage($conf, $pluginManager, $LINKSDB, $history)
             $PAGE->assign('hide_public_links', $conf->get('privacy.hide_public_links', false));
             $PAGE->assign('api_enabled', $conf->get('api.enabled', true));
             $PAGE->assign('api_secret', $conf->get('api.secret'));
-            $history->updateSettings();
             $PAGE->renderPage('configure');
             exit;
         }
@@ -1572,7 +1571,6 @@ function renderPage($conf, $pluginManager, $LINKSDB, $history)
 
     // Plugin administration form action
     if ($targetPage == Router::$PAGE_SAVE_PLUGINSADMIN) {
-        $history->updateSettings();
         try {
             if (isset($_POST['parameters_form'])) {
                 unset($_POST['parameters_form']);
@@ -1584,6 +1582,7 @@ function renderPage($conf, $pluginManager, $LINKSDB, $history)
                 $conf->set('general.enabled_plugins', save_plugin_config($_POST));
             }
             $conf->write(isLoggedIn());
+            $history->updateSettings();
         }
         catch (Exception $e) {
             error_log(

--- a/tests/HistoryTest.php
+++ b/tests/HistoryTest.php
@@ -74,21 +74,21 @@ class HistoryTest extends PHPUnit_Framework_TestCase
         $history->addLink(['id' => 0]);
         $actual = $history->getHistory()[0];
         $this->assertEquals(History::CREATED, $actual['event']);
-        $this->assertTrue(new DateTime('-2 seconds') < DateTime::createFromFormat(DateTime::ATOM, $actual['datetime']));
+        $this->assertTrue(new DateTime('-2 seconds') < $actual['datetime']);
         $this->assertEquals(0, $actual['id']);
 
         $history = new History(self::$historyFilePath);
         $history->addLink(['id' => 1]);
         $actual = $history->getHistory()[0];
         $this->assertEquals(History::CREATED, $actual['event']);
-        $this->assertTrue(new DateTime('-2 seconds') < DateTime::createFromFormat(DateTime::ATOM, $actual['datetime']));
+        $this->assertTrue(new DateTime('-2 seconds') < $actual['datetime']);
         $this->assertEquals(1, $actual['id']);
 
         $history = new History(self::$historyFilePath);
         $history->addLink(['id' => 'str']);
         $actual = $history->getHistory()[0];
         $this->assertEquals(History::CREATED, $actual['event']);
-        $this->assertTrue(new DateTime('-2 seconds') < DateTime::createFromFormat(DateTime::ATOM, $actual['datetime']));
+        $this->assertTrue(new DateTime('-2 seconds') < $actual['datetime']);
         $this->assertEquals('str', $actual['id']);
     }
 
@@ -101,7 +101,7 @@ class HistoryTest extends PHPUnit_Framework_TestCase
         $history->updateLink(['id' => 1]);
         $actual = $history->getHistory()[0];
         $this->assertEquals(History::UPDATED, $actual['event']);
-        $this->assertTrue(new DateTime('-2 seconds') < DateTime::createFromFormat(DateTime::ATOM, $actual['datetime']));
+        $this->assertTrue(new DateTime('-2 seconds') < $actual['datetime']);
         $this->assertEquals(1, $actual['id']);
     }
 
@@ -114,7 +114,7 @@ class HistoryTest extends PHPUnit_Framework_TestCase
         $history->deleteLink(['id' => 1]);
         $actual = $history->getHistory()[0];
         $this->assertEquals(History::DELETED, $actual['event']);
-        $this->assertTrue(new DateTime('-2 seconds') < DateTime::createFromFormat(DateTime::ATOM, $actual['datetime']));
+        $this->assertTrue(new DateTime('-2 seconds') < $actual['datetime']);
         $this->assertEquals(1, $actual['id']);
     }
 
@@ -127,7 +127,7 @@ class HistoryTest extends PHPUnit_Framework_TestCase
         $history->updateSettings();
         $actual = $history->getHistory()[0];
         $this->assertEquals(History::SETTINGS, $actual['event']);
-        $this->assertTrue(new DateTime('-2 seconds') < DateTime::createFromFormat(DateTime::ATOM, $actual['datetime']));
+        $this->assertTrue(new DateTime('-2 seconds') < $actual['datetime']);
         $this->assertEmpty($actual['id']);
     }
 
@@ -140,13 +140,13 @@ class HistoryTest extends PHPUnit_Framework_TestCase
         $history->updateLink(['id' => 1]);
         $actual = $history->getHistory()[0];
         $this->assertEquals(History::UPDATED, $actual['event']);
-        $this->assertTrue(new DateTime('-2 seconds') < DateTime::createFromFormat(DateTime::ATOM, $actual['datetime']));
+        $this->assertTrue(new DateTime('-2 seconds') < $actual['datetime']);
         $this->assertEquals(1, $actual['id']);
 
         $history->addLink(['id' => 1]);
         $actual = $history->getHistory()[0];
         $this->assertEquals(History::CREATED, $actual['event']);
-        $this->assertTrue(new DateTime('-2 seconds') < DateTime::createFromFormat(DateTime::ATOM, $actual['datetime']));
+        $this->assertTrue(new DateTime('-2 seconds') < $actual['datetime']);
         $this->assertEquals(1, $actual['id']);
     }
 
@@ -160,7 +160,7 @@ class HistoryTest extends PHPUnit_Framework_TestCase
         $history = new History(self::$historyFilePath);
         $actual = $history->getHistory()[0];
         $this->assertEquals(History::UPDATED, $actual['event']);
-        $this->assertTrue(new DateTime('-2 seconds') < DateTime::createFromFormat(DateTime::ATOM, $actual['datetime']));
+        $this->assertTrue(new DateTime('-2 seconds') < $actual['datetime']);
         $this->assertEquals(1, $actual['id']);
     }
 
@@ -176,12 +176,12 @@ class HistoryTest extends PHPUnit_Framework_TestCase
         $history = new History(self::$historyFilePath);
         $actual = $history->getHistory()[0];
         $this->assertEquals(History::CREATED, $actual['event']);
-        $this->assertTrue(new DateTime('-2 seconds') < DateTime::createFromFormat(DateTime::ATOM, $actual['datetime']));
+        $this->assertTrue(new DateTime('-2 seconds') < $actual['datetime']);
         $this->assertEquals(1, $actual['id']);
 
         $actual = $history->getHistory()[1];
         $this->assertEquals(History::UPDATED, $actual['event']);
-        $this->assertTrue(new DateTime('-2 seconds') < DateTime::createFromFormat(DateTime::ATOM, $actual['datetime']));
+        $this->assertTrue(new DateTime('-2 seconds') < $actual['datetime']);
         $this->assertEquals(1, $actual['id']);
     }
 
@@ -194,7 +194,7 @@ class HistoryTest extends PHPUnit_Framework_TestCase
         $history->updateLink(['id' => 1]);
         $this->assertEquals(1, count($history->getHistory()));
         $arr = $history->getHistory();
-        $arr[0]['datetime'] = (new DateTime('-1 hour'))->format(DateTime::ATOM);
+        $arr[0]['datetime'] = new DateTime('-1 hour');
         FileUtils::writeFlatDB(self::$historyFilePath, $arr);
 
         $history = new History(self::$historyFilePath, 60);

--- a/tests/NetscapeBookmarkUtils/BookmarkImportTest.php
+++ b/tests/NetscapeBookmarkUtils/BookmarkImportTest.php
@@ -628,7 +628,7 @@ class BookmarkImportTest extends PHPUnit_Framework_TestCase
         $this->assertEquals($nbLinks, count($history));
         foreach ($history as $value) {
             $this->assertEquals(History::CREATED, $value['event']);
-            $this->assertTrue(new DateTime('-5 seconds') < DateTime::createFromFormat(DateTime::ATOM, $value['datetime']));
+            $this->assertTrue(new DateTime('-5 seconds') < $value['datetime']);
             $this->assertTrue(is_int($value['id']));
         }
 
@@ -638,7 +638,7 @@ class BookmarkImportTest extends PHPUnit_Framework_TestCase
         $this->assertEquals($nbLinks * 2, count($history));
         for ($i = 0 ; $i < $nbLinks ; $i++) {
             $this->assertEquals(History::UPDATED, $history[$i]['event']);
-            $this->assertTrue(new DateTime('-5 seconds') < DateTime::createFromFormat(DateTime::ATOM, $history[$i]['datetime']));
+            $this->assertTrue(new DateTime('-5 seconds') < $history[$i]['datetime']);
             $this->assertTrue(is_int($history[$i]['id']));
         }
     }

--- a/tests/api/controllers/GetLinkIdTest.php
+++ b/tests/api/controllers/GetLinkIdTest.php
@@ -62,6 +62,7 @@ class GetLinkIdTest extends \PHPUnit_Framework_TestCase
         $this->container = new Container();
         $this->container['conf'] = $this->conf;
         $this->container['db'] = new \LinkDB(self::$testDatastore, true, false);
+        $this->container['history'] = null;
 
         $this->controller = new Links($this->container);
     }

--- a/tests/api/controllers/GetLinksTest.php
+++ b/tests/api/controllers/GetLinksTest.php
@@ -61,6 +61,7 @@ class GetLinksTest extends \PHPUnit_Framework_TestCase
         $this->container = new Container();
         $this->container['conf'] = $this->conf;
         $this->container['db'] = new \LinkDB(self::$testDatastore, true, false);
+        $this->container['history'] = null;
 
         $this->controller = new Links($this->container);
     }

--- a/tests/api/controllers/HistoryTest.php
+++ b/tests/api/controllers/HistoryTest.php
@@ -30,11 +30,6 @@ class HistoryTest extends \PHPUnit_Framework_TestCase
     protected $refHistory = null;
 
     /**
-     * @var \History instance.
-     */
-    protected $history;
-
-    /**
      * @var Container instance.
      */
     protected $container;
@@ -52,10 +47,10 @@ class HistoryTest extends \PHPUnit_Framework_TestCase
         $this->conf = new ConfigManager('tests/utils/config/configJson.json.php');
         $this->refHistory = new \ReferenceHistory();
         $this->refHistory->write(self::$testHistory);
-        $this->conf->set('resource.history', self::$testHistory);
         $this->container = new Container();
         $this->container['conf'] = $this->conf;
         $this->container['db'] = true;
+        $this->container['history'] = new \History(self::$testHistory);
 
         $this->controller = new History($this->container);
     }

--- a/tests/api/controllers/InfoTest.php
+++ b/tests/api/controllers/InfoTest.php
@@ -54,6 +54,7 @@ class InfoTest extends \PHPUnit_Framework_TestCase
         $this->container = new Container();
         $this->container['conf'] = $this->conf;
         $this->container['db'] = new \LinkDB(self::$testDatastore, true, false);
+        $this->container['history'] = null;
 
         $this->controller = new Info($this->container);
     }

--- a/tests/utils/ReferenceHistory.php
+++ b/tests/utils/ReferenceHistory.php
@@ -15,8 +15,19 @@ class ReferenceHistory
     public function __construct()
     {
         $this->addEntry(
-            History::CREATED,
-            DateTime::createFromFormat('Ymd_His', '20170101_121212'),
+            History::DELETED,
+            DateTime::createFromFormat('Ymd_His', '20170303_121216'),
+            124
+        );
+
+        $this->addEntry(
+            History::SETTINGS,
+            DateTime::createFromFormat('Ymd_His', '20170302_121215')
+        );
+
+        $this->addEntry(
+            History::UPDATED,
+            DateTime::createFromFormat('Ymd_His', '20170301_121214'),
             123
         );
 
@@ -27,20 +38,9 @@ class ReferenceHistory
         );
 
         $this->addEntry(
-            History::UPDATED,
-            DateTime::createFromFormat('Ymd_His', '20170301_121214'),
+            History::CREATED,
+            DateTime::createFromFormat('Ymd_His', '20170101_121212'),
             123
-        );
-
-        $this->addEntry(
-            History::SETTINGS,
-            DateTime::createFromFormat('Ymd_His', '20170302_121215')
-        );
-
-        $this->addEntry(
-            History::DELETED,
-            DateTime::createFromFormat('Ymd_His', '20170303_121216'),
-            124
         );
     }
 


### PR DESCRIPTION
  * datetime is now store as an object in history store file
  * Reset the history file due to datetime format change
  * History: fix entries order
  * Add settings history entry only when they're updated