### PR TITLE
Add php-json as required PHP module

### DIFF
--- a/doc/md/Server-configuration.md
+++ b/doc/md/Server-configuration.md
@@ -28,12 +28,12 @@ Version | Status | Shaarli compatibility
 Extension | Required? | Usage
 ---|:---:|---
 [`openssl`](http://php.net/manual/en/book.openssl.php) | All | OpenSSL, HTTPS
+[`php-json`](http://php.net/manual/en/book.json.php) | required | ?
 [`php-mbstring`](http://php.net/manual/en/book.mbstring.php) | CentOS, Fedora, RHEL, Windows, some hosting providers | multibyte (Unicode) string support
 [`php-gd`](http://php.net/manual/en/book.image.php) | optional | required to use thumbnails
 [`php-intl`](http://php.net/manual/en/book.intl.php) | optional | localized text sorting (e.g. `e->è->f`)
 [`php-curl`](http://php.net/manual/en/book.curl.php) | optional | using cURL for fetching webpages and thumbnails in a more robust way
 [`php-gettext`](http://php.net/manual/en/book.gettext.php) | optional | Use the translation system in gettext mode (faster)
-
 --------------------------------------------------------------------------------
 
 ### SSL/TLS configuration 

--- a/doc/md/Server-configuration.md
+++ b/doc/md/Server-configuration.md
@@ -28,7 +28,7 @@ Version | Status | Shaarli compatibility
 Extension | Required? | Usage
 ---|:---:|---
 [`openssl`](http://php.net/manual/en/book.openssl.php) | All | OpenSSL, HTTPS
-[`php-json`](http://php.net/manual/en/book.json.php) | required | ?
+[`php-json`](http://php.net/manual/en/book.json.php) | required | configuration parsing
 [`php-mbstring`](http://php.net/manual/en/book.mbstring.php) | CentOS, Fedora, RHEL, Windows, some hosting providers | multibyte (Unicode) string support
 [`php-gd`](http://php.net/manual/en/book.image.php) | optional | required to use thumbnails
 [`php-intl`](http://php.net/manual/en/book.intl.php) | optional | localized text sorting (e.g. `e->è->f`)


### PR DESCRIPTION
Without php-json the installation stops with a white screen and the following error:
> 09-Nov-2019 14:05:46 UTC] PHP Fatal error:  Uncaught Error: Call to undefined function Shaarli\Config\json_encode() in /var/www/html/shaarli/application/config/ConfigJson.php:48
> Stack trace:
> #0 /var/www/html/shaarli/application/config/ConfigManager.php(239): Shaarli\Config\ConfigJson->write('data/config.jso...', Array)
> #1 /var/www/html/shaarli/index.php(1835): Shaarli\Config\ConfigManager->write(false)
> #2 /var/www/html/shaarli/index.php(178): install(Object(Shaarli\Config\ConfigManager), Object(Shaarli\Security\SessionManager), Object(Shaarli\Security\LoginManager))
> #3 {main}
>   thrown in /var/www/html/shaarli/application/config/ConfigJson.php on line 48

Tested with Shaarli 0.10.4 on CentOS 8 with Httpd 2.4.37 and PHP 7.2.11.