### PR TITLE
Add an exception to method 'whitelist_protocols' for url which started with '#'

### DIFF
--- a/application/http/UrlUtils.php
+++ b/application/http/UrlUtils.php
@@ -73,7 +73,7 @@ function add_trailing_slash($url)
  */
 function whitelist_protocols($url, $protocols)
 {
-    if (startsWith($url, '?') || startsWith($url, '/')) {
+    if (startsWith($url, '?') || startsWith($url, '/') || startsWith($url, '#')) {
         return $url;
     }
     $protocols = array_merge(['http', 'https'], $protocols);


### PR DESCRIPTION
This is to allow local link for markdown, actually a local link write with this syntax :
`[anchor](#local_link)`
produce this HTML code:

> http://#local_link

in place of 

> #local_link