### PR TITLE
fixed note bookmarklet

### DIFF
--- a/tpl/default/tools.html
+++ b/tpl/default/tools.html
@@ -97,7 +97,7 @@
             var%20desc=document.getSelection().toString();
             if(desc.length>4000){
               desc=desc.substr(0,4000)+'...';
-              alert("{function="str_replace(' ', '%20', t('The selected text is too long, it will be truncated.'))"}");
+              alert('{function="str_replace(' ', '%20', t('The selected text is too long, it will be truncated.'))"}');
             }
             window.open(
               '{$pageabsaddr}?private=1&amp;post='+


### PR DESCRIPTION
Currently the note bookmarklet of the default theme is broken due to using *unescaped* double quotes inside the double quotes of the `href=""` attribute. 

This fixes the issue by using single quotes (that's what the *Shaare link* bookmarklet already does)

fixes #933