### PR TITLE
Remove the 2nd green 'sort by' row in link list

### DIFF
--- a/tpl/default/tag.list.html
+++ b/tpl/default/tag.list.html
@@ -81,8 +81,6 @@
   <input type="hidden" name="taglist" value="{loop="$tags"}{$key} {/loop}"
 {/if}
 
-{include="tag.sort"}
-
 {include="page.footer"}
 </body>
 </html>


### PR DESCRIPTION
It isn't really useful and doesn't look good if there isn't enough tags