### PR TITLE
Adding the ability to display subtags in the tagcloud

### DIFF
--- a/application/LinkDB.php
+++ b/application/LinkDB.php
@@ -452,14 +452,17 @@ You use the community supported version of the original Shaarli project, by Seba
     }
 
     /**
-     * Returns the list of all tags
-     * Output: associative array key=tags, value=0
+     * Returns the list tags appearing in the links with the given tags
+     * @param $filteringTags: tags selecting the links to consider
+     * @param $visibility: process only all/private/public links
+     * @return: a tag=>linksCount array
      */
-    public function allTags()
+    public function linksCountPerTag($filteringTags = [], $visibility = 'all')
     {
+        $links = empty($filteringTags) ? $this->links : $this->filterSearch(['searchtags' => $filteringTags], false, $visibility);
         $tags = array();
         $caseMapping = array();
-        foreach ($this->links as $link) {
+        foreach ($links as $link) {
             foreach (preg_split('/\s+/', $link['tags'], 0, PREG_SPLIT_NO_EMPTY) as $tag) {
                 if (empty($tag)) {
                     continue;

--- a/application/PageBuilder.php
+++ b/application/PageBuilder.php
@@ -89,7 +89,7 @@ class PageBuilder
         $this->tpl->assign('hide_timestamps', $this->conf->get('privacy.hide_timestamps', false));
         $this->tpl->assign('token', getToken($this->conf));
         if ($this->linkDB !== null) {
-            $this->tpl->assign('tags', $this->linkDB->allTags());
+            $this->tpl->assign('tags', $this->linkDB->linksCountPerTag());
         }
         // To be removed with a proper theme configuration.
         $this->tpl->assign('conf', $this->conf);

--- a/index.php
+++ b/index.php
@@ -790,7 +790,9 @@ function renderPage($conf, $pluginManager, $LINKSDB, $history)
     // -------- Tag cloud
     if ($targetPage == Router::$PAGE_TAGCLOUD)
     {
-        $tags= $LINKSDB->allTags();
+        $visibility = ! empty($_SESSION['privateonly']) ? 'private' : 'all';
+        $filteringTags = isset($_GET['searchtags']) ? explode(' ', $_GET['searchtags']) : array();
+        $tags = $LINKSDB->linksCountPerTag($filteringTags, $visibility);
 
         // We sort tags alphabetically, then choose a font size according to count.
         // First, find max value.
@@ -824,6 +826,7 @@ function renderPage($conf, $pluginManager, $LINKSDB, $history)
         }
 
         $data = array(
+            'search_tags' => implode(' ', $filteringTags),
             'tags' => $tagList,
         );
         $pluginManager->executeHooks('render_tagcloud', $data, array('loggedin' => isLoggedIn()));
@@ -1351,7 +1354,7 @@ function renderPage($conf, $pluginManager, $LINKSDB, $history)
             'link' => $link,
             'link_is_new' => false,
             'http_referer' => (isset($_SERVER['HTTP_REFERER']) ? escape($_SERVER['HTTP_REFERER']) : ''),
-            'tags' => $LINKSDB->allTags(),
+            'tags' => $LINKSDB->linksCountPerTag(),
         );
         $pluginManager->executeHooks('render_editlink', $data);
 
@@ -1420,7 +1423,7 @@ function renderPage($conf, $pluginManager, $LINKSDB, $history)
             'link_is_new' => $link_is_new,
             'http_referer' => (isset($_SERVER['HTTP_REFERER']) ? escape($_SERVER['HTTP_REFERER']) : ''),
             'source' => (isset($_GET['source']) ? $_GET['source'] : ''),
-            'tags' => $LINKSDB->allTags(),
+            'tags' => $LINKSDB->linksCountPerTag(),
             'default_private_links' => $conf->get('privacy.default_private_links', false),
         );
         $pluginManager->executeHooks('render_editlink', $data);

--- a/tests/LinkDBTest.php
+++ b/tests/LinkDBTest.php
@@ -297,7 +297,7 @@ class LinkDBTest extends PHPUnit_Framework_TestCase
                 'sTuff' => 2,
                 'ut' => 1,
             ),
-            self::$publicLinkDB->allTags()
+            self::$publicLinkDB->linksCountPerTag()
         );
 
         $this->assertEquals(
@@ -325,7 +325,34 @@ class LinkDBTest extends PHPUnit_Framework_TestCase
                 'tag4' => 1,
                 'ut' => 1,
             ),
-            self::$privateLinkDB->allTags()
+            self::$privateLinkDB->linksCountPerTag()
+        );
+        $this->assertEquals(
+            array(
+                'web' => 4,
+                'cartoon' => 2,
+                'gnu' => 1,
+                'dev' => 1,
+                'samba' => 1,
+                'media' => 1,
+                'html' => 1,
+                'w3c' => 1,
+                'css' => 1,
+                'Mercurial' => 1,
+                '.hidden' => 1,
+                'hashtag' => 1,
+            ),
+            self::$privateLinkDB->linksCountPerTag(['web'])
+        );
+        $this->assertEquals(
+            array(
+                'web' => 1,
+                'html' => 1,
+                'w3c' => 1,
+                'css' => 1,
+                'Mercurial' => 1,
+            ),
+            self::$privateLinkDB->linksCountPerTag(['web'], 'private')
         );
     }
 

