### PR TITLE
httpd: always forward the 'Authorization' header

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -6,6 +6,10 @@ RewriteEngine On
 # Prevent accessing subdirectories not managed by SCM
 RewriteRule ^(.git|doxygen|vendor) - [F]
 
+# Forward the "Authorization" HTTP header
+RewriteCond %{HTTP:Authorization} ^(.*)
+RewriteRule .* - [e=HTTP_AUTHORIZATION:%1]
+
 # REST API
 RewriteCond %{REQUEST_FILENAME} !-f
 RewriteCond %{REQUEST_FILENAME} !-d


### PR DESCRIPTION
On some Apache HTTPD setups where the CGI/FastCGI mode is used, the HTTP header
containing the JWT token is not forwarded, which results in the following error
when attempting to use the REST API:

  "401 Not authorized: JWT token not provided"

This patch allows forwarding the 'Authorization' header. An alternative would
be to use the `CGIPassAuth` directive to allow all authorization headers to be
forwarded.

See:
- https://secure.php.net/manual/en/features.http-auth.php#114877
- https://stackoverflow.com/questions/26475885/authorization-header-missing-in-php-post-request
- https://stackoverflow.com/questions/13387516/authorization-header-missing-in-django-rest-framework-is-apache-to-blame
- https://stackoverflow.com/questions/17018586/apache-2-4-php-fpm-and-authorization-headers
- https://httpd.apache.org/docs/2.4/en/mod/core.html#cgipassauth

TODO:
- [ ] backport to v0.9.x