### PR TITLE
ATOM Feed: use instance name as author name instead of URL

### DIFF
--- a/tpl/default/feed.atom.html
+++ b/tpl/default/feed.atom.html
@@ -10,7 +10,7 @@
     {$value}
   {/loop}
   <author>
-    <name>{$index_url}</name>
+    <name>{$pagetitle}</name>
     <uri>{$index_url}</uri>
   </author>
   <id>{$index_url}</id>

--- a/tpl/vintage/feed.atom.html
+++ b/tpl/vintage/feed.atom.html
@@ -12,7 +12,7 @@
     {$value}
   {/loop}
   <author>
-    <name>{$index_url}</name>
+    <name>{$pagetitle}</name>
     <uri>{$index_url}</uri>
   </author>
   <id>{$index_url}</id>


### PR DESCRIPTION
Related FreshRSS/FreshRSS#2466