### PR TITLE
Fixing isso plugin data-isso-id & data-title

### DIFF
--- a/plugins/isso/isso.php
+++ b/plugins/isso/isso.php
@@ -44,7 +44,7 @@ function hook_isso_render_linklist($data, $conf)
         $link = reset($data['links']);
         $issoHtml = file_get_contents(PluginManager::$PLUGINS_PATH . '/isso/isso.html');
 
-        $isso = sprintf($issoHtml, $issoUrl, $issoUrl, $link['id'], $link['id']);
+        $isso = sprintf($issoHtml, $issoUrl, $issoUrl, $link['shorturl'], $link['title']);
         $data['plugin_end_zone'][] = $isso;
 
         // Hackish way to include this CSS file only when necessary.

--- a/tests/plugins/PluginIssoTest.php
+++ b/tests/plugins/PluginIssoTest.php
@@ -55,6 +55,8 @@ class PluginIssoTest extends PHPUnit_Framework_TestCase
                 array(
                     'id' => 12,
                     'url' => $str,
+                    'title' => 'Bookmarked web page title',
+                    'shorturl' => 'abc123',
                     'created' => DateTime::createFromFormat(LinkDB::LINK_DATE_FORMAT, $date),
                 )
             )
@@ -70,11 +72,11 @@ class PluginIssoTest extends PHPUnit_Framework_TestCase
         $this->assertEquals(1, count($data['plugin_end_zone']));
         $this->assertNotFalse(strpos(
             $data['plugin_end_zone'][0],
-            'data-isso-id="'. $data['links'][0]['id'] .'"'
+            'data-isso-id="'. $data['links'][0]['shorturl'] .'"'
         ));
         $this->assertNotFalse(strpos(
             $data['plugin_end_zone'][0],
-            'data-title="'. $data['links'][0]['id'] .'"'
+            'data-title="'. $data['links'][0]['title'] .'"'
         ));
         $this->assertNotFalse(strpos($data['plugin_end_zone'][0], 'embed.min.js'));
     }


### PR DESCRIPTION
Using the permalink instead of the internal id makes it possible to retrieve the permalink page URL from outside Shaarli.
At least another isso integration I know, Ghost blog, use an URL path as the isso id.