### PR TITLE
fix and simplify Dockerfile for armhf

### DIFF
--- a/Dockerfile.armhf
+++ b/Dockerfile.armhf
@@ -1,9 +1,38 @@
-FROM lsiobase/alpine.armhf:3.6
+# Stage 1:
+# - Copy Shaarli sources
+# - Build documentation
+FROM arm32v6/alpine:3.8 as docs
+ADD . /usr/src/app/shaarli
+RUN apk --update --no-cache add py2-pip \
+    && cd /usr/src/app/shaarli \
+    && pip install --no-cache-dir mkdocs \
+    && mkdocs build --clean
+
+# Stage 2:
+# - Resolve PHP dependencies with Composer
+FROM arm32v6/alpine:3.8 as composer
+COPY --from=docs /usr/src/app/shaarli /app/shaarli
+RUN apk --update --no-cache add php7-mbstring composer \
+    && cd /app/shaarli \
+    && composer --prefer-dist --no-dev install
+
+# Stage 3:
+# - Frontend dependencies
+FROM arm32v6/alpine:3.8 as node
+COPY --from=composer /app/shaarli /shaarli
+RUN apk --update --no-cache add yarn nodejs-current python2 build-base \
+    && cd /shaarli \
+    && yarn install \
+    && yarn run build \
+    && rm -rf node_modules
+
+# Stage 4:
+# - Shaarli image
+FROM arm32v6/alpine:3.8
 LABEL maintainer="Shaarli Community"
 
 RUN apk --update --no-cache add \
         ca-certificates \
-        curl \
         nginx \
         php7 \
         php7-ctype \
@@ -15,7 +44,6 @@ RUN apk --update --no-cache add \
         php7-json \
         php7-mbstring \
         php7-openssl \
-        php7-phar \
         php7-session \
         php7-xml \
         php7-zlib \
@@ -25,22 +53,19 @@ COPY .docker/nginx.conf /etc/nginx/nginx.conf
 COPY .docker/php-fpm.conf /etc/php7/php-fpm.conf
 COPY .docker/services.d /etc/services.d
 
-RUN curl -sS https://getcomposer.org/installer | php7 -- --install-dir=/usr/local/bin --filename=composer \
-    && rm -rf /etc/php7/php-fpm.d/www.conf \
+RUN rm -rf /etc/php7/php-fpm.d/www.conf \
     && sed -i 's/post_max_size.*/post_max_size = 10M/' /etc/php7/php.ini \
     && sed -i 's/upload_max_filesize.*/upload_max_filesize = 10M/' /etc/php7/php.ini
 
 
 WORKDIR /var/www
-RUN curl -L https://github.com/shaarli/Shaarli/archive/master.tar.gz | tar xzf - \
-    && mv Shaarli-master shaarli \
-    && cd shaarli \
-    && composer --prefer-dist --no-dev install \
-    && rm -rf ~/.composer \
-    && chown -R nginx:nginx . \
+COPY --from=node /shaarli /var/www/shaarli
+
+RUN chown -R nginx:nginx . \
     && ln -sf /dev/stdout /var/log/nginx/shaarli.access.log \
     && ln -sf /dev/stderr /var/log/nginx/shaarli.error.log
 
+VOLUME /var/www/shaarli/cache
 VOLUME /var/www/shaarli/data
 
 EXPOSE 80


### PR DESCRIPTION
Docker build wasn't working for armhf, so I picked the Dockerfile and adapted it to armhf
Build result is available at https://gitlab.com/docker-rpi/shaarli/container_registry