### PR TITLE
docker: add alpine,debian,ubuntu test images

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,6 +19,16 @@ PHP_COMMA_SOURCE = index.php,application,tests,plugins
 all: static_analysis_summary check_permissions test
 
 ##
+# Docker test adapter
+#
+# Shaarli sources and vendored libraries are copied from a shared volume
+# to a user-owned directory to enable running tests as a non-root user.
+##
+docker_%:
+	rsync -az /shaarli/ ~/shaarli/
+	cd ~/shaarli && make $*
+
+##
 # Concise status of the project
 # These targets are non-blocking: || exit 0
 ##

--- a/doc/md/Unit-tests-Docker.md
+++ b/doc/md/Unit-tests-Docker.md
@@ -1,0 +1,56 @@
+## Running tests inside Docker containers
+
+Read first:
+
+- [Docker 101](docker/docker-101.md)
+- [Docker resources](docker/resources.md)
+- [Unit tests](Unit-tests.md)
+
+### Docker test images
+
+Test Dockerfiles are located under `docker/tests/<distribution>/Dockerfile`,
+and can be used to build Docker images to run Shaarli test suites under common
+Linux environments.
+
+Dockerfiles are provided for the following environments:
+
+- `alpine36` - [Alpine 3.6](https://www.alpinelinux.org/downloads/)
+- `debian8` - [Debian 8 Jessie](https://www.debian.org/DebianJessie) (oldstable)
+- `debian9` - [Debian 9 Stretch](https://wiki.debian.org/DebianStretch) (stable)
+- `ubuntu16` - [Ubuntu 16.04 Xenial Xerus](http://releases.ubuntu.com/16.04/) (LTS)
+
+What's behind the curtains:
+
+- each image provides:
+    - a base Linux OS
+    - Shaarli PHP dependencies (OS packages)
+    - test PHP dependencies (OS packages)
+    - Composer
+- the local workspace is mapped to the container's `/shaarli/` directory,
+- the files are rsync'd to so tests are run using a standard Linux user account
+  (running tests as `root` would bypass permission checks and may hide issues)
+- the tests are run inside the container.
+
+### Building test images
+
+```bash
+# build the Debian 9 Docker image
+$ cd /path/to/shaarli
+$ cd docker/test/debian9
+$ docker build -t shaarli-test:debian9 .
+```
+
+### Running tests
+
+```bash
+$ cd /path/to/shaarli
+
+# install/update 3rd-party test dependencies
+$ composer install --prefer-dist
+
+# run tests using the freshly built image
+$ docker run -v $PWD:/shaarli shaarli-test:debian9 docker_test
+
+# run the full test campaign
+$ docker run -v $PWD:/shaarli shaarli-test:debian9 docker_all_tests
+```

--- a/docker/test/alpine36/Dockerfile
+++ b/docker/test/alpine36/Dockerfile
@@ -1,0 +1,34 @@
+FROM alpine:3.6
+MAINTAINER Shaarli Community
+
+RUN apk --update --no-cache add \
+        ca-certificates \
+        curl \
+        make \
+        php7 \
+        php7-ctype \
+        php7-curl \
+        php7-dom \
+        php7-gd \
+        php7-iconv \
+        php7-intl \
+        php7-json \
+        php7-mbstring \
+        php7-openssl \
+        php7-phar \
+        php7-session \
+        php7-simplexml \
+        php7-tokenizer \
+        php7-xdebug \
+        php7-xml \
+        php7-zlib \
+        rsync
+
+RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
+
+RUN mkdir /shaarli
+WORKDIR /shaarli
+VOLUME /shaarli
+
+ENTRYPOINT ["make"]
+CMD []

--- a/docker/test/debian8/Dockerfile
+++ b/docker/test/debian8/Dockerfile
@@ -1,0 +1,35 @@
+FROM debian:jessie
+MAINTAINER Shaarli Community
+
+ENV TERM dumb
+ENV DEBIAN_FRONTEND noninteractive
+ENV LANG en_US.UTF-8
+ENV LANGUAGE en_US:en
+
+RUN apt-get update \
+    && apt-get install --no-install-recommends -y \
+       ca-certificates \
+       curl \
+       locales \
+       make \
+       php5 \
+       php5-curl \
+       php5-gd \
+       php5-intl \
+       php5-xdebug \
+       rsync \
+    && apt-get clean
+
+RUN locale-gen en_US.UTF-8 \
+    && locale-gen de_DE.UTF-8 \
+    && locale-gen fr_FR.UTF-8
+
+ADD https://getcomposer.org/composer.phar /usr/local/bin/composer
+RUN chmod 755 /usr/local/bin/composer
+
+RUN mkdir /shaarli
+WORKDIR /shaarli
+VOLUME /shaarli
+
+ENTRYPOINT ["make"]
+CMD []

--- a/docker/test/debian9/Dockerfile
+++ b/docker/test/debian9/Dockerfile
@@ -1,0 +1,36 @@
+FROM debian:stretch
+MAINTAINER Shaarli Community
+
+ENV TERM dumb
+ENV DEBIAN_FRONTEND noninteractive
+ENV LANG en_US.UTF-8
+ENV LANGUAGE en_US:en
+
+RUN apt-get update \
+    && apt-get install --no-install-recommends -y \
+       ca-certificates \
+       curl \
+       locales \
+       make \
+       php7.0 \
+       php7.0-curl \
+       php7.0-gd \
+       php7.0-intl \
+       php7.0-xml \
+       php-xdebug \
+       rsync \
+    && apt-get clean
+
+RUN locale-gen en_US.UTF-8 \
+    && locale-gen de_DE.UTF-8 \
+    && locale-gen fr_FR.UTF-8
+
+ADD https://getcomposer.org/composer.phar /usr/local/bin/composer
+RUN chmod 755 /usr/local/bin/composer
+
+RUN mkdir /shaarli
+WORKDIR /shaarli
+VOLUME /shaarli
+
+ENTRYPOINT ["make"]
+CMD []

--- a/docker/test/ubuntu16/Dockerfile
+++ b/docker/test/ubuntu16/Dockerfile
@@ -1,0 +1,36 @@
+FROM ubuntu:16.04
+MAINTAINER Shaarli Community
+
+ENV TERM dumb
+ENV DEBIAN_FRONTEND noninteractive
+ENV LANG en_US.UTF-8
+ENV LANGUAGE en_US:en
+
+RUN apt-get update \
+    && apt-get install --no-install-recommends -y \
+       ca-certificates \
+       curl \
+       language-pack-de \
+       language-pack-en \
+       language-pack-fr \
+       locales \
+       make \
+       php7.0 \
+       php7.0-curl \
+       php7.0-gd \
+       php7.0-intl \
+       php7.0-xml \
+       php-xdebug \
+       rsync \
+    && apt-get clean
+
+ADD https://getcomposer.org/composer.phar /usr/local/bin/composer
+RUN chmod 755 /usr/local/bin/composer
+
+RUN useradd -m dev \
+    && mkdir /shaarli
+USER dev
+WORKDIR /shaarli
+
+ENTRYPOINT ["make"]
+CMD []

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -45,6 +45,7 @@ pages:
     - Static analysis: Static-analysis.md
     - Theming: Theming.md
     - Unit tests: Unit-tests.md
+    - Unit tests inside Docker: Unit-tests-Docker.md
 - About:
     - FAQ: FAQ.md
     - Community & Related software: Community-&-Related-software.md


### PR DESCRIPTION
Hi!

I've created a bunch of Dockerfiles to help debugging #843 & #845 and allow running Shaarli tests (`make <stuff>`) under different containerized environments.

Q: Would there be interest in including these resources in the main repository?

Usage:

```bash
# build the Debian 9 Docker image
$ cd /path/to/shaarli
$ cd docker/test/debian9
$ docker build -t shaarli-test:debian9 .

# run tests using the freshly built image
$ cd /path/to/shaarli
$ docker run -v $PWD:/shaarli shaarli-test:debian9 docker_test
```

What's behind the curtains:
- each image provides a base OS + PHP packages + composer
- the local workspace is mapped to the container's `/shaarli/` directory
- the files are rsync'd to avoid running tests as `root` (which bypasses any permission issue)
- the tests are run within the container

---

Relates to https://github.com/shaarli/Shaarli/issues/843

Added:
- Makefile target to run commands in a Docker test context
- Docker images to run Shaarli test suites:
  - Alpine 3.6
  - Debian 8
  - Debian 9
  - Ubuntu 16.04
- Documentation