### PR TITLE
thumbnailer: add soundcloud.com to list of common media domains

### DIFF
--- a/application/Thumbnailer.php
+++ b/application/Thumbnailer.php
@@ -27,6 +27,7 @@ class Thumbnailer
         'instagram.com',
         'pinterest.com',
         'pinterest.fr',
+        'soundcloud.com',
         'tumblr.com',
         'deviantart.com',
     ];


### PR DESCRIPTION
OpenGraph thumbnails are well supported on soundcloud.com, displaying an album/track/artist cover image