### PR TITLE
Add print CSS rules to the default template

### DIFF
--- a/assets/default/scss/shaarli.scss
+++ b/assets/default/scss/shaarli.scss
@@ -1611,3 +1611,17 @@ form {
     white-space: nowrap;
   }
 }
+
+// Print rules
+@media print {
+  .shaarli-menu {
+    position: absolute;
+  }
+
+  .search-linklist,
+  .link-count-block,
+  .linklist-item-infos-controls-group,
+  .mobile-buttons {
+    display: none;
+  }
+}

--- a/tpl/default/linklist.html
+++ b/tpl/default/linklist.html
@@ -52,7 +52,7 @@
 {/loop}
 
 <div id="linklist">
-  <div id="link-count-block" class="pure-g">
+  <div id="link-count-block" class="pure-g link-count-block">
     <div class="pure-u-lg-2-24 pure-u-1-24"></div>
     <div id="link-count-content" class="pure-u-lg-20-24 pure-u-22-24">
       <div class="linkcount pure-u-lg-0 center">
@@ -287,7 +287,7 @@
     {/loop}
   </div>
 
-<div id="linklist-paging-bottom-block" class="pure-g">
+<div id="linklist-paging-bottom-block" class="pure-g link-count-block">
   <div class="pure-u-lg-2-24 pure-u-1-24"></div>
   <div id="linklist-paging-bottom-content" class="pure-u-lg-20-24 pure-u-22-24">
     {include="linklist.paging"}


### PR DESCRIPTION
Fixes #1291

  * Display the header bar only on the first page
  * Hide search bars, pagination buttons, filters, and edit/delete buttons