### PR TITLE
 Run Shaarli's tests against PHP 7.3 RC1 on Travis 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,8 @@ dist: trusty
 matrix:
   include:
     - language: php
+      php: 7.3
+    - language: php
       php: 7.2
     - language: php
       php: 7.1


### PR DESCRIPTION
Fixed non escaped `-` in regex. 

Requires shaarli/netscape-bookmark-parser#46 to be merged and release to get this one green.