### PR TITLE
Force HTTPS if the original port is 443 behind a reverse proxy

### DIFF
--- a/application/HttpUtils.php
+++ b/application/HttpUtils.php
@@ -302,6 +302,13 @@ function server_url($server)
                 $port = $server['HTTP_X_FORWARDED_PORT'];
             }
 
+            // This is a workaround for proxies that don't forward the scheme properly.
+            // Connecting over port 443 has to be in HTTPS.
+            // See https://github.com/shaarli/Shaarli/issues/1022
+            if ($port == '443') {
+                $scheme = 'https';
+            }
+
             if (($scheme == 'http' && $port != '80')
                 || ($scheme == 'https' && $port != '443')
             ) {

--- a/tests/HttpUtils/ServerUrlTest.php
+++ b/tests/HttpUtils/ServerUrlTest.php
@@ -186,4 +186,36 @@ class ServerUrlTest extends PHPUnit_Framework_TestCase
             )
         );
     }
+
+    /**
+     * Misconfigured server (see #1022): Proxy HTTP but 443
+     */
+    public function testHttpWithPort433()
+    {
+        $this->assertEquals(
+            'https://host.tld',
+            server_url(
+                array(
+                    'HTTPS' => 'Off',
+                    'SERVER_NAME' => 'host.tld',
+                    'SERVER_PORT' => '80',
+                    'HTTP_X_FORWARDED_PROTO' => 'http',
+                    'HTTP_X_FORWARDED_PORT' => '443'
+                )
+            )
+        );
+
+        $this->assertEquals(
+            'https://host.tld',
+            server_url(
+                array(
+                    'HTTPS' => 'Off',
+                    'SERVER_NAME' => 'host.tld',
+                    'SERVER_PORT' => '80',
+                    'HTTP_X_FORWARDED_PROTO' => 'https, http',
+                    'HTTP_X_FORWARDED_PORT' => '443, 80'
+                )
+            )
+        );
+    }
 }


### PR DESCRIPTION
Fixes #1022