### PR TITLE
ldap authentication, fixes shaarli/Shaarli#1343

### DIFF
--- a/application/security/LoginManager.php
+++ b/application/security/LoginManager.php
@@ -204,12 +204,20 @@ class LoginManager
      */
     public function checkCredentialsFromLdap($login, $password, $connect = null, $bind = null)
     {
-        $connect = $connect ?? function($host) { return ldap_connect($host); };
-        $bind = $bind ?? function($handle, $dn, $password) { return ldap_bind($handle, $dn, $password); };
+        $connect = $connect ?? function($host) {
+            $resource = ldap_connect($host);
+
+            ldap_set_option($resource, LDAP_OPT_PROTOCOL_VERSION, 3);
+
+            return $resource;
+        };
+        $bind = $bind ?? function($handle, $dn, $password) {
+            return ldap_bind($handle, $dn, $password);
+        };
 
         return $bind(
             $connect($this->configManager->get('ldap.host')),
-            sprintf($this->configManager->get('ldap.dn'), $login), 
+            sprintf($this->configManager->get('ldap.dn'), $login),
             $password
         );
     }

--- a/application/security/LoginManager.php
+++ b/application/security/LoginManager.php
@@ -141,7 +141,7 @@ class LoginManager
     public function checkCredentials($remoteIp, $clientIpId, $login, $password)
     {
         // Check login matches config
-        if ($login != $this->configManager->get('credentials.login')) {
+        if ($login !== $this->configManager->get('credentials.login')) {
             return false;
         }
 

--- a/application/security/LoginManager.php
+++ b/application/security/LoginManager.php
@@ -206,7 +206,12 @@ class LoginManager
     {
         $connect = $connect ?? function($host) { return ldap_connect($host); };
         $bind = $bind ?? function($handle, $dn, $password) { return ldap_bind($handle, $dn, $password); };
-        return $bind($connect($this->configManager->get('ldap.host')), sprintf($this->configManager->get('ldap.dn'), $login), $password);
+
+        return $bind(
+            $connect($this->configManager->get('ldap.host')),
+            sprintf($this->configManager->get('ldap.dn'), $login), 
+            $password
+        );
     }
 
     /**

--- a/application/security/LoginManager.php
+++ b/application/security/LoginManager.php
@@ -147,8 +147,10 @@ class LoginManager
 
         // Check credentials
         try {
-            if (($this->configManager->get('ldap.host') != "" && $this->checkCredentialsFromLdap($login, $password))
-                || ($this->configManager->get('ldap.host') == "" && $this->checkCredentialsFromLocalConfig($login, $password))) {
+            $useLdapLogin = !empty($this->configManager->get('ldap.host'));
+            if ((false === $useLdapLogin && $this->checkCredentialsFromLocalConfig($login, $password))
+                || (true === $useLdapLogin && $this->checkCredentialsFromLdap($login, $password))
+            ) {
                     $this->sessionManager->storeLoginInfo($clientIpId);
                     logm(
                         $this->configManager->get('resource.log'),

--- a/doc/md/Shaarli-configuration.md
+++ b/doc/md/Shaarli-configuration.md
@@ -122,6 +122,11 @@ Must be an associative array: `translation domain => translation path`.
 - **enable_thumbnails**: Enable or disable thumbnail display.  
 - **enable_localcache**: Enable or disable local cache.
 
+### LDAP
+
+- **host**: LDAP host used for user authentication
+- **dn**: user DN template (`sprintf` format, `%s` being replaced by user login)
+
 ## Configuration file example
 
 ```json
@@ -223,6 +228,10 @@ Must be an associative array: `translation domain => translation path`.
         "extensions": {
             "demo": "plugins/demo_plugin/languages/"
         }
+    },
+    "ldap": {
+        "host": "ldap://localhost",
+        "dn": "uid=%s,ou=people,dc=example,dc=org"
     }
 } ?>
 ```

--- a/tests/security/LoginManagerTest.php
+++ b/tests/security/LoginManagerTest.php
@@ -314,7 +314,7 @@ class LoginManagerTest extends TestCase
      */
     public function testCheckCredentialsFromLdapWrongLoginAndPassword()
     {
-        $this->coddnfigManager->set('ldap.host', 'dummy');
+        $this->configManager->set('ldap.host', 'dummy');
         $this->assertFalse(
             $this->loginManager->checkCredentialsFromLdap($this->login, $this->password, function() { return null; }, function() { return false; })
         );

--- a/tests/security/LoginManagerTest.php
+++ b/tests/security/LoginManagerTest.php
@@ -78,6 +78,7 @@ class LoginManagerTest extends TestCase
             'security.ban_after' => 2,
             'security.ban_duration' => 3600,
             'security.trusted_proxies' => [$this->trustedProxy],
+            'ldap.host' => '',
         ]);
 
         $this->cookie = [];
@@ -294,6 +295,39 @@ class LoginManagerTest extends TestCase
     {
         $this->assertTrue(
             $this->loginManager->checkCredentials('', '', $this->login, $this->password)
+        );
+    }
+
+    /**
+     * Check user credentials through LDAP - server unreachable
+     */
+    public function testCheckCredentialsFromUnreachableLdap()
+    {
+        $this->configManager->set('ldap.host', 'dummy');
+        $this->assertFalse(
+            $this->loginManager->checkCredentials('', '', $this->login, $this->password)
+        );
+    }
+
+    /**
+     * Check user credentials through LDAP - wrong login and password supplied
+     */
+    public function testCheckCredentialsFromLdapWrongLoginAndPassword()
+    {
+        $this->coddnfigManager->set('ldap.host', 'dummy');
+        $this->assertFalse(
+            $this->loginManager->checkCredentialsFromLdap($this->login, $this->password, function() { return null; }, function() { return false; })
+        );
+    }
+
+    /**
+     * Check user credentials through LDAP - correct login and password supplied
+     */
+    public function testCheckCredentialsFromLdapGoodLoginAndPassword()
+    {
+        $this->configManager->set('ldap.host', 'dummy');
+        $this->assertTrue(
+            $this->loginManager->checkCredentialsFromLdap($this->login, $this->password, function() { return null; }, function() { return true; })
         );
     }
 }


### PR DESCRIPTION
This makes authentication through LDAP possible.

If "`ldap.host`" is defined in config and is not an empty string, then the user is authenticated through LDAP bind.
Otherwise, authentication is local.