### PR TITLE
Import from Semantic Scuttle is broken if DOCTYPE capitalization is not correct

### DIFF
--- a/doc/md/Backup,-restore,-import-and-export.md
+++ b/doc/md/Backup,-restore,-import-and-export.md
@@ -38,6 +38,12 @@ See [this issue](https://github.com/sebsauvage/Shaarli/issues/146) for import tw
 
 To correctly import the tags from a [SemanticScuttle](http://semanticscuttle.sourceforge.net/) HTML export, edit the HTML file before importing and replace all occurences of `tags=` (lowercase) to `TAGS=` (uppercase).
 
+Also, be sure to have the correct capitalization for the DOCTYPE string:
+
+```
+<!DOCTYPE NETSCAPE-Bookmark-file-1>
+```
+
 ### Scuttle
 
 Shaarli cannot import data directly from [Scuttle](https://github.com/scronide/scuttle).


### PR DESCRIPTION
Importing from Semantic Scuttle was failing for me. This fixed the issue (seen on https://www.versvs.net/shaarli-gestor-enlaces-libre-completo/#comment-119304).

