### PR TITLE
docker: add 'latest' image

### DIFF
--- a/doc/md/docker/shaarli-images.md
+++ b/doc/md/docker/shaarli-images.md
@@ -5,13 +5,22 @@ The images can be found in the [`shaarli/shaarli`](https://hub.docker.com/r/shaa
 repository.
 
 ### Available image tags
-- `latest`: master branch (tarball release)
+- `latest`: latest branch (tarball release)
+- `master`: master branch (tarball release)
 - `stable`: stable branch (tarball release)
 
-All images rely on:
+The `latest` and `master` images rely on:
+
+- [Alpine Linux](https://www.alpinelinux.org/)
+- [PHP7-FPM](http://php-fpm.org/)
+- [Nginx](http://nginx.org/)
+
+The `stable` image relies on:
+
 - [Debian 8 Jessie](https://hub.docker.com/_/debian/)
 - [PHP5-FPM](http://php-fpm.org/)
 - [Nginx](http://nginx.org/)
+
 
 ### Download from DockerHub
 ```bash

--- a/docker/alpine/Dockerfile.latest
+++ b/docker/alpine/Dockerfile.latest
@@ -1,0 +1,47 @@
+FROM alpine:3.6
+MAINTAINER Shaarli Community
+
+RUN apk --update --no-cache add \
+        ca-certificates \
+        curl \
+        nginx \
+        php7 \
+        php7-ctype \
+        php7-curl \
+        php7-fpm \
+        php7-gd \
+        php7-iconv \
+        php7-intl \
+        php7-json \
+        php7-mbstring \
+        php7-openssl \
+        php7-phar \
+        php7-session \
+        php7-xml \
+        php7-zlib \
+        s6
+
+COPY nginx.conf /etc/nginx/nginx.conf
+COPY php-fpm.conf /etc/php7/php-fpm.conf
+COPY services.d /etc/services.d
+
+RUN curl -sS https://getcomposer.org/installer | php7 -- --install-dir=/usr/local/bin --filename=composer \
+    && rm -rf /etc/php7/php-fpm.d/www.conf \
+    && sed -i 's/post_max_size.*/post_max_size = 10M/' /etc/php7/php.ini \
+    && sed -i 's/upload_max_filesize.*/upload_max_filesize = 10M/' /etc/php7/php.ini
+
+
+WORKDIR /var/www
+RUN curl -L https://github.com/shaarli/Shaarli/archive/latest.tar.gz | tar xzf - \
+    && mv Shaarli-latest shaarli \
+    && cd shaarli \
+    && composer --prefer-dist --no-dev install \
+    && rm -rf ~/.composer \
+    && chown -R nginx:nginx .
+
+VOLUME /var/www/shaarli/data
+
+EXPOSE 80
+
+ENTRYPOINT ["/bin/s6-svscan", "/etc/services.d"]
+CMD []

--- a/docker/alpine/IMAGE.md
+++ b/docker/alpine/IMAGE.md
@@ -1,5 +1,10 @@
-## shaarli:latest
-- [Debian 8 Jessie](https://hub.docker.com/_/debian/)
-- [PHP5-FPM](http://php-fpm.org/)
+## Alpine images
+- [Alpine Linux](https://www.alpinelinux.org/)
+- [PHP-FPM](http://php-fpm.org/)
 - [Nginx](http://nginx.org/)
-- [Shaarli](https://github.com/shaarli/Shaarli)
+
+### `shaarli/shaarli:latest`
+- [Shaarli](https://github.com/shaarli/Shaarli), `latest` branch
+
+### `shaarli/shaarli:master`
+- [Shaarli](https://github.com/shaarli/Shaarli), `master` branch


### PR DESCRIPTION
This implies the following changes:
- `shaarli/shaarli:latest` will now point to the `latest` release
- `shaarli/shaarli:master` will point to the `master` branch