### PR TITLE
Refactor user login and session management

### DIFF
--- a/application/HttpUtils.php
+++ b/application/HttpUtils.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * GET an HTTP URL to retrieve its content
- * Uses the cURL library or a fallback method 
+ * Uses the cURL library or a fallback method
  *
  * @param string          $url               URL to get (http://...)
  * @param int             $timeout           network timeout (in seconds)
@@ -414,6 +414,37 @@ function getIpAddressFromProxy($server, $trustedIps)
 
     return array_pop($ips);
 }
+
+
+/**
+ * Return an identifier based on the advertised client IP address(es)
+ *
+ * This aims at preventing session hijacking from users behind the same proxy
+ * by relying on HTTP headers.
+ *
+ * See:
+ * - https://secure.php.net/manual/en/reserved.variables.server.php
+ * - https://stackoverflow.com/questions/3003145/how-to-get-the-client-ip-address-in-php
+ * - https://stackoverflow.com/questions/12233406/preventing-session-hijacking
+ * - https://stackoverflow.com/questions/21354859/trusting-x-forwarded-for-to-identify-a-visitor
+ *
+ * @param array $server The $_SERVER array
+ *
+ * @return string An identifier based on client IP address information
+ */
+function client_ip_id($server)
+{
+    $ip = $server['REMOTE_ADDR'];
+
+    if (isset($server['HTTP_X_FORWARDED_FOR'])) {
+        $ip = $ip . '_' . $server['HTTP_X_FORWARDED_FOR'];
+    }
+    if (isset($server['HTTP_CLIENT_IP'])) {
+        $ip = $ip . '_' . $server['HTTP_CLIENT_IP'];
+    }
+    return $ip;
+}
+
 
 /**
  * Returns true if Shaarli's currently browsed in HTTPS.

--- a/application/LoginManager.php
+++ b/application/LoginManager.php
@@ -6,11 +6,22 @@ namespace Shaarli;
  */
 class LoginManager
 {
+    /** @var array A reference to the $_GLOBALS array */
     protected $globals = [];
+
+    /** @var ConfigManager Configuration Manager instance **/
     protected $configManager = null;
+
+    /** @var SessionManager Session Manager instance **/
     protected $sessionManager = null;
+
+    /** @var string Path to the file containing IP bans */
     protected $banFile = '';
+
+    /** @var bool Whether the user is logged in **/
     protected $isLoggedIn = false;
+
+    /** @var bool Whether the Shaarli instance is open to public edition **/
     protected $openShaarli = false;
 
     /**

--- a/application/LoginManager.php
+++ b/application/LoginManager.php
@@ -48,7 +48,6 @@ class LoginManager
     /**
      * Check user session state and validity (expiration)
      *
-     * @param array  $session    The $_SESSION array (reference)
      * @param array  $cookie     The $_COOKIE array
      * @param string $webPath    Path on the server in which the cookie will be available on
      * @param string $clientIpId Client IP address identifier
@@ -56,7 +55,7 @@ class LoginManager
      *
      * @return bool true if the user session is valid, false otherwise
      */
-    public function checkLoginState(& $session, $cookie, $webPath, $clientIpId, $token)
+    public function checkLoginState($cookie, $webPath, $clientIpId, $token)
     {
         if (! $this->configManager->exists('credentials.login')) {
             // Shaarli is not configured yet

--- a/application/PageBuilder.php
+++ b/application/PageBuilder.php
@@ -25,6 +25,9 @@ class PageBuilder
      * @var LinkDB $linkDB instance.
      */
     protected $linkDB;
+    
+    /** @var bool $isLoggedIn Whether the user is logged in **/
+    protected $isLoggedIn = false;
 
     /**
      * PageBuilder constructor.
@@ -34,12 +37,13 @@ class PageBuilder
      * @param LinkDB        $linkDB instance.
      * @param string        $token  Session token
      */
-    public function __construct(&$conf, $linkDB = null, $token = null)
+    public function __construct(&$conf, $linkDB = null, $token = null, $isLoggedIn = false)
     {
         $this->tpl = false;
         $this->conf = $conf;
         $this->linkDB = $linkDB;
         $this->token = $token;
+        $this->isLoggedIn = $isLoggedIn;
     }
 
     /**
@@ -55,7 +59,7 @@ class PageBuilder
                 $this->conf->get('resource.update_check'),
                 $this->conf->get('updates.check_updates_interval'),
                 $this->conf->get('updates.check_updates'),
-                isLoggedIn(),
+                $this->isLoggedIn,
                 $this->conf->get('updates.check_updates_branch')
             );
             $this->tpl->assign('newVersion', escape($version));
@@ -67,6 +71,7 @@ class PageBuilder
             $this->tpl->assign('versionError', escape($exc->getMessage()));
         }
 
+        $this->tpl->assign('is_logged_in', $this->isLoggedIn);
         $this->tpl->assign('feedurl', escape(index_url($_SERVER)));
         $searchcrits = ''; // Search criteria
         if (!empty($_GET['searchtags'])) {

--- a/application/SessionManager.php
+++ b/application/SessionManager.php
@@ -6,6 +6,10 @@ namespace Shaarli;
  */
 class SessionManager
 {
+    /** Session expiration timeout, in seconds */
+    public static $INACTIVITY_TIMEOUT = 3600;
+
+    /** Local reference to the global $_SESSION array */
     protected $session = [];
 
     /**

--- a/application/security/LoginManager.php
+++ b/application/security/LoginManager.php
@@ -1,5 +1,5 @@
 <?php
-namespace Shaarli;
+namespace Shaarli\Security;
 
 use Shaarli\Config\ConfigManager;
 

--- a/application/security/LoginManager.php
+++ b/application/security/LoginManager.php
@@ -95,7 +95,6 @@ class LoginManager
             // The user client has a valid stay-signed-in cookie
             // Session information is updated with the current client information
             $this->sessionManager->storeLoginInfo($clientIpId);
-            $this->isLoggedIn = true;
 
         } elseif ($this->sessionManager->hasSessionExpired()
             || $this->sessionManager->hasClientIpChanged($clientIpId)
@@ -105,6 +104,7 @@ class LoginManager
             return;
         }
 
+        $this->isLoggedIn = true;
         $this->sessionManager->extendSession();
     }
 

--- a/application/security/LoginManager.php
+++ b/application/security/LoginManager.php
@@ -46,7 +46,7 @@ class LoginManager
         $this->sessionManager = $sessionManager;
         $this->banFile = $this->configManager->get('resource.ban_file', 'data/ipbans.php');
         $this->readBanFile();
-        if ($this->configManager->get('security.open_shaarli')) {
+        if ($this->configManager->get('security.open_shaarli') === true) {
             $this->openShaarli = true;
         }
     }
@@ -80,8 +80,6 @@ class LoginManager
      *
      * @param array  $cookie     The $_COOKIE array
      * @param string $clientIpId Client IP address identifier
-     *
-     * @return bool true if the user session is valid, false otherwise
      */
     public function checkLoginState($cookie, $clientIpId)
     {
@@ -94,11 +92,12 @@ class LoginManager
         if (isset($cookie[self::$STAY_SIGNED_IN_COOKIE])
             && $cookie[self::$STAY_SIGNED_IN_COOKIE] === $this->staySignedInToken
         ) {
+            // The user client has a valid stay-signed-in cookie
+            // Session information is updated with the current client information
             $this->sessionManager->storeLoginInfo($clientIpId);
             $this->isLoggedIn = true;
-        }
 
-        if ($this->sessionManager->hasSessionExpired()
+        } elseif ($this->sessionManager->hasSessionExpired()
             || $this->sessionManager->hasClientIpChanged($clientIpId)
         ) {
             $this->sessionManager->logout();

--- a/application/security/LoginManager.php
+++ b/application/security/LoginManager.php
@@ -49,13 +49,12 @@ class LoginManager
      * Check user session state and validity (expiration)
      *
      * @param array  $cookie     The $_COOKIE array
-     * @param string $webPath    Path on the server in which the cookie will be available on
      * @param string $clientIpId Client IP address identifier
      * @param string $token      Session token
      *
      * @return bool true if the user session is valid, false otherwise
      */
-    public function checkLoginState($cookie, $webPath, $clientIpId, $token)
+    public function checkLoginState($cookie, $clientIpId, $token)
     {
         if (! $this->configManager->exists('credentials.login')) {
             // Shaarli is not configured yet
@@ -73,7 +72,7 @@ class LoginManager
         if ($this->sessionManager->hasSessionExpired()
             || $this->sessionManager->hasClientIpChanged($clientIpId)
         ) {
-            $this->sessionManager->logout($webPath);
+            $this->sessionManager->logout();
             $this->isLoggedIn = false;
             return;
         }

--- a/application/security/SessionManager.php
+++ b/application/security/SessionManager.php
@@ -1,5 +1,5 @@
 <?php
-namespace Shaarli;
+namespace Shaarli\Security;
 
 use Shaarli\Config\ConfigManager;
 

--- a/application/security/SessionManager.php
+++ b/application/security/SessionManager.php
@@ -113,8 +113,6 @@ class SessionManager
      */
     public function storeLoginInfo($clientIpId)
     {
-        // Generate unique random number (different than phpsessionid)
-        $this->session['uid'] = sha1(uniqid('', true) . '_' . mt_rand());
         $this->session['ip'] = $clientIpId;
         $this->session['username'] = $this->conf->get('credentials.login');
         $this->extendTimeValidityBy(self::$SHORT_TIMEOUT);
@@ -154,7 +152,6 @@ class SessionManager
     public function logout()
     {
         if (isset($this->session)) {
-            unset($this->session['uid']);
             unset($this->session['ip']);
             unset($this->session['expires_on']);
             unset($this->session['username']);
@@ -172,9 +169,6 @@ class SessionManager
      */
     public function hasSessionExpired()
     {
-        if (empty($this->session['uid'])) {
-            return true;
-        }
         if (time() >= $this->session['expires_on']) {
             return true;
         }

--- a/application/security/SessionManager.php
+++ b/application/security/SessionManager.php
@@ -169,6 +169,9 @@ class SessionManager
      */
     public function hasSessionExpired()
     {
+        if (empty($this->session['expires_on'])) {
+            return true;
+        }
         if (time() >= $this->session['expires_on']) {
             return true;
         }
@@ -188,7 +191,7 @@ class SessionManager
         if ($this->conf->get('security.session_protection_disabled') === true) {
             return false;
         }
-        if ($this->session['ip'] == $clientIpId) {
+        if (isset($this->session['ip']) && $this->session['ip'] === $clientIpId) {
             return false;
         }
         return true;

--- a/application/security/SessionManager.php
+++ b/application/security/SessionManager.php
@@ -14,9 +14,6 @@ class SessionManager
     /** @var int Session expiration timeout, in seconds */
     public static $LONG_TIMEOUT = 31536000; // 1 year
 
-    /** @var string Name of the cookie set after logging in **/
-    public static $LOGGED_IN_COOKIE = 'shaarli_staySignedIn';
-
     /** @var array Local reference to the global $_SESSION array */
     protected $session = [];
 

--- a/composer.json
+++ b/composer.json
@@ -36,7 +36,8 @@
             "Shaarli\\Api\\Controllers\\": "application/api/controllers",
             "Shaarli\\Api\\Exceptions\\": "application/api/exceptions",
             "Shaarli\\Config\\": "application/config/",
-            "Shaarli\\Config\\Exception\\": "application/config/exception"
+            "Shaarli\\Config\\Exception\\": "application/config/exception",
+            "Shaarli\\Security\\": "application/security"
         }
     }
 }

--- a/index.php
+++ b/index.php
@@ -123,6 +123,7 @@ if (isset($_COOKIE['shaarli']) && !SessionManager::checkId($_COOKIE['shaarli']))
 $conf = new ConfigManager();
 $sessionManager = new SessionManager($_SESSION, $conf);
 $loginManager = new LoginManager($GLOBALS, $conf, $sessionManager);
+$clientIpId = client_ip_id($_SERVER);
 
 // LC_MESSAGES isn't defined without php-intl, in this case use LC_COLLATE locale instead.
 if (! defined('LC_MESSAGES')) {
@@ -178,7 +179,7 @@ if (! is_file($conf->getConfigFileExt())) {
 // a token depending of deployment salt, user password, and the current ip
 define('STAY_SIGNED_IN_TOKEN', sha1($conf->get('credentials.hash') . $_SERVER['REMOTE_ADDR'] . $conf->get('credentials.salt')));
 
-$loginManager->checkLoginState($_SERVER, $_SESSION, $_COOKIE, WEB_PATH, STAY_SIGNED_IN_TOKEN);
+$loginManager->checkLoginState($_SESSION, $_COOKIE, WEB_PATH, $clientIpId, STAY_SIGNED_IN_TOKEN);
 
 /**
  * Adapter function for PageBuilder
@@ -200,7 +201,7 @@ if (isset($_POST['login'])) {
     }
     if (isset($_POST['password'])
         && $sessionManager->checkToken($_POST['token'])
-        && $loginManager->checkCredentials($_SERVER, $_POST['login'], $_POST['password'])
+        && $loginManager->checkCredentials($_SERVER['REMOTE_ADDR'], $clientIpId, $_POST['login'], $_POST['password'])
     ) {
         // Login/password is OK.
         $loginManager->handleSuccessfulLogin($_SERVER);

--- a/index.php
+++ b/index.php
@@ -207,7 +207,7 @@ function setup_login_state($conf)
     }
     // If session does not exist on server side, or IP address has changed, or session has expired, logout.
     if (empty($_SESSION['uid'])
-        || ($conf->get('security.session_protection_disabled') === false && $_SESSION['ip'] != allIPs())
+        || ($conf->get('security.session_protection_disabled') === false && $_SESSION['ip'] != client_ip_id($_SERVER))
         || time() >= $_SESSION['expires_on'])
     {
         logout();
@@ -231,16 +231,6 @@ $userIsLoggedIn = setup_login_state($conf);
 // ------------------------------------------------------------------------------------------
 // Session management
 
-// Returns the IP address of the client (Used to prevent session cookie hijacking.)
-function allIPs()
-{
-    $ip = $_SERVER['REMOTE_ADDR'];
-    // Then we use more HTTP headers to prevent session hijacking from users behind the same proxy.
-    if (isset($_SERVER['HTTP_X_FORWARDED_FOR'])) { $ip=$ip.'_'.$_SERVER['HTTP_X_FORWARDED_FOR']; }
-    if (isset($_SERVER['HTTP_CLIENT_IP'])) { $ip=$ip.'_'.$_SERVER['HTTP_CLIENT_IP']; }
-    return $ip;
-}
-
 /**
  * Load user session.
  *
@@ -249,7 +239,7 @@ function allIPs()
 function fillSessionInfo($conf)
 {
     $_SESSION['uid'] = sha1(uniqid('',true).'_'.mt_rand()); // Generate unique random number (different than phpsessionid)
-    $_SESSION['ip']=allIPs();                // We store IP address(es) of the client to make sure session is not hijacked.
+    $_SESSION['ip'] = client_ip_id($_SERVER);
     $_SESSION['username']= $conf->get('credentials.login');
     $_SESSION['expires_on']=time()+INACTIVITY_TIMEOUT;  // Set session expiration.
 }

--- a/index.php
+++ b/index.php
@@ -78,8 +78,8 @@ require_once 'application/Updater.php';
 use \Shaarli\Languages;
 use \Shaarli\ThemeUtils;
 use \Shaarli\Config\ConfigManager;
-use \Shaarli\LoginManager;
-use \Shaarli\SessionManager;
+use \Shaarli\Security\LoginManager;
+use \Shaarli\Security\SessionManager;
 
 // Ensure the PHP version is supported
 try {

--- a/index.php
+++ b/index.php
@@ -179,7 +179,7 @@ if (! is_file($conf->getConfigFileExt())) {
 // a token depending of deployment salt, user password, and the current ip
 define('STAY_SIGNED_IN_TOKEN', sha1($conf->get('credentials.hash') . $_SERVER['REMOTE_ADDR'] . $conf->get('credentials.salt')));
 
-$loginManager->checkLoginState($_SESSION, $_COOKIE, WEB_PATH, $clientIpId, STAY_SIGNED_IN_TOKEN);
+$loginManager->checkLoginState($_COOKIE, WEB_PATH, $clientIpId, STAY_SIGNED_IN_TOKEN);
 
 /**
  * Adapter function to ensure compatibility with third-party templates

--- a/tests/HttpUtils/ClientIpIdTest.php
+++ b/tests/HttpUtils/ClientIpIdTest.php
@@ -1,0 +1,52 @@
+<?php
+/**
+ * HttpUtils' tests
+ */
+
+require_once 'application/HttpUtils.php';
+
+/**
+ * Unitary tests for client_ip_id()
+ */
+class ClientIpIdTest extends PHPUnit_Framework_TestCase
+{
+    /**
+     * Get a remote client ID based on its IP
+     */
+    public function testClientIpIdRemote()
+    {
+        $this->assertEquals(
+            '10.1.167.42',
+            client_ip_id(['REMOTE_ADDR' => '10.1.167.42'])
+        );
+    }
+
+    /**
+     * Get a remote client ID based on its IP and proxy information (1)
+     */
+    public function testClientIpIdRemoteForwarded()
+    {
+        $this->assertEquals(
+            '10.1.167.42_127.0.1.47',
+            client_ip_id([
+                'REMOTE_ADDR' => '10.1.167.42',
+                'HTTP_X_FORWARDED_FOR' => '127.0.1.47'
+            ])
+        );
+    }
+
+    /**
+     * Get a remote client ID based on its IP and proxy information (2)
+     */
+    public function testClientIpIdRemoteForwardedClient()
+    {
+        $this->assertEquals(
+            '10.1.167.42_10.1.167.56_127.0.1.47',
+            client_ip_id([
+                'REMOTE_ADDR' => '10.1.167.42',
+                'HTTP_X_FORWARDED_FOR' => '10.1.167.56',
+                'HTTP_CLIENT_IP' => '127.0.1.47'
+            ])
+        );
+    }
+}

--- a/tests/LoginManagerTest.php
+++ b/tests/LoginManagerTest.php
@@ -38,7 +38,7 @@ class LoginManagerTest extends TestCase
         $this->globals = &$GLOBALS;
         unset($this->globals['IPBANS']);
 
-        $this->loginManager = new LoginManager($this->globals, $this->configManager);
+        $this->loginManager = new LoginManager($this->globals, $this->configManager, null);
         $this->server['REMOTE_ADDR'] = $this->ipAddr;
     }
 
@@ -59,7 +59,7 @@ class LoginManagerTest extends TestCase
             $this->banFile,
             "<?php\n\$GLOBALS['IPBANS']=array('FAILURES' => array('127.0.0.1' => 99));\n?>"
         );
-        new LoginManager($this->globals, $this->configManager);
+        new LoginManager($this->globals, $this->configManager, null);
         $this->assertEquals(99, $this->globals['IPBANS']['FAILURES']['127.0.0.1']);
     }
 

--- a/tests/security/LoginManagerTest.php
+++ b/tests/security/LoginManagerTest.php
@@ -1,5 +1,5 @@
 <?php
-namespace Shaarli;
+namespace Shaarli\Security;
 
 require_once 'tests/utils/FakeConfigManager.php';
 use \PHPUnit\Framework\TestCase;

--- a/tests/security/SessionManagerTest.php
+++ b/tests/security/SessionManagerTest.php
@@ -164,7 +164,6 @@ class SessionManagerTest extends TestCase
     {
         $this->sessionManager->storeLoginInfo('ip_id');
 
-        $this->assertTrue(isset($this->session['uid']));
         $this->assertGreaterThan(time(), $this->session['expires_on']);
         $this->assertEquals('ip_id', $this->session['ip']);
         $this->assertEquals('johndoe', $this->session['username']);
@@ -209,7 +208,6 @@ class SessionManagerTest extends TestCase
     public function testLogout()
     {
         $this->session = [
-            'uid' => 'some-uid',
             'ip' => 'ip_id',
             'expires_on' => time() + 1000,
             'username' => 'johndoe',
@@ -218,7 +216,6 @@ class SessionManagerTest extends TestCase
         ];
         $this->sessionManager->logout();
 
-        $this->assertFalse(isset($this->session['uid']));
         $this->assertFalse(isset($this->session['ip']));
         $this->assertFalse(isset($this->session['expires_on']));
         $this->assertFalse(isset($this->session['username']));
@@ -227,19 +224,10 @@ class SessionManagerTest extends TestCase
     }
 
     /**
-     * The session is considered as expired because the UID is missing
-     */
-    public function testHasExpiredNoUid()
-    {
-        $this->assertTrue($this->sessionManager->hasSessionExpired());
-    }
-
-    /**
      * The session is active and expiration time has been reached
      */
     public function testHasExpiredTimeElapsed()
     {
-        $this->session['uid'] = 'some-uid';
         $this->session['expires_on'] = time() - 10;
 
         $this->assertTrue($this->sessionManager->hasSessionExpired());
@@ -250,7 +238,6 @@ class SessionManagerTest extends TestCase
      */
     public function testHasNotExpired()
     {
-        $this->session['uid'] = 'some-uid';
         $this->session['expires_on'] = time() + 1000;
 
         $this->assertFalse($this->sessionManager->hasSessionExpired());

--- a/tests/security/SessionManagerTest.php
+++ b/tests/security/SessionManagerTest.php
@@ -5,7 +5,7 @@ require_once 'tests/utils/FakeConfigManager.php';
 require_once 'tests/utils/ReferenceSessionIdHashes.php';
 ReferenceSessionIdHashes::genAllHashes();
 
-use \Shaarli\SessionManager;
+use \Shaarli\Security\SessionManager;
 use \PHPUnit\Framework\TestCase;
 
 

--- a/tests/security/SessionManagerTest.php
+++ b/tests/security/SessionManagerTest.php
@@ -17,7 +17,7 @@ class SessionManagerTest extends TestCase
     /** @var array Session ID hashes */
     protected static $sidHashes = null;
 
-    /** @var FakeConfigManager ConfigManager substitute for testing */
+    /** @var \FakeConfigManager ConfigManager substitute for testing */
     protected $conf = null;
 
     /** @var array $_SESSION array for testing */

--- a/tests/security/SessionManagerTest.php
+++ b/tests/security/SessionManagerTest.php
@@ -14,11 +14,17 @@ use \PHPUnit\Framework\TestCase;
  */
 class SessionManagerTest extends TestCase
 {
-    // Session ID hashes
+    /** @var array Session ID hashes */
     protected static $sidHashes = null;
 
-    // Fake ConfigManager
-    protected static $conf = null;
+    /** @var FakeConfigManager ConfigManager substitute for testing */
+    protected $conf = null;
+
+    /** @var array $_SESSION array for testing */
+    protected $session = [];
+
+    /** @var SessionManager Server-side session management abstraction */
+    protected $sessionManager = null;
 
     /**
      * Assign reference data
@@ -26,7 +32,20 @@ class SessionManagerTest extends TestCase
     public static function setUpBeforeClass()
     {
         self::$sidHashes = ReferenceSessionIdHashes::getHashes();
-        self::$conf = new FakeConfigManager();
+    }
+
+    /**
+     * Initialize or reset test resources
+     */
+    public function setUp()
+    {
+        $this->conf = new FakeConfigManager([
+            'credentials.login' => 'johndoe',
+            'credentials.salt' => 'salt',
+            'security.session_protection_disabled' => false,
+        ]);
+        $this->session = [];
+        $this->sessionManager = new SessionManager($this->session, $this->conf);
     }
 
     /**
@@ -34,12 +53,9 @@ class SessionManagerTest extends TestCase
      */
     public function testGenerateToken()
     {
-        $session = [];
-        $sessionManager = new SessionManager($session, self::$conf);
+        $token = $this->sessionManager->generateToken();
 
-        $token = $sessionManager->generateToken();
-
-        $this->assertEquals(1, $session['tokens'][$token]);
+        $this->assertEquals(1, $this->session['tokens'][$token]);
         $this->assertEquals(40, strlen($token));
     }
 
@@ -54,7 +70,7 @@ class SessionManagerTest extends TestCase
                 $token => 1,
             ],
         ];
-        $sessionManager = new SessionManager($session, self::$conf);
+        $sessionManager = new SessionManager($session, $this->conf);
 
         // check and destroy the token
         $this->assertTrue($sessionManager->checkToken($token));
@@ -69,21 +85,18 @@ class SessionManagerTest extends TestCase
      */
     public function testGenerateAndCheckToken()
     {
-        $session = [];
-        $sessionManager = new SessionManager($session, self::$conf);
-
-        $token = $sessionManager->generateToken();
+        $token = $this->sessionManager->generateToken();
 
         // ensure a token has been generated
-        $this->assertEquals(1, $session['tokens'][$token]);
+        $this->assertEquals(1, $this->session['tokens'][$token]);
         $this->assertEquals(40, strlen($token));
 
         // check and destroy the token
-        $this->assertTrue($sessionManager->checkToken($token));
-        $this->assertFalse(isset($session['tokens'][$token]));
+        $this->assertTrue($this->sessionManager->checkToken($token));
+        $this->assertFalse(isset($this->session['tokens'][$token]));
 
         // ensure the token has been destroyed
-        $this->assertFalse($sessionManager->checkToken($token));
+        $this->assertFalse($this->sessionManager->checkToken($token));
     }
 
     /**
@@ -91,10 +104,7 @@ class SessionManagerTest extends TestCase
      */
     public function testCheckInvalidToken()
     {
-        $session = [];
-        $sessionManager = new SessionManager($session, self::$conf);
-
-        $this->assertFalse($sessionManager->checkToken('4dccc3a45ad9d03e5542b90c37d8db6d10f2b38b'));
+        $this->assertFalse($this->sessionManager->checkToken('4dccc3a45ad9d03e5542b90c37d8db6d10f2b38b'));
     }
 
     /**
@@ -145,5 +155,132 @@ class SessionManagerTest extends TestCase
         $this->assertFalse(
             SessionManager::checkId('c0ZqcWF3VFE2NmJBdm1HMVQ0ZHJ3UmZPbTFsNGhkNHI=')
         );
+    }
+
+    /**
+     * Store login information after a successful login
+     */
+    public function testStoreLoginInfo()
+    {
+        $this->sessionManager->storeLoginInfo('ip_id');
+
+        $this->assertTrue(isset($this->session['uid']));
+        $this->assertGreaterThan(time(), $this->session['expires_on']);
+        $this->assertEquals('ip_id', $this->session['ip']);
+        $this->assertEquals('johndoe', $this->session['username']);
+    }
+
+    /**
+     * Extend a server-side session by SessionManager::$SHORT_TIMEOUT
+     */
+    public function testExtendSession()
+    {
+        $this->sessionManager->extendSession();
+
+        $this->assertGreaterThan(time(), $this->session['expires_on']);
+        $this->assertLessThanOrEqual(
+            time() + SessionManager::$SHORT_TIMEOUT,
+            $this->session['expires_on']
+        );
+    }
+
+    /**
+     * Extend a server-side session by SessionManager::$LONG_TIMEOUT
+     */
+    public function testExtendSessionStaySignedIn()
+    {
+        $this->sessionManager->setStaySignedIn(true);
+        $this->sessionManager->extendSession();
+
+        $this->assertGreaterThan(time(), $this->session['expires_on']);
+        $this->assertGreaterThan(
+            time() + SessionManager::$LONG_TIMEOUT - 10,
+            $this->session['expires_on']
+        );
+        $this->assertLessThanOrEqual(
+            time() + SessionManager::$LONG_TIMEOUT,
+            $this->session['expires_on']
+        );
+    }
+
+    /**
+     * Unset session variables after logging out
+     */
+    public function testLogout()
+    {
+        $this->session = [
+            'uid' => 'some-uid',
+            'ip' => 'ip_id',
+            'expires_on' => time() + 1000,
+            'username' => 'johndoe',
+            'visibility' => 'public',
+            'untaggedonly' => false,
+        ];
+        $this->sessionManager->logout();
+
+        $this->assertFalse(isset($this->session['uid']));
+        $this->assertFalse(isset($this->session['ip']));
+        $this->assertFalse(isset($this->session['expires_on']));
+        $this->assertFalse(isset($this->session['username']));
+        $this->assertFalse(isset($this->session['visibility']));
+        $this->assertFalse(isset($this->session['untaggedonly']));
+    }
+
+    /**
+     * The session is considered as expired because the UID is missing
+     */
+    public function testHasExpiredNoUid()
+    {
+        $this->assertTrue($this->sessionManager->hasSessionExpired());
+    }
+
+    /**
+     * The session is active and expiration time has been reached
+     */
+    public function testHasExpiredTimeElapsed()
+    {
+        $this->session['uid'] = 'some-uid';
+        $this->session['expires_on'] = time() - 10;
+
+        $this->assertTrue($this->sessionManager->hasSessionExpired());
+    }
+
+    /**
+     * The session is active and expiration time has not been reached
+     */
+    public function testHasNotExpired()
+    {
+        $this->session['uid'] = 'some-uid';
+        $this->session['expires_on'] = time() + 1000;
+
+        $this->assertFalse($this->sessionManager->hasSessionExpired());
+    }
+
+    /**
+     * Session hijacking protection is disabled, we assume the IP has not changed
+     */
+    public function testHasClientIpChangedNoSessionProtection()
+    {
+        $this->conf->set('security.session_protection_disabled', true);
+
+        $this->assertFalse($this->sessionManager->hasClientIpChanged(''));
+    }
+
+    /**
+     * The client IP identifier has not changed
+     */
+    public function testHasClientIpChangedNope()
+    {
+        $this->session['ip'] = 'ip_id';
+        $this->assertFalse($this->sessionManager->hasClientIpChanged('ip_id'));
+    }
+
+    /**
+     * The client IP identifier has changed
+     */
+    public function testHasClientIpChanged()
+    {
+        $this->session['ip'] = 'ip_id_one';
+        $this->assertTrue($this->sessionManager->hasClientIpChanged('ip_id_two'));
     }
 }

--- a/tests/utils/FakeConfigManager.php
+++ b/tests/utils/FakeConfigManager.php
@@ -42,4 +42,16 @@ class FakeConfigManager
         }
         return $key;
     }
+
+    /**
+     * Check if a setting exists
+     *
+     * @param string $setting Asked setting, keys separated with dots
+     *
+     * @return bool true if the setting exists, false otherwise
+     */
+    public function exists($setting)
+    {
+        return array_key_exists($setting, $this->values);
+    }
 }

--- a/tpl/default/linklist.html
+++ b/tpl/default/linklist.html
@@ -136,7 +136,7 @@
               <div class="linklist-item-thumbnail">{$thumb}</div>
             {/if}
 
-            {if="isLoggedIn()"}
+            {if="$is_logged_in"}
               <div class="linklist-item-editbuttons">
                 {if="$value.private"}
                   <span class="label label-private">{$strPrivate}</span>
@@ -179,7 +179,7 @@
 
             <div class="linklist-item-infos-date-url-block pure-g">
               <div class="linklist-item-infos-dateblock pure-u-lg-7-12 pure-u-1">
-                {if="isLoggedIn()"}
+                {if="$is_logged_in"}
                   <div class="linklist-item-infos-controls-group pure-u-0 pure-u-lg-visible">
                     <span class="linklist-item-infos-controls-item ctrl-checkbox">
                       <input type="checkbox" class="delete-checkbox" value="{$value.id}">
@@ -196,7 +196,7 @@
                   </div>
                 {/if}
                 <a href="?{$value.shorturl}" title="{$strPermalink}">
-                  {if="!$hide_timestamps || isLoggedIn()"}
+                  {if="!$hide_timestamps || $is_logged_in"}
                     {$updated=$value.updated_timestamp ? $strEdited. format_date($value.updated) : $strPermalink}
                     <span class="linkdate" title="{$updated}">
                       <i class="fa fa-clock-o"></i>
@@ -236,7 +236,7 @@
                     {if="$link_plugin_counter - 1 != $counter"}&middot;{/if}
                   {/loop}
                 {/if}
-                {if="isLoggedIn()"}
+                {if="$is_logged_in"}
                   &middot;
                   <a href="?delete_link&amp;lf_linkdate={$value.id}&amp;token={$token}"
                      title="{$strDelete}" class="delete-link confirm-delete">

--- a/tpl/default/linklist.paging.html
+++ b/tpl/default/linklist.paging.html
@@ -1,11 +1,11 @@
 <div class="linklist-paging">
   <div class="paging pure-g">
     <div class="linklist-filters pure-u-1-3">
-      {if="isLoggedIn() or !empty($action_plugin)"}
+      {if="$is_logged_in or !empty($action_plugin)"}
         <span class="linklist-filters-text pure-u-0 pure-u-lg-visible">
           {'Filters'|t}
         </span>
-        {if="isLoggedIn()"}
+        {if="$is_logged_in"}
         <a href="?visibility=private" title="{'Only display private links'|t}"
            class="{if="$visibility==='private'"}filter-on{else}filter-off{/if}"
         ><i class="fa fa-user-secret"></i></a>

--- a/tpl/default/page.footer.html
+++ b/tpl/default/page.footer.html
@@ -4,7 +4,7 @@
   <div class="pure-u-2-24"></div>
   <div id="footer" class="pure-u-20-24 footer-container">
     <strong><a href="https://github.com/shaarli/Shaarli">Shaarli</a></strong>
-    {if="isLoggedIn()===true"}
+    {if="$is_logged_in===true"}
       {$version}
     {/if}
     &middot;

--- a/tpl/default/page.header.html
+++ b/tpl/default/page.header.html
@@ -17,7 +17,7 @@
             {$shaarlititle}
           </a>
         </li>
-        {if="isLoggedIn() || $openshaarli"}
+        {if="$is_logged_in || $openshaarli"}
           <li class="pure-menu-item">
             <a href="?do=addlink" class="pure-menu-link" id="shaarli-menu-shaare">
               <i class="fa fa-plus" ></i> {'Shaare'|t}
@@ -50,7 +50,7 @@
         <li class="pure-menu-item pure-u-lg-0 shaarli-menu-mobile" id="shaarli-menu-mobile-rss">
             <a href="?do={$feed_type}{$searchcrits}" class="pure-menu-link">{'RSS Feed'|t}</a>
         </li>
-        {if="isLoggedIn()"}
+        {if="$is_logged_in"}
           <li class="pure-menu-item pure-u-lg-0 shaarli-menu-mobile" id="shaarli-menu-mobile-logout">
             <a href="?do=logout" class="pure-menu-link">{'Logout'|t}</a>
           </li>
@@ -74,7 +74,7 @@
               <i class="fa fa-rss"></i>
             </a>
           </li>
-          {if="!isLoggedIn()"}
+          {if="!$is_logged_in"}
             <li class="pure-menu-item" id="shaarli-menu-desktop-login">
               <a href="?do=login" class="pure-menu-link"
                  data-open-id="header-login-form"
@@ -120,7 +120,7 @@
       </div>
     </div>
   </div>
-  {if="!isLoggedIn()"}
+  {if="!$is_logged_in"}
     <form method="post" name="loginform">
       <div class="subheader-form header-login-form" id="header-login-form">
         <input type="text" name="login" placeholder="{'Username'|t}" tabindex="3">
@@ -155,7 +155,7 @@
   </div>
 {/if}
 
-{if="!empty($plugin_errors) && isLoggedIn()"}
+{if="!empty($plugin_errors) && $is_logged_in"}
   <div class="pure-g new-version-message pure-alert pure-alert-error pure-alert-closable" id="shaarli-errors-alert">
     <div class="pure-u-2-24"></div>
     <div class="pure-u-20-24">

--- a/tpl/default/tag.list.html
+++ b/tpl/default/tag.list.html
@@ -49,7 +49,7 @@
       {loop="tags"}
         <div class="tag-list-item pure-g" data-tag="{$key}">
           <div class="pure-u-1">
-            {if="isLoggedIn()===true"}
+            {if="$is_logged_in===true"}
               <a href="#" class="delete-tag"><i class="fa fa-trash"></i></a>&nbsp;&nbsp;
               <a href="?do=changetag&fromtag={$key|urlencode}" class="rename-tag">
                 <i class="fa fa-pencil-square-o {$key}"></i>
@@ -63,7 +63,7 @@
               {$value}
             {/loop}
           </div>
-          {if="isLoggedIn()===true"}
+          {if="$is_logged_in===true"}
             <div class="rename-tag-form pure-u-1">
               <input type="text" name="{$key}" value="{$key}" class="rename-tag-input" />
               <a href="#" class="validate-rename-tag"><i class="fa fa-check"></i></a>
@@ -81,7 +81,7 @@
   </div>
 </div>
 
-{if="isLoggedIn()===true"}
+{if="$is_logged_in===true"}
   <input type="hidden" name="taglist" value="{loop="$tags"}{$key} {/loop}"
 {/if}
 

--- a/tpl/vintage/daily.html
+++ b/tpl/vintage/daily.html
@@ -53,7 +53,7 @@
                                 <img src="img/squiggle.png" width="25" height="26" title="permalink" alt="permalink">
                             </a>
                         </div>
-                        {if="!$hide_timestamps || isLoggedIn()"}
+                        {if="!$hide_timestamps || $is_logged_in"}
                             <div class="dailyEntryLinkdate">
                                 <a href="?{$value.shorturl}">{function="strftime('%c', $link.timestamp)"}</a>
                             </div>

--- a/tpl/vintage/linklist.html
+++ b/tpl/vintage/linklist.html
@@ -82,7 +82,7 @@
             <a id="{$value.shorturl}"></a>
             <div class="thumbnail">{$value.url|thumbnail}</div>
             <div class="linkcontainer">
-                {if="isLoggedIn()"}
+                {if="$is_logged_in"}
                     <div class="linkeditbuttons">
                         <form method="GET" class="buttoneditform">
                             <input type="hidden" name="edit_link" value="{$value.id}">
@@ -102,7 +102,7 @@
                 </span>
                 <br>
                 {if="$value.description"}<div class="linkdescription">{$value.description}</div>{/if}
-                {if="!$hide_timestamps || isLoggedIn()"}
+                {if="!$hide_timestamps || $is_logged_in"}
                     {$updated=$value.updated_timestamp ? 'Edited: '. format_date($value.updated) : 'Permalink'}
                     <span class="linkdate" title="Permalink">
                         <a href="?{$value.shorturl}">

--- a/tpl/vintage/linklist.paging.html
+++ b/tpl/vintage/linklist.paging.html
@@ -1,5 +1,5 @@
 <div class="paging">
-{if="isLoggedIn()"}
+{if="$is_logged_in"}
     <div class="paging_privatelinks">
       <a href="?visibility=private">
 		{if="$visibility=='private'"}

--- a/tpl/vintage/page.footer.html
+++ b/tpl/vintage/page.footer.html
@@ -25,7 +25,7 @@
 
 <script src="js/shaarli.min.js"></script>
 
-{if="isLoggedIn()"}
+{if="$is_logged_in"}
 <script>function confirmDeleteLink() { var agree=confirm("Are you sure you want to delete this link ?"); if (agree) return true ; else return false ; }</script>
 {/if}
 

--- a/tpl/vintage/page.header.html
+++ b/tpl/vintage/page.header.html
@@ -17,7 +17,7 @@
     {ignore} When called as a popup from bookmarklet, do not display menu. {/ignore}
 {else}
 <li><a href="{$titleLink}" class="nomobile">Home</a></li>
-    {if="isLoggedIn()"}
+    {if="$is_logged_in"}
     <li><a href="?do=logout">Logout</a></li>
     <li><a href="?do=tools">Tools</a></li>
     <li><a href="?do=addlink">Add link</a></li>
@@ -46,7 +46,7 @@
   </ul>
 </div>
 
-{if="!empty($plugin_errors) && isLoggedIn()"}
+{if="!empty($plugin_errors) && $is_logged_in"}
     <ul class="errors">
         {loop="$plugin_errors"}
             <li>{$value}</li>


### PR DESCRIPTION
This is the second step towards refactoring the login and session system (see #1008), and makes room for future improvements: login/logout/session management is currently mixed up between `LoginManager` and `SessionManager`, with `ConfigManager` acting as a data backend.

Despite the PR being in progress, feel free to comment (esp. on variable and method naming) and suggest improvements!

## PR scope
### Changed
- Refactored functions:
    - `allIPs()` => `client_ip_id`
    - `fillSessionInfo()` => `SessionManager->storeLoginInfo()`
    - `setup_login_state()` => `LoginManager->checkLoginState()`
    - `check_auth()` = > `LoginManager->checkCredentials()`
- group security features under the `Shaarli\Security` namespace
- refactor session and cookie duration mechanism (aka `staySignedIn`, `longlastingsession`)
- refactor user stay-signed-in token management
- inject `$isLoggedIn` state to `PageBuilder`, set the `$is_logged_in` template variable
- update templates to use `$is_logged_in` instead of the global `isLoggedIn()`
- add an adapter `isLoggedIn()` function to ensure compatibility with 3rd-party templates

### Added
- test coverage for `SessionManager`

### Removed
- unused `SessionManager` UID (see commit message for removal details)

### WIP:
- test coverage for `LoginManager`

## Future work
### Separation of concerns
- move the IP ban management to a dedicated class
- add `get()` and `set()` methods to `SessionManager` to wrap `$_SESSION[...]` operations
- add `getVisibility()` and `setVisibility()` methods to `SessionManager`
- move `storeLoginInfo()` and `logout()` logic from `SessionManager` to `LoginManager`

### Security
- use safe hashing functions and comparison operators for all hashes and passwords:
    - [password_hash](https://secure.php.net/manual/en/function.password-hash.php)
    - [password_verify](https://secure.php.net/manual/en/function.password-verify.php)
    - [rfc:timing_attack](https://wiki.php.net/rfc/timing_attack)
    - [rfc:deprecate-uniqid](https://wiki.php.net/rfc/deprecate-uniqid)
- refactor the logic behind open-shaarli as it bypasses login checks in a non-(obvious|expected) way

### Improvements
- add `ConfigManager->isConfigured()` to check if the user has setup Shaarli
- review the session extension mechanism
- review the stay-signed-in mechanism