### PR TITLE
Add EditorConfig configuration

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,23 @@
+# EditorConfig: http://EditorConfig.org
+
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+indent_style = space
+indent_size = 4
+
+[*.{html,xml}]
+indent_size = 2
+
+[*.php]
+max_line_length = 100
+
+[Dockerfile]
+max_line_length = 80
+
+[Makefile]
+indent_style = tab

--- a/.gitattributes
+++ b/.gitattributes
@@ -24,6 +24,7 @@ Dockerfile      text
 *.min.js        binary
 
 # Exclude from Git archives
+.editorconfig   export-ignore
 .gitattributes  export-ignore
 .github         export-ignore
 .gitignore      export-ignore


### PR DESCRIPTION
EditorConfig allows specifying indentation, line feed and encoding
properties according to the type of file being edited.

Most editors support it out-of-the-box, or can benefit from it through a
plugin.

See:
- http://editorconfig.org/
- https://github.com/editorconfig/editorconfig
- https://github.com/editorconfig/editorconfig/wiki/EditorConfig-Properties