### PR TITLE
Fix issue 'You are not authorized to add a link' with thumbnails enabled

### DIFF
--- a/application/Updater.php
+++ b/application/Updater.php
@@ -502,7 +502,7 @@ class Updater
             return true;
         }
 
-        $thumbnailsEnabled = $this->conf->get('thumbnail.enable_thumbnails', true);
+        $thumbnailsEnabled = extension_loaded('gd') && $this->conf->get('thumbnail.enable_thumbnails', true);
         $this->conf->set('thumbnails.mode', $thumbnailsEnabled ? Thumbnailer::MODE_ALL : Thumbnailer::MODE_NONE);
         $this->conf->set('thumbnails.width', 125);
         $this->conf->set('thumbnails.height', 90);

--- a/index.php
+++ b/index.php
@@ -1635,9 +1635,9 @@ function buildLinkList($PAGE, $LINKSDB, $conf, $pluginManager, $loginManager)
         uasort($taglist, 'strcasecmp');
         $link['taglist'] = $taglist;
 
-        // Thumbnails enabled, not a note,
+        // Logged in, thumbnails enabled, not a note,
         // and (never retrieved yet or no valid cache file)
-        if ($thumbnailsEnabled && $link['url'][0] != '?'
+        if ($loginManager->isLoggedIn() && $thumbnailsEnabled && $link['url'][0] != '?'
             && (! isset($link['thumbnail']) || ($link['thumbnail'] !== false && ! is_file($link['thumbnail'])))
         ) {
             $elem = $LINKSDB[$keys[$i]];


### PR DESCRIPTION
Do not try to alter the datastore by updating thumbnails if the user isn't logged in.

Also, do not enable thumbnails if PHP GD extension is not installed/loaded.

Fixes #1198 