### PR TITLE
Improve documentation about how to create and initialize a plugin

### DIFF
--- a/doc/md/Plugin-System.md
+++ b/doc/md/Plugin-System.md
@@ -18,7 +18,7 @@ The plugin system let you:
 
 First, chose a plugin name, such as `demo_plugin`.
 
-Under `plugin` folder, create a folder named with your plugin name. Then create a <plugin_name>.php file in that folder.
+Under `plugin` folder, create a folder named with your plugin name. Then create a <plugin_name>.meta file and a <plugin_name>.php file in that folder.
 
 You should have the following tree view:
 
@@ -26,16 +26,19 @@ You should have the following tree view:
 | index.php
 | plugins/
 |---| demo_plugin/
+|   |---| demo_plugin.meta
 |   |---| demo_plugin.php
 ```
 
 ### Plugin initialization
 
-At the beginning of Shaarli execution, all enabled plugins are loaded. At this point, the plugin system looks for an `init()` function to execute and run it if it exists. This function must be named this way, and takes the `ConfigManager` as parameter.
+At the beginning of Shaarli execution, all enabled plugins are loaded. At this point, the plugin system looks for an `init()` function in the <plugin_name>.php to execute and run it if it exists. This function must be named this way, and takes the `ConfigManager` as parameter.
 
     <plugin_name>_init($conf)
 
 This function can be used to create initial data, load default settings, etc. But also to set *plugin errors*. If the initialization function returns an array of strings, they will be understand as errors, and displayed in the header to logged in users.
+
+The plugin system also looks for a `description` variable in the <plugin_name>.meta file, to be displayed in the plugin administration page.
 
 ### Understanding hooks
 

--- a/doc/md/Plugin-System.md
+++ b/doc/md/Plugin-System.md
@@ -40,6 +40,8 @@ This function can be used to create initial data, load default settings, etc. Bu
 
 The plugin system also looks for a `description` variable in the <plugin_name>.meta file, to be displayed in the plugin administration page.
 
+    description="The plugin does this and that."
+
 ### Understanding hooks
 
 A plugin is a set of functions. Each function will be triggered by the plugin system at certain point in Shaarli execution.


### PR DESCRIPTION
I've tried to create a plugin following the documentation, but it wasn't working. 

Turns out the .meta file is also required. I've modified the documentation accordingly in this PR.

The plugin might be initialized but won't be displayed in the plugin administration if that file is missing. When the plugin administration page is loaded, the plugins metas are fetched:
https://github.com/shaarli/Shaarli/blob/cf01113cad2fc772113b5d1b7cd5be5e712ae0eb/index.php#L1542
If the meta file does not exist, the iterated plugin is simply passed.
https://github.com/shaarli/Shaarli/blob/cf01113cad2fc772113b5d1b7cd5be5e712ae0eb/application/plugin/PluginManager.php#L191-L193

Technically only the file itself is required but, in the docs I've added that the description variable should be present.