### PR TITLE
Fixes a Undefined index: thumbnail in daily page.

### DIFF
--- a/index.php
+++ b/index.php
@@ -465,7 +465,7 @@ function showDaily($pageBuilder, $LINKSDB, $conf, $pluginManager, $loginManager)
         // Description: 836 characters gives roughly 342 pixel height.
         // This is not perfect, but it's usually OK.
         $length = strlen($link['title']) + (342 * strlen($link['description'])) / 836;
-        if ($link['thumbnail']) {
+        if (! empty($link['thumbnail'])) {
             $length += 100; // 1 thumbnails roughly takes 100 pixels height.
         }
         // Then put in column which is the less filled:


### PR DESCRIPTION
This PR fixes a notice that appear on daily page when at least one link has no thumbnail:

```html
<br />
<b>Notice</b>:  Undefined index: thumbnail in <b>F:\Dev\PHP\shaarli\index.php</b> on line <b>468</b><br />
<!DOCTYPE html>
```

It's invisible with the default theme but visible in the HTML itself.