### PR TITLE
Firefox Social title: Use document.title instead of RainTPL variable

### DIFF
--- a/application/HttpUtils.php
+++ b/application/HttpUtils.php
@@ -401,3 +401,31 @@ function getIpAddressFromProxy($server, $trustedIps)
 
     return array_pop($ips);
 }
+
+/**
+ * Returns true if Shaarli's currently browsed in HTTPS.
+ * Supports reverse proxies (if the headers are correctly set).
+ *
+ * @param array $server $_SERVER.
+ *
+ * @return bool true if HTTPS, false otherwise.
+ */
+function is_https($server)
+{
+
+    if (isset($server['HTTP_X_FORWARDED_PORT'])) {
+        // Keep forwarded port
+        if (strpos($server['HTTP_X_FORWARDED_PORT'], ',') !== false) {
+            $ports = explode(',', $server['HTTP_X_FORWARDED_PORT']);
+            $port = trim($ports[0]);
+        } else {
+            $port = $server['HTTP_X_FORWARDED_PORT'];
+        }
+
+        if ($port == '443') {
+            return true;
+        }
+    }
+
+    return ! empty($server['HTTPS']);
+}

--- a/index.php
+++ b/index.php
@@ -1063,10 +1063,10 @@ function renderPage($conf, $pluginManager, $LINKSDB, $history)
     // -------- Display the Tools menu if requested (import/export/bookmarklet...)
     if ($targetPage == Router::$PAGE_TOOLS)
     {
-        $data = array(
+        $data = [
             'pageabsaddr' => index_url($_SERVER),
-            'sslenabled' => !empty($_SERVER['HTTPS'])
-        );
+            'sslenabled' => is_https($_SERVER),
+        ];
         $pluginManager->executeHooks('render_tools', $data);
 
         foreach ($data as $key => $value) {

--- a/tests/HttpUtils/IsHttpsTest.php
+++ b/tests/HttpUtils/IsHttpsTest.php
@@ -1,0 +1,36 @@
+<?php
+
+
+/**
+ * Class IsHttpsTest
+ *
+ * Test class for is_https() function.
+ */
+class IsHttpsTest extends PHPUnit_Framework_TestCase
+{
+
+    /**
+     * Test is_https with HTTPS values.
+     */
+    public function testIsHttpsTrue()
+    {
+        $this->assertTrue(is_https(['HTTPS' => true]));
+        $this->assertTrue(is_https(['HTTPS' => '1']));
+        $this->assertTrue(is_https(['HTTPS' => false, 'HTTP_X_FORWARDED_PORT' => 443]));
+        $this->assertTrue(is_https(['HTTPS' => false, 'HTTP_X_FORWARDED_PORT' => '443']));
+        $this->assertTrue(is_https(['HTTPS' => false, 'HTTP_X_FORWARDED_PORT' => '443,123,456,']));
+    }
+
+    /**
+     * Test is_https with HTTP values.
+     */
+    public function testIsHttpsFalse()
+    {
+        $this->assertFalse(is_https([]));
+        $this->assertFalse(is_https(['HTTPS' => false]));
+        $this->assertFalse(is_https(['HTTPS' => '0']));
+        $this->assertFalse(is_https(['HTTPS' => false, 'HTTP_X_FORWARDED_PORT' => 123]));
+        $this->assertFalse(is_https(['HTTPS' => false, 'HTTP_X_FORWARDED_PORT' => '123']));
+        $this->assertFalse(is_https(['HTTPS' => false, 'HTTP_X_FORWARDED_PORT' => ',123,456,']));
+    }
+}

--- a/tpl/default/js/shaarli.js
+++ b/tpl/default/js/shaarli.js
@@ -607,10 +607,11 @@ function htmlEntities(str)
 function activateFirefoxSocial(node) {
     var loc = location.href;
     var baseURL = loc.substring(0, loc.lastIndexOf("/") + 1);
+    var title = document.title;
 
     // Keeping the data separated (ie. not in the DOM) so that it's maintainable and diffable.
     var data = {
-        name: "{$shaarlititle}",
+        name: title,
         description: "The personal, minimalist, super-fast, database free, bookmarking service by the Shaarli community.",
         author: "Shaarli",
         version: "1.0.0",


### PR DESCRIPTION
Fixes #929 

Also make `$sslenabled` work behind a reverse proxy.

Without `HTTP_X_FORWARDED_PORT` check, `$sslenabled` might be set to false even though the user is using HTTPS, thus disabling Firefox Social block display.

This needs to be tested behind HTTPS + reverse proxy.