--- a/tpl/default/css/shaarli.css
+++ b/tpl/default/css/shaarli.css
@@ -211,7 +211,7 @@ body, .pure-g [class*="pure-u"] {
     }
 }
 
-#search, #search-linklist {
+#search, #search-linklist, #search-tagcloud {
     text-align: center;
     width: 100%;
 }
@@ -234,6 +234,7 @@ body, .pure-g [class*="pure-u"] {
 }
 
 #search button,
+#search-tagcloud button,
 #search-linklist button {
     background: transparent;
     border: none;
@@ -250,6 +251,9 @@ body, .pure-g [class*="pure-u"] {
 #search button:hover,
 #search-linklist button:hover {
     color: #fff;
+}
+#search-tagcloud button:hover {
+    color: #d0d0d0;
 }
 
 #search-linklist {

--- a/tpl/default/tagcloud.html
+++ b/tpl/default/tagcloud.html
@@ -12,6 +12,24 @@
     {$countTags=count($tags)}
     <h2 class="window-title">{'Tag cloud'|t} - {$countTags} {'tags'|t}</h2>
 
+    <div id="search-tagcloud" class="pure-g">
+      <div class="pure-u-lg-1-4"></div>
+      <div class="pure-u-1 pure-u-lg-1-2">
+        <form method="GET">
+          <input type="hidden" name="do" value="tagcloud">
+          <input type="text" name="searchtags" placeholder="{'Filter by tag'|t}"
+                 {if="!empty($search_tags)"}
+                 value="{$search_tags}"
+                 {/if}
+          autocomplete="off" data-multiple data-autofirst data-minChars="1"
+          data-list="{loop="$tags"}{$key}, {/loop}"
+          >
+          <button type="submit" class="search-button"><i class="fa fa-search"></i></button>
+        </form>
+      </div>
+      <div class="pure-u-lg-1-4"></div>
+    </div>
+
     <div id="plugin_zone_start_tagcloud" class="plugin_zone">
       {loop="$plugin_start_zone"}
         {$value}
@@ -21,7 +39,7 @@
     <div id="cloudtag">
       {loop="tags"}
         <a href="?searchtags={$key|urlencode}" style="font-size:{$value.size}em;">{$key}</a
-        ><span class="count">{$value.count}</span>
+        ><a href="?addtag={$key|urlencode}" title="{'Filter by tag'|t}" class="count">{$value.count}</a>
         {loop="$value.tag_plugin"}
           {$value}
         {/loop}

--- a/tpl/vintage/tagcloud.html
+++ b/tpl/vintage/tagcloud.html
@@ -12,7 +12,7 @@
 
     <div id="cloudtag">
         {loop="$tags"}
-            <span class="count">{$value.count}</span><a
+            <a href="?addtag={$key|urlencode}" class="count">{$value.count}</a><a
                 href="?searchtags={$key|urlencode}" style="font-size:{$value.size}em;">{$key}</a>
             {loop="$value.tag_plugin"}
                 {$value}


### PR DESCRIPTION
The counters in the tag cloud become clickable.
A demo of this feature can be seen here: https://chezsoi.org/shaarli/?do=tagcloud&searchtags=Python
If you like the idea, please tell me which tests I need to add to this PR ;)