### PR TITLE
Fix a bug happening when importing links with override option

### DIFF
--- a/application/NetscapeBookmarkUtils.php
+++ b/application/NetscapeBookmarkUtils.php
@@ -180,6 +180,7 @@ class NetscapeBookmarkUtils
                 $newLink['id'] = $existingLink['id'];
                 $newLink['created'] = $existingLink['created'];
                 $newLink['updated'] = new DateTime();
+                $newLink['shorturl'] = $existingLink['shorturl'];
                 $linkDb[$existingLink['id']] = $newLink;
                 $importCount++;
                 $overwriteCount++;


### PR DESCRIPTION
The shorturl would be set to null, generating a lot of warnings and breaking permalinks