### PR TITLE
add label to form - accessibility issue

### DIFF
--- a/tpl/default/addlink.html
+++ b/tpl/default/addlink.html
@@ -11,7 +11,8 @@
     <h2 class="window-title">{"Shaare a new link"|t}</h2>
     <form method="GET" action="#" name="addform" class="addform">
       <div>
-        <input type="text" name="post" placeholder="{'URL or leave empty to post a note'|t}" class="autofocus">
+        <label for="shaare">{'URL or leave empty to post a note'|t}</label>
+        <input type="text" name="post" id="shaare" class="autofocus">
       </div>
       <div>
         <input type="submit" value="{'Add link'|t}">


### PR DESCRIPTION
Don't use placeholder instead of label for form input.