### PR TITLE
Fix missing php7-simplexml plugin for Dockerfile.armhf

### DIFF
--- a/Dockerfile.armhf
+++ b/Dockerfile.armhf
@@ -12,7 +12,7 @@ RUN apk --update --no-cache add py2-pip \
 # - Resolve PHP dependencies with Composer
 FROM arm32v6/alpine:3.8 as composer
 COPY --from=docs /usr/src/app/shaarli /app/shaarli
-RUN apk --update --no-cache add php7-curl php7-mbstring composer \
+RUN apk --update --no-cache add php7-curl php7-mbstring php7-simplexml composer \
     && cd /app/shaarli \
     && composer --prefer-dist --no-dev install
 


### PR DESCRIPTION
This is to fix this error I got when building to my Raspberry  Pi :

  Your requirements could not be resolved to an installable set of packages.

  Problem 1
    - Installation request for slim/slim 3.12.3 -> satisfiable by slim/slim[3.12.3].
    - slim/slim 3.12.3 requires ext-simplexml * -> the requested PHP extension simplexml is missing from your system.

  To enable extensions, verify that they are enabled in your .ini files:
    - /etc/php7/php.ini
    - /etc/php7/conf.d/00_curl.ini
    - /etc/php7/conf.d/00_iconv.ini
    - /etc/php7/conf.d/00_json.ini
    - /etc/php7/conf.d/00_mbstring.ini
    - /etc/php7/conf.d/00_openssl.ini
    - /etc/php7/conf.d/01_phar.ini
  You can also run `php --ini` inside terminal to see which files are used by PHP in CLI mode.