### PR TITLE
added option to redirect all anonymous users to login page

### DIFF
--- a/application/config/ConfigManager.php
+++ b/application/config/ConfigManager.php
@@ -327,6 +327,7 @@ class ConfigManager
 
         $this->setEmpty('privacy.default_private_links', false);
         $this->setEmpty('privacy.hide_public_links', false);
+        $this->setEmpty('privacy.force_login', false);
         $this->setEmpty('privacy.hide_timestamps', false);
         // default state of the 'remember me' checkbox of the login form
         $this->setEmpty('privacy.remember_user_default', true);

--- a/doc/md/Shaarli-configuration.md
+++ b/doc/md/Shaarli-configuration.md
@@ -90,6 +90,7 @@ _These settings should not be edited_
 
 - **default_private_links**: Check the private checkbox by default for every new link.  
 - **hide_public_links**: All links are hidden while logged out.  
+- **force_login**: if **hide_public_links** and this are set to `true`, all anonymous users are redirected to the login page.
 - **hide_timestamps**: Timestamps are hidden.
 - **remember_user_default**: Default state of the login page's *remember me* checkbox
     - `true`: checked by default, `false`: unchecked by default
@@ -194,6 +195,7 @@ _These settings should not be edited_
     "privacy": {
         "default_private_links": true,
         "hide_public_links": false,
+        "force_login": false,
         "hide_timestamps": false,
         "remember_user_default": true
     },

--- a/index.php
+++ b/index.php
@@ -718,6 +718,23 @@ function renderPage($conf, $pluginManager, $LINKSDB, $history)
     $query = (isset($_SERVER['QUERY_STRING'])) ? $_SERVER['QUERY_STRING'] : '';
     $targetPage = Router::findPage($query, $_GET, isLoggedIn());
 
+    if (
+        // if the user isn't logged in
+        !isLoggedIn() &&
+        // and Shaarli doesn't have public content...
+        $conf->get('privacy.hide_public_links') &&
+        // and is configured to enforce the login
+        $conf->get('privacy.force_login') &&
+        // and the current page isn't already the login page
+        $targetPage !== Router::$PAGE_LOGIN &&
+        // and the user is not requesting a feed (which would lead to a different content-type as expected)
+        $targetPage !== Router::$PAGE_FEED_ATOM &&
+        $targetPage !== Router::$PAGE_FEED_RSS
+    ) {
+        // force current page to be the login page
+        $targetPage = Router::$PAGE_LOGIN;
+    }
+
     // Call plugin hooks for header, footer and includes, specifying which page will be rendered.
     // Then assign generated data to RainTPL.
     $common_hooks = array(


### PR DESCRIPTION
- new setting *force_login* added and documented
- if both, *force_login* and *hide_public_links* are set to true, all requests
  (except for the feeds) are redirected to the login page

I hope you can live with this adaption :wink:

fixes #952 