### PR TITLE
Use LC_COLLATE instead of LC_MESSAGES if php-intl is not installed

### DIFF
--- a/application/Languages.php
+++ b/application/Languages.php
@@ -69,6 +69,8 @@ class Languages
     {
         $this->conf = $conf;
         $confLanguage = $this->conf->get('translation.language', 'auto');
+        // Auto mode or invalid parameter, use the detected language.
+        // If the detected language is invalid, it doesn't matter, it will use English.
         if ($confLanguage === 'auto' || ! $this->isValidLanguage($confLanguage)) {
             $this->language = substr($language, 0, 5);
         } else {

--- a/index.php
+++ b/index.php
@@ -124,6 +124,11 @@ if (isset($_COOKIE['shaarli']) && !SessionManager::checkId($_COOKIE['shaarli']))
 $conf = new ConfigManager();
 $sessionManager = new SessionManager($_SESSION, $conf);
 
+// LC_MESSAGES isn't defined without php-intl, in this case use LC_COLLATE locale instead.
+if (! defined('LC_MESSAGES')) {
+    define('LC_MESSAGES', LC_COLLATE);
+}
+
 // Sniff browser language and set date format accordingly.
 if (isset($_SERVER['HTTP_ACCEPT_LANGUAGE'])) {
     autoLocale($_SERVER['HTTP_ACCEPT_LANGUAGE']);


### PR DESCRIPTION
As stated in the docs:

> LC_MESSAGES for system responses (available if PHP was compiled with libintl)

Fixes #1067