### PR TITLE
V0.11 fixes one error on 'daily' page & a malfunction for local link in Markdown render

### DIFF
--- a/application/http/UrlUtils.php
+++ b/application/http/UrlUtils.php
@@ -73,7 +73,7 @@ function add_trailing_slash($url)
  */
 function whitelist_protocols($url, $protocols)
 {
-    if (startsWith($url, '?') || startsWith($url, '/')) {
+    if (startsWith($url, '?') || startsWith($url, '/') || startsWith($url, '#')) {
         return $url;
     }
     $protocols = array_merge(['http', 'https'], $protocols);

--- a/index.php
+++ b/index.php
@@ -465,7 +465,7 @@ function showDaily($pageBuilder, $LINKSDB, $conf, $pluginManager, $loginManager)
         // Description: 836 characters gives roughly 342 pixel height.
         // This is not perfect, but it's usually OK.
         $length = strlen($link['title']) + (342 * strlen($link['description'])) / 836;
-        if ($link['thumbnail']) {
+        if (!empty($link['thumbnail'])) {
             $length += 100; // 1 thumbnails roughly takes 100 pixels height.
         }
         // Then put in column which is the less filled:


### PR DESCRIPTION
* on 'daily' page, when the thumbnail option is deactivated, an error occur during PHP parsing for index not exists for $link['thumbnail']

* local link in Markdown render
When a local link is writting in markdown syntax (with markdown render), the link:
`[text](#local_link)`
produce in render:
`<a href="http://#local_link">`
in place of:
`<a href="#local_link">`