### PR TITLE
Travis CI: upgrade distribution and remove deprecated sudo

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,4 @@
-sudo: false
-dist: trusty
+dist: bionic
 
 matrix:
   include:


### PR DESCRIPTION
This upgrade fixes PHP 7.4 fatal error builds, because dist < xenial do
not include php-gd with PHP 7.4.