### PR TITLE
Added $links_per_page variable to template and display on default template

### DIFF
--- a/application/render/PageBuilder.php
+++ b/application/render/PageBuilder.php
@@ -149,7 +149,7 @@ class PageBuilder
 
         $this->tpl->assign('formatter', $this->conf->get('formatter', 'default'));
 
-        $this->tpl->assign('links_per_page', $_SESSION['LINKS_PER_PAGE']);
+        $this->tpl->assign('links_per_page', $this->session['LINKS_PER_PAGE']);
 
         // To be removed with a proper theme configuration.
         $this->tpl->assign('conf', $this->conf);

--- a/application/render/PageBuilder.php
+++ b/application/render/PageBuilder.php
@@ -149,6 +149,8 @@ class PageBuilder
 
         $this->tpl->assign('formatter', $this->conf->get('formatter', 'default'));
 
+        $this->tpl->assign('links_per_page', $_SESSION['LINKS_PER_PAGE']);
+
         // To be removed with a proper theme configuration.
         $this->tpl->assign('conf', $this->conf);
     }

--- a/assets/default/scss/shaarli.scss
+++ b/assets/default/scss/shaarli.scss
@@ -616,11 +616,11 @@ body,
     padding: 5px;
     text-decoration: none;
     color: $dark-grey;
-  }
 
-  a.selected {
-    background: var(--main-color);
-    color: $white;
+    &.selected {
+      background: var(--main-color);
+      color: $white;
+     }
   }
 
   input {

--- a/assets/default/scss/shaarli.scss
+++ b/assets/default/scss/shaarli.scss
@@ -618,6 +618,11 @@ body,
     color: $dark-grey;
   }
 
+  a.selected {
+    background: var(--main-color);
+    color: $white;
+  }
+
   input {
     &[type='text'] {
       @extend %linksperpage-button;

--- a/tpl/default/linklist.paging.html
+++ b/tpl/default/linklist.paging.html
@@ -53,11 +53,16 @@
 
     <div class="linksperpage pure-u-1-3">
       <div class="pure-u-0 pure-u-lg-visible">{'Links per page'|t}</div>
-      <a href="{$base_path}/links-per-page?nb=20">20</a>
-      <a href="{$base_path}/links-per-page?nb=50">50</a>
-      <a href="{$base_path}/links-per-page?nb=100">100</a>
+      <a href="{$base_path}/links-per-page?nb=20"
+			{if="$links_per_page == 20"}class="selected"{/if}>20</a>
+      <a href="{$base_path}/links-per-page?nb=50"
+			{if="$links_per_page == 50"}class="selected"{/if}>50</a>
+      <a href="{$base_path}/links-per-page?nb=100"
+			{if="$links_per_page == 100"}class="selected"{/if}>100</a>
       <form method="GET" class="pure-u-0 pure-u-lg-visible" action="{$base_path}/links-per-page">
-        <input type="text" name="nb" placeholder="133">
+        <input type="text" name="nb" placeholder="133"
+			{if="$links_per_page != 20 && $links_per_page != 50 && $links_per_page != 100"}
+				value="{$links_per_page}"{/if}>
       </form>
       <a href="#" class="filter-off fold-all pure-u-0 pure-u-lg-visible" aria-label="{'Fold all'|t}" title="{'Fold all'|t}">
         <i class="fa fa-chevron-up" aria-hidden="true"></i>


### PR DESCRIPTION
Hi. I'm creating my own template and noticed there isn't a way to determine the links per page. The issue was first discussed here:

https://github.com/shaarli/Shaarli/issues/173

I added $links_per_page to the RainTpl variables and modified the default template. If the links per page are 20, 50, or 100 the appropriate button is highlighted, otherwise the links per page are displayed in the input text field.

<img width="728" alt="Screen Shot 2020-08-29 at 11 26 26 AM" src="https://user-images.githubusercontent.com/2607333/91640299-87e87900-e9ea-11ea-8b3e-2d10c3cb456d.png">
<img width="728" alt="Screen Shot 2020-08-29 at 11 26 17 AM" src="https://user-images.githubusercontent.com/2607333/91640300-88810f80-e9ea-11ea-8a01-efee13a46c95.png">

