### PR TITLE
Docker: Bump NodeJS version to prevent an issue with node-sass

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@ RUN cd shaarli \
 
 # Stage 3:
 # - Frontend dependencies
-FROM node:9.9-alpine as node
+FROM node:12-alpine as node
 COPY --from=composer /app/shaarli shaarli
 RUN cd shaarli \
     && yarn install \


### PR DESCRIPTION
I'm not exactly sure what was going but the `master` branch hasn't build on docker hub in ~3 months due to an issue with `node-sass`:

```
error An unexpected error occurred: "/shaarli/node_modules/node-sass: Command failed.
Exit code: 1
Command: sh
Arguments: -c node scripts/build.js
Directory: /shaarli/node_modules/node-sass
Output:
Building: /usr/local/bin/node /shaarli/node_modules/node-gyp/bin/node-gyp.js rebuild --verbose --libsass_ext= --libsass_cflags= --libsass_ldflags= --libsass_library=
gyp info it worked if it ends with ok
gyp verb cli [ '/usr/local/bin/node',
gyp verb cli   '/shaarli/node_modules/node-gyp/bin/node-gyp.js',
gyp verb cli   'rebuild',
gyp verb cli   '--verbose',
gyp verb cli   '--libsass_ext=',
gyp verb cli   '--libsass_cflags=',
gyp verb cli   '--libsass_ldflags=',
gyp verb cli   '--libsass_library=' ]
gyp info using node-gyp@3.8.0
gyp info using node@9.9.0 | linux | x64
gyp verb command rebuild []
gyp verb command clean []
gyp verb clean removing \"build\" directory
gyp verb command configure []
gyp verb check python checking for Python executable \"python2\" in the PATH
gyp verb `which` failed Error: not found: python2
```

Bumping NodeJS version seems to fix it, so we'll go with that.