### PR TITLE
Fix image lazy loading issues

### DIFF
--- a/assets/default/scss/shaarli.scss
+++ b/assets/default/scss/shaarli.scss
@@ -1436,6 +1436,8 @@ form {
   -webkit-transition: opacity 500ms ease-in-out;
   -moz-transition: opacity 500ms ease-in-out;
   -o-transition: opacity 500ms ease-in-out;
+  min-width: 1px;
+  min-height: 1px;
 
   &.b-loaded {
     opacity: 1;


### PR DESCRIPTION
For some reason, bLazy won't load the image if the img block has either 0 height or width.

I'm not sure what changed, but lazy loading didn't work anymore:
  * Chromium 76: both linklist and picwall
  * Firefox 68: picwall