### PR TITLE
Markdown plugin: fix RSS feed direct link reverse

### DIFF
--- a/plugins/markdown/markdown.php
+++ b/plugins/markdown/markdown.php
@@ -259,7 +259,7 @@ function reverse_space2nbsp($description)
 
 function reverse_feed_permalink($description)
 {
-    return preg_replace('@&#8212; <a href="([^"]+)" title="[^"]+">(\w+)</a>$@im', '&#8212; [$2]($1)', $description);
+    return preg_replace('@&#8212; <a href="([^"]+)" title="[^"]+">([^<]+)</a>$@im', '&#8212; [$2]($1)', $description);
 }
 
 /**

--- a/tests/plugins/PluginMarkdownTest.php
+++ b/tests/plugins/PluginMarkdownTest.php
@@ -156,6 +156,16 @@ class PluginMarkdownTest extends \PHPUnit\Framework\TestCase
         $this->assertEquals($expected, $processedText);
     }
 
+    public function testReverseFeedDirectLink()
+    {
+        $text = 'Description... ';
+        $text .= '&#8212; <a href="http://domain.tld/?0oc_VQ" title="Direct link">Direct link</a>';
+        $expected = 'Description... &#8212; [Direct link](http://domain.tld/?0oc_VQ)';
+        $processedText = reverse_feed_permalink($text);
+
+        $this->assertEquals($expected, $processedText);
+    }
+
     public function testReverseLastFeedPermalink()
     {
         $text = 'Description... ';


### PR DESCRIPTION
The plugin was only reversing permalinks and failed with setting `rss_permalinks` set to false.