### PR TITLE
Fix broken documentation links in page footer and pluginsadmin

### DIFF
--- a/tpl/default/pluginsadmin.html
+++ b/tpl/default/pluginsadmin.html
@@ -117,7 +117,7 @@
 
       <div class="center more">
         {"More plugins available"|t}
-        <a href="doc/Community-&-Related-software.html#third-party-plugins">{"in the documentation"|t}</a>.
+        <a href="doc/html/Community-&-Related-software/#third-party-plugins">{"in the documentation"|t}</a>.
       </div>
       <div class="center">
         <input type="submit" value="{'Save'|t}" name="save">

--- a/tpl/vintage/page.footer.html
+++ b/tpl/vintage/page.footer.html
@@ -1,7 +1,7 @@
 <div id="footer">
   <strong><a href="https://github.com/shaarli/Shaarli">Shaarli</a></strong>
   - The personal, minimalist, super-fast, database free, bookmarking service by the Shaarli community
-  - <a href="doc/Home.html" rel="nofollow">Help/documentation</a>
+  - <a href="doc/html/index.html" rel="nofollow">Help/documentation</a>
     {loop="$plugins_footer.text"}
         {$value}
     {/loop}


### PR DESCRIPTION
Fixes #930 

Documentation path is hardcoded to the local copy, therefore the documentation has to be present.