### PR TITLE
Delete redundant titles

### DIFF
--- a/tpl/default/tools.html
+++ b/tpl/default/tools.html
@@ -125,25 +125,22 @@
   <div class="pure-u-lg-1-3 pure-u-22-24 page-form page-form-light">
     <h2 class="window-title">{'3rd party'|t}</h2>
     <div class="tools-item">
-      <a href="https://addons.mozilla.org/fr/firefox/addon/shaarli/" title="Firefox {'Plugin'|t}">
+      <a href="https://addons.mozilla.org/fr/firefox/addon/shaarli/">
         <span class="pure-button pure-u-lg-2-3 pure-u-3-4">Firefox {'plugin'|t}</span>
       </a>
     </div>
     <div class="tools-item">
-      <a href="https://chrome.google.com/webstore/detail/shiny-shaarli/hajdfkmbdmadjmmpkkbbcnllepomekin"
-         title="Chrome {'Plugin'|t}">
+      <a href="https://chrome.google.com/webstore/detail/shiny-shaarli/hajdfkmbdmadjmmpkkbbcnllepomekin">
         <span class="pure-button pure-u-lg-2-3 pure-u-3-4">Chrome {'plugin'|t}</span>
       </a>
     </div>
     <div class="tools-item">
-      <a href="https://play.google.com/store/apps/details?id=com.dimtion.shaarlier&hl=fr"
-         title="Android Shaarlier">
+      <a href="https://play.google.com/store/apps/details?id=com.dimtion.shaarlier&hl=fr">
         <span class="pure-button pure-u-lg-2-3 pure-u-3-4">Android Shaarlier</span>
       </a>
     </div>
     <div class="tools-item">
-      <a href="https://stakali.toneiv.eu/"
-         title="Android Stakali">
+      <a href="https://stakali.toneiv.eu/">
         <span class="pure-button pure-u-lg-2-3 pure-u-3-4">Android Stakali</span>
       </a>
     </div>


### PR DESCRIPTION
Redundant titles are an accessibility issue and should be avoided.

See : https://accessibilitytips.com/2008/04/14/avoiding-redundant-title-attributes/