### PR TITLE
Fix a warning if links sticky status isn't set

### DIFF
--- a/application/bookmark/LinkDB.php
+++ b/application/bookmark/LinkDB.php
@@ -271,7 +271,8 @@ You use the community supported version of the original Shaarli project, by Seba
             ),
             'private' => 0,
             'created' => new DateTime(),
-            'tags' => 'opensource software'
+            'tags' => 'opensource software',
+            'sticky' => false,
         );
         $link['shorturl'] = link_small_hash($link['created'], $link['id']);
         $this->links[1] = $link;
@@ -284,6 +285,7 @@ You use the community supported version of the original Shaarli project, by Seba
             'private' => 1,
             'created' => new DateTime('1 minute ago'),
             'tags' => 'secretstuff',
+            'sticky' => false,
         );
         $link['shorturl'] = link_small_hash($link['created'], $link['id']);
         $this->links[0] = $link;
@@ -334,6 +336,8 @@ You use the community supported version of the original Shaarli project, by Seba
             } else {
                 $link['real_url'] = $link['url'];
             }
+
+            $link['sticky'] = isset($link['sticky']) ? $link['sticky'] : false;
 
             // To be able to load links before running the update, and prepare the update
             if (!isset($link['created'])) {

--- a/index.php
+++ b/index.php
@@ -1181,6 +1181,8 @@ function renderPage($conf, $pluginManager, $LINKSDB, $history, $sessionManager, 
             $link['thumbnail'] = $thumbnailer->get($url);
         }
 
+        $link['sticky'] = isset($link['sticky']) ? $link['sticky'] : false;
+
         $pluginManager->executeHooks('save_link', $link);
 
         $LINKSDB[$id] = $link;


### PR DESCRIPTION
  - initiate its status to false when the link is created
  - if not defined, initiate its status to false (can happen if the updater hasn't run)