### PR TITLE
Fix Docker build: gcc is no longer included in python alpine image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,7 @@
 FROM python:3-alpine as docs
 ADD . /usr/src/app/shaarli
 RUN cd /usr/src/app/shaarli \
+    && apk add --no-cache gcc musl-dev \
     && pip install --no-cache-dir mkdocs \
     && mkdocs build --clean
 


### PR DESCRIPTION
Builds have been failing for a while, again.