### PR TITLE
 Use Travis stages to run JS tests separately 

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -10,7 +10,7 @@ trim_trailing_whitespace = true
 indent_style = space
 indent_size = 4
 
-[*.{htaccess,html,js,json,xml}]
+[*.{htaccess,html,js,json,xml,yml}]
 indent_size = 2
 
 [*.php]

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,23 +1,44 @@
 sudo: false
 dist: trusty
-language: php
+
+matrix:
+  include:
+    - language: php
+      php: 7.2
+    - language: php
+      php: 7.1
+    - language: php
+      php: 7.0
+    - language: php
+      php: 5.6
+    - language: node_js
+      node_js: 8
+      cache:
+        yarn: true
+        directories:
+          - $HOME/.cache/yarn
+
+      install:
+        - yarn install
+
+      before_script:
+        - PATH=${PATH//:\.\/node_modules\/\.bin/}
+
+      script:
+        - yarn run build # Just to be sure that the build isn't broken
+        - make eslint
+
 cache:
-  yarn: true
   directories:
     - $HOME/.composer/cache
-    - $HOME/.cache/yarn
-php:
-  - 7.2
-  - 7.1
-  - 7.0
-  - 5.6
+
 install:
-  - yarn install
   - composer install --prefer-dist
+
 before_script:
   - PATH=${PATH//:\.\/node_modules\/\.bin/}
+
 script:
   - make clean
   - make check_permissions
-  - make eslint
   - make all_tests


### PR DESCRIPTION
Related to [this comment](https://github.com/shaarli/Shaarli/pull/1072#discussion_r170757510).

I chose to use stages here instead of matrix because, in my understanding, using matrix would require a bunch of `if` in the `script` section.

The only downside I see here is that the JS tests don't run in parallel, they wait for the `test` stage to be successfully completed.