### PR TITLE
Remove redirector setting from Configure page

### DIFF
--- a/tpl/default/configure.html
+++ b/tpl/default/configure.html
@@ -129,21 +129,6 @@
           </div>
         </div>
       </div>
-      <div class="pure-g">
-        <div class="pure-u-lg-{$ratioLabel} pure-u-1 ">
-          <div class="form-label">
-            <label for="redirector">
-              <span class="label-name">{'Redirector'|t}</span><br>
-              <span class="label-desc">{'e. g.'|t} <i>http://anonym.to/?</i> {'will mask the HTTP_REFERER'|t}</span>
-            </label>
-          </div>
-        </div>
-        <div class="pure-u-lg-{$ratioInput} pure-u-1 ">
-          <div class="form-input">
-            <input type="text" name="redirector" id="redirector" size="50" value="{$redirector}">
-          </div>
-        </div>
-      </div>
       <div class="clear"></div>
       <div class="pure-g">
         <div class="pure-u-lg-{$ratioLabel} pure-u-{$ratioLabelMobile} ">


### PR DESCRIPTION
This feature is pretty much useless these days as browsers have builtin features to support the thag "<meta name='referrer'", so keep the setting page as clean as possible.

Also, avoid advertising it too much, because I'm pretty sure it doesn't work very well with markdown descriptions (as Parsedown have some trouble regarding URL detection (without MarkDown link tag)).