### PR TITLE
Avoiding warning 'PHP Notice: Undefined index: updated'

### DIFF
--- a/tpl/default/includes.html
+++ b/tpl/default/includes.html
@@ -27,7 +27,7 @@
   {/if}
   {if="!$hide_timestamps || $is_logged_in"}
     <meta property="article:published_time" content="{$link.created->format(DateTime::ATOM)}" />
-    {if="$link.updated"}
+    {if="!empty($link.updated)"}
       <meta property="article:modified_time" content="{$link.updated->format(DateTime::ATOM)}" />
     {/if}
   {/if}

--- a/tpl/vintage/includes.html
+++ b/tpl/vintage/includes.html
@@ -24,7 +24,7 @@
   {/if}
   {if="!$hide_timestamps || $is_logged_in"}
     <meta property="article:published_time" content="{$link.created->format(DateTime::ATOM)}" />
-    {if="$link.updated"}
+    {if="!empty($link.updated)"}
       <meta property="article:modified_time" content="{$link.updated->format(DateTime::ATOM)}" />
     {/if}
   {/if}


### PR DESCRIPTION
Using the latest `master` branch code, the warning looked like this in my logs:
```
[error] FastCGI sent in stderr: "PHP message: PHP Notice:  Undefined index: updated in /usr/share/nginx/html/shaarli/tmp/includes.cedf684561d925457130839629000a81.rtpl.php on line 40" while reading response header from upstream
```