### PR TITLE
Do not check the IP address with session protection disabled

### DIFF
--- a/application/security/LoginManager.php
+++ b/application/security/LoginManager.php
@@ -58,6 +58,9 @@ class LoginManager
      */
     public function generateStaySignedInToken($clientIpAddress)
     {
+        if ($this->configManager->get('security.session_protection_disabled') === true) {
+            $clientIpAddress = '';
+        }
         $this->staySignedInToken = sha1(
             $this->configManager->get('credentials.hash')
             . $clientIpAddress

--- a/tests/security/LoginManagerTest.php
+++ b/tests/security/LoginManagerTest.php
@@ -260,6 +260,20 @@ class LoginManagerTest extends TestCase
     }
 
     /**
+     * Generate a token depending on the user credentials with session protected disabled
+     */
+    public function testGenerateStaySignedInTokenSessionProtectionDisabled()
+    {
+        $this->configManager->set('security.session_protection_disabled', true);
+        $this->loginManager->generateStaySignedInToken($this->clientIpAddress);
+
+        $this->assertEquals(
+            sha1($this->passwordHash . $this->salt),
+            $this->loginManager->getStaySignedInToken()
+        );
+    }
+
+    /**
      * Check user login - Shaarli has not yet been configured
      */
     public function testCheckLoginStateNotConfigured()


### PR DESCRIPTION
This allows the user to stay logged in if his IP changes.

Fixes #1106 

Note: this setting labelled « Disabled protection » can obviously become a security issue.