### PR TITLE
Add OpenGraph meta tags on permalink page

### DIFF
--- a/application/PageBuilder.php
+++ b/application/PageBuilder.php
@@ -101,7 +101,7 @@ class PageBuilder
             'version_hash',
             ApplicationUtils::getVersionHash(SHAARLI_VERSION, $this->conf->get('credentials.salt'))
         );
-        $this->tpl->assign('scripturl', index_url($_SERVER));
+        $this->tpl->assign('index_url', index_url($_SERVER));
         $visibility = ! empty($_SESSION['visibility']) ? $_SESSION['visibility'] : '';
         $this->tpl->assign('visibility', $visibility);
         $this->tpl->assign('untaggedonly', !empty($_SESSION['untaggedonly']));

--- a/plugins/markdown/markdown.php
+++ b/plugins/markdown/markdown.php
@@ -28,6 +28,7 @@ function hook_markdown_render_linklist($data, $conf)
             $value = stripNoMarkdownTag($value);
             continue;
         }
+        $value['description_src'] = $value['description'];
         $value['description'] = process_markdown(
             $value['description'],
             $conf->get('security.markdown_escape', true),

--- a/tests/plugins/PluginMarkdownTest.php
+++ b/tests/plugins/PluginMarkdownTest.php
@@ -47,6 +47,8 @@ class PluginMarkdownTest extends PHPUnit_Framework_TestCase
         $data = hook_markdown_render_linklist($data, $this->conf);
         $this->assertNotFalse(strpos($data['links'][0]['description'], '<h1>'));
         $this->assertNotFalse(strpos($data['links'][0]['description'], '<p>'));
+
+        $this->assertEquals($markdown, $data['links'][0]['description_src']);
     }
 
     /**

--- a/tpl/default/includes.html
+++ b/tpl/default/includes.html
@@ -15,3 +15,23 @@
   <link type="text/css" rel="stylesheet" href="data/user.css#" />
 {/if}
 <link rel="search" type="application/opensearchdescription+xml" href="?do=opensearch#" title="Shaarli search - {$shaarlititle}"/>
+{if="! empty($links) && count($links) === 1"}
+  {$link=reset($links)}
+  <meta property="og:title" content="{$link.title}" />
+  <meta property="og:type" content="article" />
+  <meta property="og:url" content="{$index_url}?{$link.shorturl}" />
+  {$ogDescription=isset($link.description_src) ? $link.description_src : $link.description}
+  <meta property="og:description" content="{function="substr($ogDescription, 0, 300)"}" />
+  {if="$link.thumbnail"}
+    <meta property="og:image" content="{$index_url}{$link.thumbnail}" />
+  {/if}
+  {if="!$hide_timestamps || $is_logged_in"}
+    <meta property="article:published_time" content="{$link.created->format(DateTime::ATOM)}" />
+    {if="$link.updated"}
+      <meta property="article:modified_time" content="{$link.updated->format(DateTime::ATOM)}" />
+    {/if}
+  {/if}
+  {loop="link.taglist"}
+    <meta property="article:tag" content="{$value}" />
+  {/loop}
+{/if}

--- a/tpl/vintage/includes.html
+++ b/tpl/vintage/includes.html
@@ -12,3 +12,23 @@
 {/loop}
 {if="is_file('data/user.css')"}<link type="text/css" rel="stylesheet" href="data/user.css#" />{/if}
 <link rel="search" type="application/opensearchdescription+xml" href="?do=opensearch#" title="Shaarli search - {$shaarlititle|htmlspecialchars}"/>
+{if="! empty($links) && count($links) === 1"}
+  {$link=reset($links)}
+  <meta property="og:title" content="{$link.title}" />
+  <meta property="og:type" content="article" />
+  <meta property="og:url" content="{$index_url}?{$link.shorturl}" />
+  {$ogDescription=isset($link.description_src) ? $link.description_src : $link.description}
+  <meta property="og:description" content="{function="mb_substr($ogDescription, 0, 300)"}" />
+  {if="$link.thumbnail"}
+    <meta property="og:image" content="{$index_url}{$link.thumbnail}" />
+  {/if}
+  {if="!$hide_timestamps || $is_logged_in"}
+    <meta property="article:published_time" content="{$link.created->format(DateTime::ATOM)}" />
+    {if="$link.updated"}
+      <meta property="article:modified_time" content="{$link.updated->format(DateTime::ATOM)}" />
+    {/if}
+  {/if}
+  {loop="link.taglist"}
+    <meta property="article:tag" content="{$value}" />
+  {/loop}
+{/if}


### PR DESCRIPTION
Includes:
  - og:title
  - og:type -> article
  - og:image -> if there is a thumbnail
  - og:url -> permalink
  - og:description -> first 300 chars of raw description
  - article:published_time
  - article:modified_time
  - article:tag -> one OG meta tag for each shaare tag

Fixes #258