### PR TITLE
Fix button overlapping on mobile in linklist

### DIFF
--- a/assets/default/scss/shaarli.scss
+++ b/assets/default/scss/shaarli.scss
@@ -544,7 +544,10 @@ body,
   color: $dark-grey;
   font-size: .9em;
 
+
   a {
+    display: inline-block;
+    margin: 3px 0;
     padding: 5px 8px;
     text-decoration: none;
   }


### PR DESCRIPTION
![](https://i.imgur.com/QNZ9kEC.png)

to 

![](https://i.imgur.com/YyK3orY.png)

EDIT: it's not perfect but the width depends on the size of the icon.