### PR TITLE
new setting: default value for 'remember me' checkbox

### DIFF
--- a/application/config/ConfigManager.php
+++ b/application/config/ConfigManager.php
@@ -328,6 +328,8 @@ class ConfigManager
         $this->setEmpty('privacy.default_private_links', false);
         $this->setEmpty('privacy.hide_public_links', false);
         $this->setEmpty('privacy.hide_timestamps', false);
+        // default state of the 'remember me' checkbox of the login form
+        $this->setEmpty('privacy.remember_user_default', true);
 
         $this->setEmpty('thumbnail.enable_thumbnails', true);
         $this->setEmpty('thumbnail.enable_localcache', true);

--- a/doc/md/Shaarli-configuration.md
+++ b/doc/md/Shaarli-configuration.md
@@ -91,6 +91,8 @@ _These settings should not be edited_
 - **default_private_links**: Check the private checkbox by default for every new link.  
 - **hide_public_links**: All links are hidden while logged out.  
 - **hide_timestamps**: Timestamps are hidden.
+- **remember_user_default**: Default state of the login page's *remember me* checkbox
+    - `true`: checked by default, `false`: unchecked by default
 
 ### Feed
 
@@ -192,7 +194,8 @@ _These settings should not be edited_
     "privacy": {
         "default_private_links": true,
         "hide_public_links": false,
-        "hide_timestamps": false
+        "hide_timestamps": false,
+        "remember_user_default": true
     },
     "thumbnail": {
         "enable_thumbnails": true,

--- a/index.php
+++ b/index.php
@@ -745,6 +745,8 @@ function renderPage($conf, $pluginManager, $LINKSDB, $history)
             $PAGE->assign('username', escape($_GET['username']));
         }
         $PAGE->assign('returnurl',(isset($_SERVER['HTTP_REFERER']) ? escape($_SERVER['HTTP_REFERER']):''));
+        // add default state of the 'remember me' checkbox
+        $PAGE->assign('remember_user_default', $conf->get('privacy.remember_user_default'));
         $PAGE->renderPage('loginform');
         exit;
     }

--- a/tpl/default/loginform.html
+++ b/tpl/default/loginform.html
@@ -30,7 +30,8 @@
         </div>
         <div class="remember-me">
           <input type="checkbox" name="longlastingsession" id="longlastingsessionform"
-             checked="checked" tabindex="22">
+             {if="$remember_user_default"}checked="checked"{/if}
+             tabindex="22">
           <label for="longlastingsessionform">{'Remember me'|t}</label>
         </div>
         <div>

--- a/tpl/vintage/loginform.html
+++ b/tpl/vintage/loginform.html
@@ -24,7 +24,9 @@
         </label>
         <input type="submit" value="Login" class="bigbutton" tabindex="4">
         <label for="longlastingsession">
-          <input type="checkbox" name="longlastingsession" id="longlastingsession" tabindex="3">
+          <input type="checkbox" name="longlastingsession"
+                 id="longlastingsession" tabindex="3"
+                 {if="$remember_user_default"}checked="checked"{/if}>
           Stay signed in (Do not check on public computers)</label>
         <input type="hidden" name="token" value="{$token}">
         {if="$returnurl"}<input type="hidden" name="returnurl" value="{$returnurl}">{/if}


### PR DESCRIPTION
- the default state for the login page's 'remember me' checkbox can now be configured
- adapted the default and vintage theme to consider the new setting
- added documentation for the new setting

fixes #936 