### PR TITLE
travis: explicitly set the build dist to `precise`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 sudo: false
+dist: precise
 language: php
 addons:
   apt:


### PR DESCRIPTION
Travis is currently migrating its default build environment from `precise` to `trusty`, hence Brazilian Portuguese being the default locale in some tests... wait, wat?

https://travis-ci.org/shaarli/Shaarli/builds/259870211

I'm not sure for now whether it's an issue with Travis environments, or we need to refresh our CI configuration to match the new environments. In the meantime, let's stick to a working CI setup :)

---

See https://blog.travis-ci.com/2017-07-11-trusty-as-default-linux-is-coming