### PR TITLE
Documentation: drop PHP 7.0 compatibility in Shaarli 11.x

### DIFF
--- a/doc/md/Server-configuration.md
+++ b/doc/md/Server-configuration.md
@@ -17,7 +17,7 @@ Version | Status | Shaarli compatibility
 :---:|:---:|:---:
 7.2 | Supported | Yes
 7.1 | Supported | Yes
-7.0 | Supported | Yes
+7.0 | EOL: 2018-12-03 | Yes (up to Shaarli 0.10.x)
 5.6 | EOL: 2018-12-31 | Yes (up to Shaarli 0.10.x)
 5.5 | EOL: 2016-07-10 | Yes
 5.4 | EOL: 2015-09-14 | Yes (up to Shaarli 0.8.x)


### PR DESCRIPTION
related to #1249