### PR TITLE
 Fix removal of on=... attributes from html (generated from markdown)

### DIFF
--- a/plugins/markdown/markdown.php
+++ b/plugins/markdown/markdown.php
@@ -288,7 +288,7 @@ function sanitize_html($description)
             $description);
     }
     $description = preg_replace(
-        '#(<[^>]+)on[a-z]*="?[^ "]*"?#is',
+        '#(<[^>]+\s)on[a-z]*="?[^ "]*"?#is',
         '$1',
         $description);
     return $description;


### PR DESCRIPTION
The removal of `on=...` attributes is rather destructive because it is performed without really parsing the html. E.g. when using the markdown plugin and having something like `[text](http://domain.tld?action=value)` will result in garbled html. This tiny change fixes this a bit, only removing when preceded by whitespace, which will always be the case with JS event handlers. So will work in more/most cases, still the best method would be using a html parser, which I think most will consider overkill.