### PR TITLE
Revert part of #1220

### DIFF
--- a/doc/custom_theme/main.html
+++ b/doc/custom_theme/main.html
@@ -20,6 +20,4 @@ the blocks defined in base.html and its included child templates.
 
 {% if page and page.is_homepage %}<meta name="description" content="{{ config.site_description }}">{% endif %}
 {% if config.site_author %}<meta name="author" content="{{ config.site_author }}">{% endif %}
-{% if config.site_favicon %}<link rel="shortcut icon" href="{{ config.site_favicon|url }}">
-{% else %}<link rel="shortcut icon" href="{{ 'img/favicon.ico'|url }}">{% endif %}
 {%- endblock %}


### PR DESCRIPTION
Fixes #1177
The `url` template filter is [only supported in Mkdocs 1.0+](https://github.com/mkdocs/mkdocs/blob/master/docs/about/release-notes.md#internal-refactor-of-pages-files-and-navigation)
Readthedocs.org uses Mkdocs `0.17.3 ` while `make htmldoc` fetches the [latest version from pypi](https://pypi.org/project/mkdocs/) which is `1.0.4`.
Following https://github.com/shaarli/Shaarli/pull/1220, building the docs fails with https://readthedocs.org/projects/shaarli/builds/7886340/