### PR TITLE
docs: add readthedocs configuration file

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,0 +1,15 @@
+# .readthedocs.yml
+# Read the Docs configuration file
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+
+# Required
+version: 2
+
+# Build documentation with MkDocs
+mkdocs:
+  configuration: mkdocs.yml
+
+# Optionally set the version of Python and requirements required to build your docs
+# https://github.com/rtfd/readthedocs.org/issues/5250
+python:
+  version: 3.5


### PR DESCRIPTION
workaround for mkdocs incompatibility with python 3.7
Readthedocs builds were failing for some time
https://github.com/rtfd/readthedocs.org/issues/5250

Build success: https://readthedocs.org/api/v2/build/8840127.txt