### PR TITLE
Documentation : Fix current version file name

### DIFF
--- a/doc/md/Upgrade-and-migration.md
+++ b/doc/md/Upgrade-and-migration.md
@@ -3,7 +3,7 @@
 ### Note your current version
 
 If anything goes wrong, it's important for us to know which version you're upgrading from.
-The current version is present in the `version.php` file.
+The current version is present in the `shaarli_version.php` file.
 
 ### Backup your data
 


### PR DESCRIPTION
I can't see the version.php file, so I guess the documentation should point to shaarli_version.php