### PR TITLE
Add a filter to only display public links

### DIFF
--- a/application/PageBuilder.php
+++ b/application/PageBuilder.php
@@ -85,7 +85,6 @@ class PageBuilder
         $this->tpl->assign('scripturl', index_url($_SERVER));
         $visibility = ! empty($_SESSION['visibility']) ? $_SESSION['visibility'] : '';
         $this->tpl->assign('visibility', $visibility);
-        $this->tpl->assign('nextVisibility', $this->getNextVisibility($visibility));
         $this->tpl->assign('untaggedonly', !empty($_SESSION['untaggedonly']));
         $this->tpl->assign('pagetitle', $this->conf->get('general.title', 'Shaarli'));
         if ($this->conf->exists('general.header_link')) {
@@ -171,25 +170,5 @@ class PageBuilder
         header($_SERVER['SERVER_PROTOCOL'] .' '. t('404 Not Found'));
         $this->tpl->assign('error_message', $message);
         $this->renderPage('404');
-    }
-
-    /**
-     * Return the next visibility option:
-     *      private -> public -> all
-     *
-     * @param string $current visibility value
-     *
-     * @return string next visibility value
-     */
-    protected function getNextVisibility($current)
-    {
-        switch ($current) {
-            case 'private':
-                return 'public';
-            case 'public':
-                return '';
-            default:
-                return 'private';
-        }
     }
 }

--- a/application/PageBuilder.php
+++ b/application/PageBuilder.php
@@ -83,7 +83,9 @@ class PageBuilder
             ApplicationUtils::getVersionHash(SHAARLI_VERSION, $this->conf->get('credentials.salt'))
         );
         $this->tpl->assign('scripturl', index_url($_SERVER));
-        $this->tpl->assign('privateonly', !empty($_SESSION['privateonly'])); // Show only private links?
+        $visibility = ! empty($_SESSION['visibility']) ? $_SESSION['visibility'] : '';
+        $this->tpl->assign('visibility', $visibility);
+        $this->tpl->assign('nextVisibility', $this->getNextVisibility($visibility));
         $this->tpl->assign('untaggedonly', !empty($_SESSION['untaggedonly']));
         $this->tpl->assign('pagetitle', $this->conf->get('general.title', 'Shaarli'));
         if ($this->conf->exists('general.header_link')) {
@@ -169,5 +171,25 @@ class PageBuilder
         header($_SERVER['SERVER_PROTOCOL'] .' '. t('404 Not Found'));
         $this->tpl->assign('error_message', $message);
         $this->renderPage('404');
+    }
+
+    /**
+     * Return the next visibility option:
+     *      private -> public -> all
+     *
+     * @param string $current visibility value
+     *
+     * @return string next visibility value
+     */
+    protected function getNextVisibility($current)
+    {
+        switch ($current) {
+            case 'private':
+                return 'public';
+            case 'public':
+                return '';
+            default:
+                return 'private';
+        }
     }
 }

--- a/application/Updater.php
+++ b/application/Updater.php
@@ -445,6 +445,18 @@ class Updater
         $this->linkDB->save($this->conf->get('resource.page_cache'));
         return true;
     }
