### PR TITLE
Nginx logs to stdout for Docker images

### DIFF
--- a/docker/alpine/Dockerfile.armhf.latest
+++ b/docker/alpine/Dockerfile.armhf.latest
@@ -37,7 +37,9 @@ RUN curl -L https://github.com/shaarli/Shaarli/archive/latest.tar.gz | tar xzf -
     && cd shaarli \
     && composer --prefer-dist --no-dev install \
     && rm -rf ~/.composer \
-    && chown -R nginx:nginx .
+    && chown -R nginx:nginx . \
+    && ln -sf /dev/stdout /var/log/nginx/shaarli.access.log \
+    && ln -sf /dev/stderr /var/log/nginx/shaarli.error.log
 
 VOLUME /var/www/shaarli/data
 

--- a/docker/alpine/Dockerfile.armhf.master
+++ b/docker/alpine/Dockerfile.armhf.master
@@ -37,7 +37,9 @@ RUN curl -L https://github.com/shaarli/Shaarli/archive/master.tar.gz | tar xzf -
     && cd shaarli \
     && composer --prefer-dist --no-dev install \
     && rm -rf ~/.composer \
-    && chown -R nginx:nginx .
+    && chown -R nginx:nginx . \
+    && ln -sf /dev/stdout /var/log/nginx/shaarli.access.log \
+    && ln -sf /dev/stderr /var/log/nginx/shaarli.error.log
 
 VOLUME /var/www/shaarli/data
 

--- a/docker/alpine/Dockerfile.latest
+++ b/docker/alpine/Dockerfile.latest
@@ -42,7 +42,10 @@ RUN rm -rf /etc/php7/php-fpm.d/www.conf \
 WORKDIR /var/www
 COPY --from=composer /app/shaarli shaarli
 
-RUN chown -R nginx:nginx .
+RUN chown -R nginx:nginx . \
+    && ln -sf /dev/stdout /var/log/nginx/shaarli.access.log \
+    && ln -sf /dev/stderr /var/log/nginx/shaarli.error.log
+
 VOLUME /var/www/shaarli/data
 
 EXPOSE 80

--- a/docker/alpine/Dockerfile.master
+++ b/docker/alpine/Dockerfile.master
@@ -42,7 +42,10 @@ RUN rm -rf /etc/php7/php-fpm.d/www.conf \
 WORKDIR /var/www
 COPY --from=composer /app/shaarli shaarli
 
-RUN chown -R nginx:nginx .
+RUN chown -R nginx:nginx . \
+    && ln -sf /dev/stdout /var/log/nginx/shaarli.access.log \
+    && ln -sf /dev/stderr /var/log/nginx/shaarli.error.log
+
 VOLUME /var/www/shaarli/data
 
 EXPOSE 80


### PR DESCRIPTION
This change allows to see the nginx logs with `docker logs <container>`.

This trick didn't work with the Debian image.