### PR TITLE
Session cookie setting being set while session is active

### DIFF
--- a/index.php
+++ b/index.php
@@ -243,7 +243,9 @@ if (isset($_POST['login'])) {
         }
 
         // Send cookie with the new expiration date to the browser
+        session_destroy();
         session_set_cookie_params($expirationTime, $cookiedir, $_SERVER['SERVER_NAME']);
+        session_start();
         session_regenerate_id(true);
 
         // Optional redirect after login:


### PR DESCRIPTION
Trying to do will raise a warning since PHP 7.2, and it never worked as intended.
See: https://bugs.php.net/bug.php\?id\=75650

I've noticed this because dev mode now raise exceptions on warnings:

```
PHP Fatal error:  Uncaught ErrorException: session_set_cookie_params(): Cannot change session cookie parameters when session is active in /home/arthur/PhpstormProjects/Shaarli/index.php:248
Stack trace:
#0 [internal function]: {closure}()
#1 /home/arthur/PhpstormProjects/Shaarli/index.php(248): session_set_cookie_params()
#2 {main}
  thrown in /home/arthur/PhpstormProjects/Shaarli/index.php on line 248
```