### PR TITLE
Adding 3rd party plugin 'markdown-toolbar' to docs

### DIFF
--- a/doc/md/Community-&-Related-software.md
+++ b/doc/md/Community-&-Related-software.md
@@ -31,6 +31,7 @@ See [REST API](REST-API) for a list of official and community clients.
 - [emojione](https://github.com/NerosTie/emojione) by [@NerosTie](https://github.com/NerosTie): Add colorful emojis to your Shaarli.
 - [google analytics](https://github.com/ericjuden/Shaarli-Google-Analytics-Plugin) by [@ericjuden](http://github.com/ericjuden): Adds Google Analytics tracking support
 - [launch](https://github.com/ArthurHoaro/launch-plugin) - Launch Plugin is a plugin designed to enhance and customize Launch Theme for Shaarli.
+- [markdown-toolbar](https://github.com/immanuelfodor/shaarli-markdown-toolbar) by [@immanuelfodor](https://github.com/immanuelfodor) - Easily insert markdown syntax into the Description field when editing a link.
 - [related](https://github.com/ilesinge/shaarli-related) by [@ilesinge](https://github.com/ilesinge) - Show related links based on the number of identical tags.
 - [social](https://github.com/alexisju/social) by [@alexisju](https://github.com/alexisju): share links to social networks.
 - [shaarli2twitter](https://github.com/ArthurHoaro/shaarli2twitter) by [@ArthurHoaro](https://github.com/ArthurHoaro) - Automatically tweet your shared links from Shaarli


### PR DESCRIPTION
Hi Everyone,

I spent the last couple of days creating a markdown editor plugin to Shaarli, if you think it is helpful for others, we can include it in the documentation. This plugin is a lot more complex thing than PR #1042, but I think it well worth the effort. It improved the overall link adding/editing experience a lot for me, especially on mobile. It was a pain every time to get the symbols on my Android keyboard, but now it is a single click.

https://github.com/immanuelfodor/shaarli-markdown-toolbar
