### PR TITLE
Make sure that bookmark sort is consistent, even with equal timestamps

### DIFF
--- a/application/bookmark/LinkDB.php
+++ b/application/bookmark/LinkDB.php
@@ -102,7 +102,7 @@ class LinkDB implements Iterator, Countable, ArrayAccess
         $isLoggedIn,
         $hidePublicLinks
     ) {
-    
+
         $this->datastore = $datastore;
         $this->loggedIn = $isLoggedIn;
         $this->hidePublicLinks = $hidePublicLinks;
@@ -415,7 +415,7 @@ You use the community supported version of the original Shaarli project, by Seba
         $visibility = 'all',
         $untaggedonly = false
     ) {
-    
+
         // Filter link database according to parameters.
         $searchtags = isset($filterRequest['searchtags']) ? escape($filterRequest['searchtags']) : '';
         $searchterm = isset($filterRequest['searchterm']) ? escape($filterRequest['searchterm']) : '';
@@ -532,6 +532,9 @@ You use the community supported version of the original Shaarli project, by Seba
         usort($this->links, function ($a, $b) use ($order) {
             if (isset($a['sticky']) && isset($b['sticky']) && $a['sticky'] !== $b['sticky']) {
                 return $a['sticky'] ? -1 : 1;
+            }
+            if ($a['created'] == $b['created']) {
+                return $a['id'] < $b['id'] ? 1 * $order : -1 * $order;
             }
             return $a['created'] < $b['created'] ? 1 * $order : -1 * $order;
         });

--- a/tests/bookmark/LinkDBTest.php
+++ b/tests/bookmark/LinkDBTest.php
@@ -619,4 +619,39 @@ class LinkDBTest extends \PHPUnit\Framework\TestCase
 
         $this->assertEquals($expected, $tags, var_export($tags, true));
     }
+
+    /**
+     * Make sure that bookmarks with the same timestamp have a consistent order:
+     * if their creation date is equal, bookmarks are sorted by ID DESC.
+     */
+    public function testConsistentOrder()
+    {
+        $nextId = 42;
+        $creation = DateTime::createFromFormat('Ymd_His', '20190807_130444');
+        $linkDB = new LinkDB(self::$testDatastore, true, false);
+        for ($i = 0; $i < 4; ++$i) {
+            $linkDB[$nextId + $i] = [
+                'id' => $nextId + $i,
+                'url' => 'http://'. $i,
+                'created' => $creation,
+                'title' => true,
+                'description' => true,
+                'tags' => true,
+            ];
+        }
+
+        // Check 4 new links 4 times
+        for ($i = 0; $i < 4; ++$i) {
+            $linkDB->save('tests');
+            $linkDB = new LinkDB(self::$testDatastore, true, false);
+            $count = 3;
+            foreach ($linkDB as $link) {
+                $this->assertEquals($nextId + $count, $link['id']);
+                $this->assertEquals('http://'. $count, $link['url']);
+                if (--$count < 0) {
+                    break;
+                }
+            }
+        }
+    }
 }


### PR DESCRIPTION
If timestamps are equals, we sort bookmarks by ID.
Note that bookmarks are reorder when the datastore is saved.

Fixes #1348