+
+    /**
+     * Change privateonly session key to visibility.
+     */
+    public function updateMethodVisibilitySession()
+    {
+        if (isset($_SESSION['privateonly'])) {
+            unset($_SESSION['privateonly']);
+            $_SESSION['visibility'] = 'private';
+        }
+        return true;
+    }
 }
 
 /**

--- a/inc/languages/fr/LC_MESSAGES/shaarli.po
+++ b/inc/languages/fr/LC_MESSAGES/shaarli.po
@@ -1,15 +1,15 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Shaarli\n"
-"POT-Creation-Date: 2017-12-16 14:27+0100\n"
-"PO-Revision-Date: 2017-12-16 14:27+0100\n"
+"POT-Creation-Date: 2018-01-24 18:43+0100\n"
+"PO-Revision-Date: 2018-01-24 18:44+0100\n"
 "Last-Translator: \n"
 "Language-Team: Shaarli\n"
 "Language: fr_FR\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"X-Generator: Poedit 2.0.5\n"
+"X-Generator: Poedit 2.0.6\n"
 "X-Poedit-Basepath: ../../../..\n"
 "Plural-Forms: nplurals=2; plural=(n > 1);\n"
 "X-Poedit-SourceCharset: UTF-8\n"
@@ -161,11 +161,11 @@ msgstr ""
 "a été importé avec succès en %d secondes : %d liens importés, %d liens "
 "écrasés, %d liens ignorés."
 
-#: application/PageBuilder.php:169
+#: application/PageBuilder.php:168
 msgid "The page you are trying to reach does not exist or has been deleted."
 msgstr "La page que vous essayez de consulter n'existe pas ou a été supprimée."
 
-#: application/PageBuilder.php:171
+#: application/PageBuilder.php:170
 msgid "404 Not Found"
 msgstr "404 Introuvable"
 
@@ -265,46 +265,46 @@ msgstr "NON. Vous êtes banni pour le moment. Revenez plus tard."
 msgid "Wrong login/password."
 msgstr "Nom d'utilisateur ou mot de passe incorrects."
 
-#: index.php:1093
+#: index.php:1103
 msgid "You are not supposed to change a password on an Open Shaarli."
 msgstr ""
 "Vous n'êtes pas censé modifier le mot de passe d'un Shaarli en mode ouvert."
 
-#: index.php:1098 index.php:1139 index.php:1215 index.php:1245 index.php:1345
+#: index.php:1108 index.php:1149 index.php:1225 index.php:1255 index.php:1355
 msgid "Wrong token."
 msgstr "Jeton invalide."
 
-#: index.php:1103
+#: index.php:1113
 msgid "The old password is not correct."
 msgstr "L'ancien mot de passe est incorrect."
 
-#: index.php:1123
+#: index.php:1133
 msgid "Your password has been changed"
 msgstr "Votre mot de passe a été modifié"
 
-#: index.php:1176
+#: index.php:1186
 msgid "Configuration was saved."
 msgstr "La configuration a été sauvegardé."
 
-#: index.php:1227
+#: index.php:1237
 #, php-format
 msgid "The tag was removed from %d link."
 msgid_plural "The tag was removed from %d links."
 msgstr[0] "Le tag a été supprimé de %d lien."
 msgstr[1] "Le tag a été supprimé de %d liens."
 
-#: index.php:1228
+#: index.php:1238
 #, php-format
 msgid "The tag was renamed in %d link."
 msgid_plural "The tag was renamed in %d links."
 msgstr[0] "Le tag a été renommé dans %d lien."
 msgstr[1] "Le tag a été renommé dans %d liens."
 
-#: index.php:1444
+#: index.php:1454
 msgid "Note: "
 msgstr "Note : "
 
-#: index.php:1553
+#: index.php:1563
 #, php-format
 msgid ""
 "The file you are trying to upload is probably bigger than what this "
@@ -314,7 +314,7 @@ msgstr ""
 "le serveur web peut accepter (%s). Merci de l'envoyer en parties plus "
 "légères."
 
-#: index.php:1973
+#: index.php:1983
 #, php-format
 msgid ""
 "<pre>Sessions do not seem to work correctly on your server.<br>Make sure the "
@@ -333,7 +333,7 @@ msgstr ""
 "cookies. Nous vous recommandons d'accéder à votre serveur depuis son adresse "
 "IP ou un <em>Fully Qualified Domain Name</em>.<br>"
 
-#: index.php:1983
+#: index.php:1993
 msgid "Click to try again."
 msgstr "Cliquer ici pour réessayer."
 
@@ -933,25 +933,30 @@ msgstr "Filtres"
 
 #: tmp/linklist.paging.b91ef64efc3688266305ea9b42e5017e.rtpl.php:12
 #: tmp/linklist.paging.cedf684561d925457130839629000a81.rtpl.php:12
-msgid "Filter links by visibility"
-msgstr "Filtrer les liens par visibilité"
+msgid "Only display private links"
+msgstr "Afficher uniquement les liens privés"
 
-#: tmp/linklist.paging.b91ef64efc3688266305ea9b42e5017e.rtpl.php:17
-#: tmp/linklist.paging.cedf684561d925457130839629000a81.rtpl.php:17
+#: tmp/linklist.paging.b91ef64efc3688266305ea9b42e5017e.rtpl.php:15
+#: tmp/linklist.paging.cedf684561d925457130839629000a81.rtpl.php:15
+msgid "Only display public links"
+msgstr "Afficher uniquement les liens publics"
+
+#: tmp/linklist.paging.b91ef64efc3688266305ea9b42e5017e.rtpl.php:20
+#: tmp/linklist.paging.cedf684561d925457130839629000a81.rtpl.php:20
 msgid "Filter untagged links"
 msgstr "Filtrer par liens privés"
 
-#: tmp/linklist.paging.b91ef64efc3688266305ea9b42e5017e.rtpl.php:21
-#: tmp/linklist.paging.b91ef64efc3688266305ea9b42e5017e.rtpl.php:73
-#: tmp/linklist.paging.cedf684561d925457130839629000a81.rtpl.php:21
-#: tmp/linklist.paging.cedf684561d925457130839629000a81.rtpl.php:73
+#: tmp/linklist.paging.b91ef64efc3688266305ea9b42e5017e.rtpl.php:24
+#: tmp/linklist.paging.b91ef64efc3688266305ea9b42e5017e.rtpl.php:76
+#: tmp/linklist.paging.cedf684561d925457130839629000a81.rtpl.php:24
+#: tmp/linklist.paging.cedf684561d925457130839629000a81.rtpl.php:76
 #: tmp/page.footer.b91ef64efc3688266305ea9b42e5017e.rtpl.php:43
 #: tmp/page.footer.cedf684561d925457130839629000a81.rtpl.php:43
 msgid "Fold all"
 msgstr "Replier tout"
 
-#: tmp/linklist.paging.b91ef64efc3688266305ea9b42e5017e.rtpl.php:66
-#: tmp/linklist.paging.cedf684561d925457130839629000a81.rtpl.php:66
+#: tmp/linklist.paging.b91ef64efc3688266305ea9b42e5017e.rtpl.php:69
+#: tmp/linklist.paging.cedf684561d925457130839629000a81.rtpl.php:69
 msgid "Links per page"
 msgstr "Liens par page"
 
@@ -1284,8 +1289,8 @@ msgstr ""
 "Glisser ce lien dans votre barre de favoris ou cliquer droit dessus et « "
 "Ajouter aux favoris »"
 
-#~ msgid "Filter private links"
-#~ msgstr "Filtrer par liens privés"
+#~ msgid "Filter links by visibility"
+#~ msgstr "Filtrer les liens par visibilité"
 
 #~ msgid "Redirector"
 #~ msgstr "Redirecteur"

--- a/inc/languages/fr/LC_MESSAGES/shaarli.po
+++ b/inc/languages/fr/LC_MESSAGES/shaarli.po
@@ -1,15 +1,15 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Shaarli\n"
-"POT-Creation-Date: 2017-11-11 10:59+0100\n"
-"PO-Revision-Date: 2017-11-11 11:00+0100\n"
+"POT-Creation-Date: 2017-12-16 14:27+0100\n"
+"PO-Revision-Date: 2017-12-16 14:27+0100\n"
 "Last-Translator: \n"
 "Language-Team: Shaarli\n"
 "Language: fr_FR\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"X-Generator: Poedit 2.0.4\n"
+"X-Generator: Poedit 2.0.5\n"
 "X-Poedit-Basepath: ../../../..\n"
 "Plural-Forms: nplurals=2; plural=(n > 1);\n"
 "X-Poedit-SourceCharset: UTF-8\n"
@@ -161,11 +161,11 @@ msgstr ""
 "a été importé avec succès en %d secondes : %d liens importés, %d liens "
 "écrasés, %d liens ignorés."
 
-#: application/PageBuilder.php:167
+#: application/PageBuilder.php:169
 msgid "The page you are trying to reach does not exist or has been deleted."
 msgstr "La page que vous essayez de consulter n'existe pas ou a été supprimée."
 
-#: application/PageBuilder.php:169
+#: application/PageBuilder.php:171
 msgid "404 Not Found"
 msgstr "404 Introuvable"
 
@@ -178,17 +178,17 @@ msgstr "Les fichiers de l'extension \"%s\" sont introuvables."
 msgid "Couldn't retrieve Updater class methods."
 msgstr "Impossible de récupérer les méthodes de la classe Updater."
 
-#: application/Updater.php:493
+#: application/Updater.php:506
 msgid "An error occurred while running the update "
 msgstr "Une erreur s'est produite lors de l'exécution de la mise à jour "
 
-#: application/Updater.php:533
+#: application/Updater.php:546
 msgid "Updates file path is not set, can't write updates."
 msgstr ""
 "Le chemin vers le fichier de mise à jour n'est pas défini, impossible "
 "d'écrire les mises à jour."
 
-#: application/Updater.php:538
+#: application/Updater.php:551
 msgid "Unable to write updates in "
 msgstr "Impossible d'écrire les mises à jour dans "
 
@@ -265,46 +265,46 @@ msgstr "NON. Vous êtes banni pour le moment. Revenez plus tard."
 msgid "Wrong login/password."
 msgstr "Nom d'utilisateur ou mot de passe incorrects."
 
-#: index.php:1092
+#: index.php:1093
 msgid "You are not supposed to change a password on an Open Shaarli."
 msgstr ""
 "Vous n'êtes pas censé modifier le mot de passe d'un Shaarli en mode ouvert."
 
-#: index.php:1097 index.php:1138 index.php:1214 index.php:1244 index.php:1344
+#: index.php:1098 index.php:1139 index.php:1215 index.php:1245 index.php:1345
 msgid "Wrong token."
 msgstr "Jeton invalide."
 
-#: index.php:1102
+#: index.php:1103
 msgid "The old password is not correct."
 msgstr "L'ancien mot de passe est incorrect."
 
-#: index.php:1122
+#: index.php:1123
 msgid "Your password has been changed"
 msgstr "Votre mot de passe a été modifié"
 
-#: index.php:1175
+#: index.php:1176
 msgid "Configuration was saved."
 msgstr "La configuration a été sauvegardé."
 
-#: index.php:1226
+#: index.php:1227
 #, php-format
 msgid "The tag was removed from %d link."
 msgid_plural "The tag was removed from %d links."
 msgstr[0] "Le tag a été supprimé de %d lien."
 msgstr[1] "Le tag a été supprimé de %d liens."
 
-#: index.php:1227
+#: index.php:1228
 #, php-format
 msgid "The tag was renamed in %d link."
 msgid_plural "The tag was renamed in %d links."
 msgstr[0] "Le tag a été renommé dans %d lien."
 msgstr[1] "Le tag a été renommé dans %d liens."
 
-#: index.php:1443
+#: index.php:1444
 msgid "Note: "
 msgstr "Note : "
 
-#: index.php:1552
+#: index.php:1553
 #, php-format
 msgid ""
 "The file you are trying to upload is probably bigger than what this "
@@ -314,7 +314,7 @@ msgstr ""
 "le serveur web peut accepter (%s). Merci de l'envoyer en parties plus "
 "légères."
 
-#: index.php:1972
+#: index.php:1973
 #, php-format
 msgid ""
 "<pre>Sessions do not seem to work correctly on your server.<br>Make sure the "
@@ -333,7 +333,7 @@ msgstr ""
 "cookies. Nous vous recommandons d'accéder à votre serveur depuis son adresse "
 "IP ou un <em>Fully Qualified Domain Name</em>.<br>"
 
-#: index.php:1982
+#: index.php:1983
 msgid "Click to try again."
 msgstr "Cliquer ici pour réessayer."
 
@@ -870,10 +870,10 @@ msgstr "Recherche texte"
 #: tmp/linklist.b91ef64efc3688266305ea9b42e5017e.rtpl.php:38
 #: tmp/page.header.b91ef64efc3688266305ea9b42e5017e.rtpl.php:124
 #: tmp/page.header.cedf684561d925457130839629000a81.rtpl.php:124
-#: tmp/tag.cloud.b91ef64efc3688266305ea9b42e5017e.rtpl.php:33
-#: tmp/tag.cloud.b91ef64efc3688266305ea9b42e5017e.rtpl.php:61
-#: tmp/tag.list.b91ef64efc3688266305ea9b42e5017e.rtpl.php:33
-#: tmp/tag.list.b91ef64efc3688266305ea9b42e5017e.rtpl.php:71
+#: tmp/tag.cloud.b91ef64efc3688266305ea9b42e5017e.rtpl.php:36
+#: tmp/tag.cloud.b91ef64efc3688266305ea9b42e5017e.rtpl.php:64
+#: tmp/tag.list.b91ef64efc3688266305ea9b42e5017e.rtpl.php:36
+#: tmp/tag.list.b91ef64efc3688266305ea9b42e5017e.rtpl.php:74
 msgid "Filter by tag"
 msgstr "Filtrer par tag"
 
@@ -933,25 +933,25 @@ msgstr "Filtres"
 
 #: tmp/linklist.paging.b91ef64efc3688266305ea9b42e5017e.rtpl.php:12
 #: tmp/linklist.paging.cedf684561d925457130839629000a81.rtpl.php:12
-msgid "Filter private links"
-msgstr "Filtrer par liens privés"
+msgid "Filter links by visibility"
+msgstr "Filtrer les liens par visibilité"
 
-#: tmp/linklist.paging.b91ef64efc3688266305ea9b42e5017e.rtpl.php:18
-#: tmp/linklist.paging.cedf684561d925457130839629000a81.rtpl.php:18
+#: tmp/linklist.paging.b91ef64efc3688266305ea9b42e5017e.rtpl.php:17
+#: tmp/linklist.paging.cedf684561d925457130839629000a81.rtpl.php:17
 msgid "Filter untagged links"
 msgstr "Filtrer par liens privés"
 
-#: tmp/linklist.paging.b91ef64efc3688266305ea9b42e5017e.rtpl.php:22
-#: tmp/linklist.paging.b91ef64efc3688266305ea9b42e5017e.rtpl.php:74
-#: tmp/linklist.paging.cedf684561d925457130839629000a81.rtpl.php:22
-#: tmp/linklist.paging.cedf684561d925457130839629000a81.rtpl.php:74
+#: tmp/linklist.paging.b91ef64efc3688266305ea9b42e5017e.rtpl.php:21
+#: tmp/linklist.paging.b91ef64efc3688266305ea9b42e5017e.rtpl.php:73
+#: tmp/linklist.paging.cedf684561d925457130839629000a81.rtpl.php:21
+#: tmp/linklist.paging.cedf684561d925457130839629000a81.rtpl.php:73
 #: tmp/page.footer.b91ef64efc3688266305ea9b42e5017e.rtpl.php:43
 #: tmp/page.footer.cedf684561d925457130839629000a81.rtpl.php:43
 msgid "Fold all"
 msgstr "Replier tout"
 
-#: tmp/linklist.paging.b91ef64efc3688266305ea9b42e5017e.rtpl.php:67
-#: tmp/linklist.paging.cedf684561d925457130839629000a81.rtpl.php:67
+#: tmp/linklist.paging.b91ef64efc3688266305ea9b42e5017e.rtpl.php:66
+#: tmp/linklist.paging.cedf684561d925457130839629000a81.rtpl.php:66
 msgid "Links per page"
 msgstr "Liens par page"
 
@@ -1127,8 +1127,8 @@ msgstr "Aucun paramètre disponible."
 msgid "tags"
 msgstr "tags"
 
-#: tmp/tag.cloud.b91ef64efc3688266305ea9b42e5017e.rtpl.php:23
-#: tmp/tag.list.b91ef64efc3688266305ea9b42e5017e.rtpl.php:23
+#: tmp/tag.cloud.b91ef64efc3688266305ea9b42e5017e.rtpl.php:24
+#: tmp/tag.list.b91ef64efc3688266305ea9b42e5017e.rtpl.php:24
 msgid "List all links with those tags"
 msgstr "Lister tous les liens avec ces tags"
 
@@ -1283,6 +1283,9 @@ msgid ""
 msgstr ""
 "Glisser ce lien dans votre barre de favoris ou cliquer droit dessus et « "
 "Ajouter aux favoris »"
+
+#~ msgid "Filter private links"
+#~ msgstr "Filtrer par liens privés"
 
 #~ msgid "Redirector"
 #~ msgstr "Redirecteur"

--- a/index.php
+++ b/index.php
@@ -282,7 +282,7 @@ function logout() {
         unset($_SESSION['uid']);
         unset($_SESSION['ip']);
         unset($_SESSION['username']);
-        unset($_SESSION['privateonly']);
+        unset($_SESSION['visibility']);
         unset($_SESSION['untaggedonly']);
     }
     setcookie('shaarli_staySignedIn', FALSE, 0, WEB_PATH);
@@ -800,7 +800,7 @@ function renderPage($conf, $pluginManager, $LINKSDB, $history, $sessionManager)
     // -------- Tag cloud
     if ($targetPage == Router::$PAGE_TAGCLOUD)
     {
-        $visibility = ! empty($_SESSION['privateonly']) ? 'private' : 'all';
+        $visibility = ! empty($_SESSION['visibility']) ? $_SESSION['visibility'] : '';
         $filteringTags = isset($_GET['searchtags']) ? explode(' ', $_GET['searchtags']) : [];
         $tags = $LINKSDB->linksCountPerTag($filteringTags, $visibility);
 
@@ -845,7 +845,7 @@ function renderPage($conf, $pluginManager, $LINKSDB, $history, $sessionManager)
     // -------- Tag list
     if ($targetPage == Router::$PAGE_TAGLIST)
     {
-        $visibility = ! empty($_SESSION['privateonly']) ? 'private' : 'all';
+        $visibility = ! empty($_SESSION['visibility']) ? $_SESSION['visibility'] : '';
         $filteringTags = isset($_GET['searchtags']) ? explode(' ', $_GET['searchtags']) : [];
         $tags = $LINKSDB->linksCountPerTag($filteringTags, $visibility);
         foreach ($filteringTags as $tag) {
@@ -1011,15 +1011,16 @@ function renderPage($conf, $pluginManager, $LINKSDB, $history, $sessionManager)
     }
 
     // -------- User wants to see only private links (toggle)
-    if (isset($_GET['privateonly'])) {
-        if (empty($_SESSION['privateonly'])) {
-            $_SESSION['privateonly'] = 1; // See only private links
-        } else {
-            unset($_SESSION['privateonly']); // See all links
+    if (isset($_GET['visibility'])) {
+        unset($_SESSION['visibility']);
+        if ($_GET['visibility'] === 'private') {
+            $_SESSION['visibility'] = 'private'; // See only private links
+        } else if ($_GET['visibility'] === 'public') {
+            $_SESSION['visibility'] = 'public'; // See only public links
         }
 
         if (! empty($_SERVER['HTTP_REFERER'])) {
-            $location = generateLocation($_SERVER['HTTP_REFERER'], $_SERVER['HTTP_HOST'], array('privateonly'));
+            $location = generateLocation($_SERVER['HTTP_REFERER'], $_SERVER['HTTP_HOST'], array('visibility'));
         } else {
             $location = '?';
         }
@@ -1667,7 +1668,7 @@ function buildLinkList($PAGE,$LINKSDB, $conf, $pluginManager)
         }
     } else {
         // Filter links according search parameters.
-        $visibility = ! empty($_SESSION['privateonly']) ? 'private' : 'all';
+        $visibility = ! empty($_SESSION['visibility']) ? $_SESSION['visibility'] : '';
         $request = [
             'searchtags' => $searchtags,
             'searchterm' => $searchterm,
@@ -1743,7 +1744,7 @@ function buildLinkList($PAGE,$LINKSDB, $conf, $pluginManager)
         'result_count' => count($linksToDisplay),
         'search_term' => $searchterm,
         'search_tags' => $searchtags,
-        'visibility' => ! empty($_SESSION['privateonly']) ? 'private' : '',
+        'visibility' => ! empty($_SESSION['visibility']) ? $_SESSION['visibility'] : '',
         'redirector' => $conf->get('redirector.url'),  // Optional redirector URL.
         'links' => $linkDisp,
     );

--- a/index.php
+++ b/index.php
@@ -1012,11 +1012,21 @@ function renderPage($conf, $pluginManager, $LINKSDB, $history, $sessionManager)
 
     // -------- User wants to see only private links (toggle)
     if (isset($_GET['visibility'])) {
-        unset($_SESSION['visibility']);
         if ($_GET['visibility'] === 'private') {
-            $_SESSION['visibility'] = 'private'; // See only private links
+            // Visibility not set or not already private, set private, otherwise reset it
+            if (empty($_SESSION['visibility']) || $_SESSION['visibility'] !== 'private') {
+                // See only private links
+                $_SESSION['visibility'] = 'private';
+            } else {
+                unset($_SESSION['visibility']);
+            }
         } else if ($_GET['visibility'] === 'public') {
-            $_SESSION['visibility'] = 'public'; // See only public links
+            if (empty($_SESSION['visibility']) || $_SESSION['visibility'] !== 'public') {
+                // See only public links
+                $_SESSION['visibility'] = 'public';
+            } else {
+                unset($_SESSION['visibility']);
+            }
         }
 
         if (! empty($_SERVER['HTTP_REFERER'])) {

--- a/tpl/default/css/shaarli.css
+++ b/tpl/default/css/shaarli.css
@@ -453,6 +453,11 @@ body, .pure-g [class*="pure-u"] {
     background: #1b926c;
 }
 
+.linklist-filters .filter-block {
+    color: #f5f5f5;
+    background: #ac2925;
+}
+
 .linklist-pages {
     margin: 5px 0;
     color: #252525;

--- a/tpl/default/linklist.paging.html
+++ b/tpl/default/linklist.paging.html
@@ -6,8 +6,8 @@
           {'Filters'|t}
         </span>
         {if="isLoggedIn()"}
-        <a href="?privateonly" title="{'Filter private links'|t}"
-           class={if="$privateonly"}"filter-on"{else}"filter-off"{/if}
+        <a href="?visibility={$nextVisibility}" title="{'Filter links by visibility'|t}"
+           class="{if="$visibility=='private'"}filter-on{elseif="$visibility=='public'"}filter-block{else}filter-off{/if}"
         ><i class="fa fa-key"></i></a>
         {/if}
         <a href="?untaggedonly" title="{'Filter untagged links'|t}"

--- a/tpl/default/linklist.paging.html
+++ b/tpl/default/linklist.paging.html
@@ -6,9 +6,12 @@
           {'Filters'|t}
         </span>
         {if="isLoggedIn()"}
-        <a href="?visibility={$nextVisibility}" title="{'Filter links by visibility'|t}"
-           class="{if="$visibility=='private'"}filter-on{elseif="$visibility=='public'"}filter-block{else}filter-off{/if}"
-        ><i class="fa fa-key"></i></a>
+        <a href="?visibility=private" title="{'Only display private links'|t}"
+           class="{if="$visibility==='private'"}filter-on{else}filter-off{/if}"
+        ><i class="fa fa-user-secret"></i></a>
+        <a href="?visibility=public" title="{'Only display public links'|t}"
+           class="{if="$visibility==='public'"}filter-on{else}filter-off{/if}"
+        ><i class="fa fa-globe"></i></a>
         {/if}
         <a href="?untaggedonly" title="{'Filter untagged links'|t}"
            class={if="$untaggedonly"}"filter-on"{else}"filter-off"{/if}

--- a/tpl/vintage/linklist.paging.html
+++ b/tpl/vintage/linklist.paging.html
@@ -1,11 +1,11 @@
 <div class="paging">
 {if="isLoggedIn()"}
     <div class="paging_privatelinks">
-        <a href="?privateonly">
-		{if="$privateonly"}
-		<img src="images/private_16x16_active.png#" width="16" height="16" title="Click to see all links" alt="Click to see all links">
+        <a href="?visibility={$nextVisibility}">
+		{if="$visibility=='private' || $visibility=='public'"}
+		<img src="images/private_16x16_active.png#" width="16" height="16" title="Filter links by visibility" alt="Filter links by visibility">
 		{else}
-		<img src="images/private_16x16.png#" width="16" height="16" title="Click to see only private links" alt="Click to see only private links">
+		<img src="images/private_16x16.png#" width="16" height="16" title="Filter links by visibility" alt="Filter links by visibility">
 		{/if}
 		</a>
 

--- a/tpl/vintage/linklist.paging.html
+++ b/tpl/vintage/linklist.paging.html
@@ -1,8 +1,8 @@
 <div class="paging">
 {if="isLoggedIn()"}
     <div class="paging_privatelinks">
-        <a href="?visibility={$nextVisibility}">
-		{if="$visibility=='private' || $visibility=='public'"}
+        <a href="?visibility=private">
+		{if="$visibility=='private'"}
 		<img src="images/private_16x16_active.png#" width="16" height="16" title="Filter links by visibility" alt="Filter links by visibility">
 		{else}
 		<img src="images/private_16x16.png#" width="16" height="16" title="Filter links by visibility" alt="Filter links by visibility">


### PR DESCRIPTION
When the key filter is clicked once, it only displays private link. When it is clicked on again, it becomes red and only public links are displayed. Another click and all links are displayed. The current visibility status is shown in the search banner

Fixes #1030