### PR TITLE
Inject tag list everywhere to make autocomplete work on the fixed search bar

### DIFF
--- a/application/PageBuilder.php
+++ b/application/PageBuilder.php
@@ -22,15 +22,22 @@ class PageBuilder
     protected $conf;
 
     /**
+     * @var LinkDB $linkDB instance.
+     */
+    protected $linkDB;
+
+    /**
      * PageBuilder constructor.
      * $tpl is initialized at false for lazy loading.
      *
-     * @param ConfigManager $conf Configuration Manager instance (reference).
+     * @param ConfigManager $conf   Configuration Manager instance (reference).
+     * @param LinkDB        $linkDB instance.
      */
-    public function __construct(&$conf)
+    public function __construct(&$conf, $linkDB = null)
     {
         $this->tpl = false;
         $this->conf = $conf;
+        $this->linkDB = $linkDB;
     }
 
     /**
@@ -81,6 +88,9 @@ class PageBuilder
         $this->tpl->assign('feed_type', $this->conf->get('feed.show_atom', true) !== false ? 'atom' : 'rss');
         $this->tpl->assign('hide_timestamps', $this->conf->get('privacy.hide_timestamps', false));
         $this->tpl->assign('token', getToken($this->conf));
+        if ($this->linkDB !== null) {
+            $this->tpl->assign('tags', $this->linkDB->allTags());
+        }
         // To be removed with a proper theme configuration.
         $this->tpl->assign('conf', $this->conf);
     }

--- a/index.php
+++ b/index.php
@@ -728,7 +728,7 @@ function renderPage($conf, $pluginManager, $LINKSDB, $history)
         die($e->getMessage());
     }
 
-    $PAGE = new PageBuilder($conf);
+    $PAGE = new PageBuilder($conf, $LINKSDB);
     $PAGE->assign('linkcount', count($LINKSDB));
     $PAGE->assign('privateLinkcount', count_private($LINKSDB));
     $PAGE->assign('plugin_errors', $pluginManager->getErrors());
@@ -1170,7 +1170,6 @@ function renderPage($conf, $pluginManager, $LINKSDB, $history)
     if ($targetPage == Router::$PAGE_CHANGETAG)
     {
         if (empty($_POST['fromtag']) || (empty($_POST['totag']) && isset($_POST['renametag']))) {
-            $PAGE->assign('tags', $LINKSDB->allTags());
             $PAGE->renderPage('changetag');
             exit;
         }
@@ -1700,7 +1699,6 @@ function buildLinkList($PAGE,$LINKSDB, $conf, $pluginManager)
         'visibility' => ! empty($_SESSION['privateonly']) ? 'private' : '',
         'redirector' => $conf->get('redirector.url'),  // Optional redirector URL.
         'links' => $linkDisp,
-        'tags' => $LINKSDB->allTags(),
     );
 
     // If there is only a single link, we change on-the-fly the title of the page.


### PR DESCRIPTION
Currently, tag autocompletion only works on the link list and the tagcloud. Since the new theme provides a search bar in any page, the tags must be set.