### PR TITLE
Tagcloud/list improvments

### DIFF
--- a/index.php
+++ b/index.php
@@ -805,6 +805,9 @@ function renderPage($conf, $pluginManager, $LINKSDB, $history)
 
         $tagList = array();
         foreach($tags as $key => $value) {
+            if (in_array($key, $filteringTags)) {
+                continue;
+            }
             // Tag font size scaling:
             //   default 15 and 30 logarithm bases affect scaling,
             //   22 and 6 are arbitrary font sizes for max and min sizes.
@@ -829,12 +832,17 @@ function renderPage($conf, $pluginManager, $LINKSDB, $history)
         exit;
     }
 
-    // -------- Tag cloud
+    // -------- Tag list
     if ($targetPage == Router::$PAGE_TAGLIST)
     {
         $visibility = ! empty($_SESSION['privateonly']) ? 'private' : 'all';
         $filteringTags = isset($_GET['searchtags']) ? explode(' ', $_GET['searchtags']) : [];
         $tags = $LINKSDB->linksCountPerTag($filteringTags, $visibility);
+        foreach ($filteringTags as $tag) {
+            if (array_key_exists($tag, $tags)) {
+                unset($tags[$tag]);
+            }
+        }
 
         if (! empty($_GET['sort']) && $_GET['sort'] === 'alpha') {
             alphabetical_sort($tags, false, true);

--- a/tpl/default/tag.cloud.html
+++ b/tpl/default/tag.cloud.html
@@ -13,6 +13,11 @@
   <div class="pure-u-lg-2-3 pure-u-22-24 page-form page-visitor">
     {$countTags=count($tags)}
     <h2 class="window-title">{'Tag cloud'|t} - {$countTags} {'tags'|t}</h2>
+    {if="!empty($search_tags)"}
+    <p class="enter">
+      <a href="?searchtags={$search_tags|urlencode}">{'List all links with those tags'|t}</a>
+    </p>
+    {/if}
 
     <div id="search-tagcloud" class="pure-g">
       <div class="pure-u-lg-1-4"></div>
@@ -40,7 +45,7 @@
 
     <div id="cloudtag">
       {loop="tags"}
-        <a href="?searchtags={$key|urlencode}" style="font-size:{$value.size}em;">{$key}</a
+        <a href="?searchtags={$key|urlencode} {$search_tags|urlencode}" style="font-size:{$value.size}em;">{$key}</a
         ><a href="?addtag={$key|urlencode}" title="{'Filter by tag'|t}" class="count">{$value.count}</a>
         {loop="$value.tag_plugin"}
           {$value}

--- a/tpl/default/tag.list.html
+++ b/tpl/default/tag.list.html
@@ -13,6 +13,9 @@
   <div class="pure-u-lg-2-3 pure-u-22-24 page-form page-visitor">
     {$countTags=count($tags)}
     <h2 class="window-title">{'Tag list'|t} - {$countTags} {'tags'|t}</h2>
+    <p style="text-align: center">
+      <a href="?searchtags={$search_tags|urlencode}">{'List all links with those tags'|t}</a>
+    </p>
 
     <div id="search-tagcloud" class="pure-g">
       <div class="pure-u-lg-1-4"></div>
@@ -50,7 +53,7 @@
             {/if}
 
             <a href="?addtag={$key|urlencode}" title="{'Filter by tag'|t}" class="count">{$value}</a>
-            <a href="?searchtags={$key|urlencode}" class="tag-link">{$key}</a>
+            <a href="?searchtags={$key|urlencode} {$search_tags|urlencode}" class="tag-link">{$key}</a>
 
             {loop="$value.tag_plugin"}
               {$value}


### PR DESCRIPTION
This PR is a follow-up of #878 and adds the following to the tag cloud / tag list views :

- it fixes a small bug: when a first tag is select in the tagcloud, the links to the linklist should include BOTH the 1st tag AND the tag pointed by the link

- tags searched are not included in the list of displayed tags anymore

- if some search tags have been set, below the tags count a link is added to redirect to the linklist view filtered by those tags