### PR TITLE
Update session start condition

### DIFF
--- a/index.php
+++ b/index.php
@@ -111,7 +111,7 @@ ini_set('session.use_trans_sid', false);
 
 session_name('shaarli');
 // Start session if needed (Some server auto-start sessions).
-if (session_id() == '') {
+if (session_status() == PHP_SESSION_NONE) {
     session_start();
 }
 


### PR DESCRIPTION
Recommended method for PHP >= 5.4.0 as seen here https://stackoverflow.com/questions/6249707/check-if-php-session-has-already-started

Per https://shaarli.readthedocs.io/en/master/Server-configuration/ Shaarli supports PHP >= 5.6