### PR TITLE
Processes markdown also for linksToDisplay on Daily page

### DIFF
--- a/plugins/markdown/markdown.php
+++ b/plugins/markdown/markdown.php
@@ -70,6 +70,19 @@ function hook_markdown_render_feed($data, $conf)
  */
 function hook_markdown_render_daily($data, $conf)
 {
+    // Manipulate raw data
+    foreach ($data['linksToDisplay'] as &$value) {
+        if (!empty($value['tags']) && noMarkdownTag($value['tags'])) {
+            $value = stripNoMarkdownTag($value);
+            continue;
+        }
+        $value['formatedDescription'] = process_markdown(
+            $value['formatedDescription'],
+            $conf->get('security.markdown_escape', true),
+            $conf->get('security.allowed_protocols')
+        );
+    }
+    
     // Manipulate columns data
     foreach ($data['cols'] as &$value) {
         foreach ($value as &$value2) {

--- a/tests/plugins/PluginMarkdownTest.php
+++ b/tests/plugins/PluginMarkdownTest.php
@@ -57,7 +57,8 @@ class PluginMarkdownTest extends PHPUnit_Framework_TestCase
     {
         $markdown = '# My title' . PHP_EOL . 'Very interesting content.';
         $data = array(
-            'linksToDisplay' => arrat(
+            // Raw data
+            'linksToDisplay' => array(
                 // nth link
                 0 => array(
                     'formatedDescription' => $markdown,
@@ -155,6 +156,7 @@ class PluginMarkdownTest extends PHPUnit_Framework_TestCase
         $this->assertEquals($str, $processed['links'][0]['description']);
 
         $data = array(
+            // Raw data
             'linksToDisplay' => array(
                 // nth link
                 0 => array(

--- a/tests/plugins/PluginMarkdownTest.php
+++ b/tests/plugins/PluginMarkdownTest.php
@@ -57,6 +57,12 @@ class PluginMarkdownTest extends PHPUnit_Framework_TestCase
     {
         $markdown = '# My title' . PHP_EOL . 'Very interesting content.';
         $data = array(
+            'linksToDisplay' => arrat(
+                // nth link
+                0 => array(
+                    'formatedDescription' => $markdown,
+                ),
+            ),
             // Columns data
             'cols' => array(
                 // First, second, third.
@@ -70,6 +76,8 @@ class PluginMarkdownTest extends PHPUnit_Framework_TestCase
         );
 
         $data = hook_markdown_render_daily($data, $this->conf);
+        $this->assertNotFalse(strpos($data['linksToDisplay'][0]['formatedDescription'], '<h1>'));
+        $this->assertNotFalse(strpos($data['linksToDisplay'][0]['formatedDescription'], '<p>'));
         $this->assertNotFalse(strpos($data['cols'][0][0]['formatedDescription'], '<h1>'));
         $this->assertNotFalse(strpos($data['cols'][0][0]['formatedDescription'], '<p>'));
     }
@@ -147,6 +155,14 @@ class PluginMarkdownTest extends PHPUnit_Framework_TestCase
         $this->assertEquals($str, $processed['links'][0]['description']);
 
         $data = array(
+            'linksToDisplay' => array(
+                // nth link
+                0 => array(
+                    'formatedDescription' => $str,
+                    'tags' => NO_MD_TAG,
+                    'taglist' => array(),
+                ),
+            ),
             // Columns data
             'cols' => array(
                 // First, second, third.
@@ -163,6 +179,7 @@ class PluginMarkdownTest extends PHPUnit_Framework_TestCase
 
         $data = hook_markdown_render_daily($data, $this->conf);
         $this->assertEquals($str, $data['cols'][0][0]['formatedDescription']);
+        $this->assertEquals($str, $data['linksToDisplay'][0]['formatedDescription']);
     }
 
     /**


### PR DESCRIPTION
This may be needed by themes that use the regular linksToDisplay entry instead of columns.