### PR TITLE
Fix permission issue introduced with multi-stage build

### DIFF
--- a/docker/alpine/Dockerfile.latest
+++ b/docker/alpine/Dockerfile.latest
@@ -42,7 +42,9 @@ RUN rm -rf /etc/php7/php-fpm.d/www.conf \
 WORKDIR /var/www
 COPY --from=composer /app/shaarli shaarli
 
+RUN chown -R nginx:nginx .
 VOLUME /var/www/shaarli/data
+
 EXPOSE 80
 
 ENTRYPOINT ["/bin/s6-svscan", "/etc/services.d"]


### PR DESCRIPTION
When Dockerfiles were migrated to multi-stage build (#1085), the `chown nginx` part was omited from the `latest` Dockerfile.

This prevents the `latest` image to run properly, crashing with such error:
```
[02-Mar-2018 13:53:50] WARNING: [pool www] child 18 said into stderr: "NOTICE: PHP message: PHP Fatal error:  Uncaught RainTpl_Exception: Cache directory tmp/doesn't have write p
ermission. Set write permission or set RAINTPL_CHECK_TEMPLATE_UPDATE to false. More details on http://www.raintpl.com/Documentation/Documentation-for-PHP-developers/Configuration
/ in /var/www/shaarli/inc/rain.tpl.class.php:321"
- -  02/Mar/2018:13:53:50 +0000 "GET /index.php" 500
[02-Mar-2018 13:53:50] WARNING: [pool www] child 18 said into stderr: "Stack trace:"
[02-Mar-2018 13:53:50] WARNING: [pool www] child 18 said into stderr: "#0 /var/www/shaarli/inc/rain.tpl.class.php(274): RainTPL->compileFile('linklist', NULL, 'tpl//default/li...
', 'tmp/', 'tmp/linklist.b9...')"
[02-Mar-2018 13:53:50] WARNING: [pool www] child 18 said into stderr: "#1 /var/www/shaarli/inc/rain.tpl.class.php(164): RainTPL->check_template('linklist')"
[02-Mar-2018 13:53:50] WARNING: [pool www] child 18 said into stderr: "#2 /var/www/shaarli/application/PageBuilder.php(155): RainTPL->draw('linklist')"
[02-Mar-2018 13:53:50] WARNING: [pool www] child 18 said into stderr: "#3 /var/www/shaarli/index.php(673): PageBuilder->renderPage('linklist')"
[02-Mar-2018 13:53:50] WARNING: [pool www] child 18 said into stderr: "#4 /var/www/shaarli/index.php(1631): showLinkList(Object(PageBuilder), Object(LinkDB), Object(Shaarli\Confi
g\ConfigManager), Object(PluginManager))"
[02-Mar-2018 13:53:50] WARNING: [pool www] child 18 said into stderr: "#5 /var/www/shaarli/index.php(2319): renderPage(Object(Shaarli\Config\ConfigManager), Object(PluginManager)
, Object(LinkDB), Object(History), Object..."
```

This PR adds the required `chown`.