### PR TITLE
Remove Travis unit tests against PHP 5.6 and 7.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,10 +9,6 @@ matrix:
       php: 7.2
     - language: php
       php: 7.1
-    - language: php
-      php: 7.0
-    - language: php
-      php: 5.6
     - language: node_js
       node_js: 8
       cache:


### PR DESCRIPTION
Related to v0.11 release.