### PR TITLE
Add Yunohost install badge in the ReadMe

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,10 @@ _It is designed to be personal (single-user), fast and handy._
 - [Change log](CHANGELOG.md)
 - [Bugs/Feature requests/Discussion](https://github.com/shaarli/Shaarli/issues/)
 
+#### Install with Yunohost
+Shaarli is available as a [Yunohost](https://yunohost.org) app: [Shaarli_ynh](https://github.com/YunoHost-Apps/shaarli_ynh).
+[![Install Shaarli with YunoHost](https://install-app.yunohost.org/install-with-yunohost.png)](https://install-app.yunohost.org/?app=shaarli)
+
 ### Demo
 
 You can use this [public demo instance of Shaarli](https://demo.shaarli.org).


### PR DESCRIPTION
Proposal : Add a button to install with Yunohost in a one-click way.
This would reference the existence of an easy/user-friendly install for Yunohost users.

Note: this is just a proposal, feel free to change the way I integrated the button / message in your ReadMe (I'm wondering for instance why there is no "How to install" part, and if this addition would not confuse people: they could think Shaarli can only be installed with Yunohost)