### PR TITLE
Building Docker image for armhf outputs error

### DIFF
--- a/Dockerfile.armhf
+++ b/Dockerfile.armhf
@@ -3,7 +3,7 @@
 # - Build documentation
 FROM arm32v6/alpine:3.8 as docs
 ADD . /usr/src/app/shaarli
-RUN apk --update --no-cache add py2-pip  \
+RUN apk --update --no-cache add py2-pip \
     && cd /usr/src/app/shaarli \
     && pip install --no-cache-dir mkdocs \
     && mkdocs build --clean

--- a/Dockerfile.armhf
+++ b/Dockerfile.armhf
@@ -36,6 +36,7 @@ RUN apk --update --no-cache add \
         nginx \
         php7 \
         php7-ctype \
+        php7-curl \
         php7-fpm \
         php7-gd \
         php7-iconv \

--- a/Dockerfile.armhf
+++ b/Dockerfile.armhf
@@ -3,7 +3,7 @@
 # - Build documentation
 FROM arm32v6/alpine:3.8 as docs
 ADD . /usr/src/app/shaarli
-RUN apk --update --no-cache add py2-pip \
+RUN apk --update --no-cache add py2-pip  \
     && cd /usr/src/app/shaarli \
     && pip install --no-cache-dir mkdocs \
     && mkdocs build --clean
@@ -12,7 +12,7 @@ RUN apk --update --no-cache add py2-pip \
 # - Resolve PHP dependencies with Composer
 FROM arm32v6/alpine:3.8 as composer
 COPY --from=docs /usr/src/app/shaarli /app/shaarli
-RUN apk --update --no-cache add php7-mbstring composer \
+RUN apk --update --no-cache add php7-curl php7-mbstring composer \
     && cd /app/shaarli \
     && composer --prefer-dist --no-dev install
 
@@ -36,7 +36,6 @@ RUN apk --update --no-cache add \
         nginx \
         php7 \
         php7-ctype \
-        php7-curl \
         php7-fpm \
         php7-gd \
         php7-iconv \


### PR DESCRIPTION
Building the docker image from Dockerfile.armhf (on Rasperrby PI 3B+) outputs the following error:

```
Loading composer repositories with package information
Installing dependencies from lock file
Your requirements could not be resolved to an installable set of packages.

  Problem 1
    - Installation request for pubsubhubbub/publisher dev-master -> satisfiable by pubsubhubbub/publisher[dev-master].
    - pubsubhubbub/publisher dev-master requires ext-curl * -> the requested PHP extension curl is missing from your system.

  To enable extensions, verify that they are enabled in your .ini files:
    - /etc/php7/php.ini
    - /etc/php7/conf.d/00_iconv.ini
    - /etc/php7/conf.d/00_json.ini
    - /etc/php7/conf.d/00_mbstring.ini
    - /etc/php7/conf.d/00_openssl.ini
    - /etc/php7/conf.d/01_phar.ini
  You can also run `php --ini` inside terminal to see which files are used by PHP in CLI mode.
The command '/bin/sh -c apk --update --no-cache add php7-mbstring composer     && cd /app/shaarli     && composer --prefer-dist --no-dev install' returned a non-zero code: 2
```

The package `php7-curl` needs to be installed earlier in the build steps, like proposed in the fix (tested and deployed).