### PR TITLE
Fix support for legacy route login redirection

### DIFF
--- a/application/legacy/LegacyController.php
+++ b/application/legacy/LegacyController.php
@@ -40,30 +40,33 @@ class LegacyController extends ShaarliVisitorController
     public function post(Request $request, Response $response): Response
     {
         $parameters = count($request->getQueryParams()) > 0 ? '?' . http_build_query($request->getQueryParams()) : '';
+        $route = '/admin/shaare';
 
         if (!$this->container->loginManager->isLoggedIn()) {
-            return $this->redirect($response, '/login?returnurl=/admin/shaare' . $parameters);
+            return $this->redirect($response, '/login?returnurl='. $this->getBasePath() . $route . $parameters);
         }
 
-        return $this->redirect($response, '/admin/shaare' . $parameters);
+        return $this->redirect($response, $route . $parameters);
     }
 
     /** Legacy route: ?addlink= */
     protected function addlink(Request $request, Response $response): Response
     {
+        $route = '/admin/add-shaare';
+
         if (!$this->container->loginManager->isLoggedIn()) {
-            return $this->redirect($response, '/login?returnurl=/admin/add-shaare');
+            return $this->redirect($response, '/login?returnurl=' . $this->getBasePath() . $route);
         }
 
-        return $this->redirect($response, '/admin/add-shaare');
+        return $this->redirect($response, $route);
     }
 
     /** Legacy route: ?do=login */
     protected function login(Request $request, Response $response): Response
     {
-        $returnurl = $request->getQueryParam('returnurl');
+        $returnUrl = $request->getQueryParam('returnurl');
 
-        return $this->redirect($response, '/login' . ($returnurl ? '?returnurl=' . $returnurl : ''));
+        return $this->redirect($response, '/login' . ($returnUrl ? '?returnurl=' . $returnUrl : ''));
     }
 
     /** Legacy route: ?do=logout */

--- a/application/legacy/LegacyController.php
+++ b/application/legacy/LegacyController.php
@@ -132,4 +132,21 @@ class LegacyController extends ShaarliVisitorController
 
         return $this->redirect($response, '/feed/' . $feedType . $parameters);
     }
+
+    /** Legacy route: ?do=configure */
+    protected function configure(Request $request, Response $response): Response
+    {
+        $route = '/admin/configure';
+
+        if (!$this->container->loginManager->isLoggedIn()) {
+            return $this->redirect($response, '/login?returnurl=' . $this->getBasePath() . $route);
+        }
+
+        return $this->redirect($response, $route);
+    }
+
+    protected function getBasePath(): string
+    {
+        return $this->container->basePath ?: '';
+    }
 }

--- a/application/legacy/LegacyController.php
+++ b/application/legacy/LegacyController.php
@@ -42,7 +42,7 @@ class LegacyController extends ShaarliVisitorController
         $parameters = count($request->getQueryParams()) > 0 ? '?' . http_build_query($request->getQueryParams()) : '';
 
         if (!$this->container->loginManager->isLoggedIn()) {
-            return $this->redirect($response, '/login' . $parameters);
+            return $this->redirect($response, '/login?returnurl=/admin/shaare' . $parameters);
         }
 
         return $this->redirect($response, '/admin/shaare' . $parameters);
@@ -52,7 +52,7 @@ class LegacyController extends ShaarliVisitorController
     protected function addlink(Request $request, Response $response): Response
     {
         if (!$this->container->loginManager->isLoggedIn()) {
-            return $this->redirect($response, '/login');
+            return $this->redirect($response, '/login?returnurl=/admin/add-shaare');
         }
 
         return $this->redirect($response, '/admin/add-shaare');
@@ -61,7 +61,9 @@ class LegacyController extends ShaarliVisitorController
     /** Legacy route: ?do=login */
     protected function login(Request $request, Response $response): Response
     {
-        return $this->redirect($response, '/login');
+        $returnurl = $request->getQueryParam('returnurl');
+
+        return $this->redirect($response, '/login' . ($returnurl ? '?returnurl=' . $returnurl : ''));
     }
 
     /** Legacy route: ?do=logout */

--- a/tests/legacy/LegacyControllerTest.php
+++ b/tests/legacy/LegacyControllerTest.php
@@ -66,11 +66,11 @@ class LegacyControllerTest extends TestCase
     {
         return [
             ['post', [], '/admin/shaare', true],
-            ['post', [], '/login?returnurl=/admin/shaare', false],
+            ['post', [], '/login?returnurl=/subfolder/admin/shaare', false],
             ['post', ['title' => 'test'], '/admin/shaare?title=test', true],
-            ['post', ['title' => 'test'], '/login?returnurl=/admin/shaare?title=test', false],
+            ['post', ['title' => 'test'], '/login?returnurl=/subfolder/admin/shaare?title=test', false],
             ['addlink', [], '/admin/add-shaare', true],
-            ['addlink', [], '/login?returnurl=/admin/add-shaare', false],
+            ['addlink', [], '/login?returnurl=/subfolder/admin/add-shaare', false],
             ['login', [], '/login', true],
             ['login', [], '/login', false],
             ['logout', [], '/admin/logout', true],

--- a/tests/legacy/LegacyControllerTest.php
+++ b/tests/legacy/LegacyControllerTest.php
@@ -66,11 +66,11 @@ class LegacyControllerTest extends TestCase
     {
         return [
             ['post', [], '/admin/shaare', true],
-            ['post', [], '/login', false],
+            ['post', [], '/login?returnurl=/admin/shaare', false],
             ['post', ['title' => 'test'], '/admin/shaare?title=test', true],
-            ['post', ['title' => 'test'], '/login?title=test', false],
+            ['post', ['title' => 'test'], '/login?returnurl=/admin/shaare?title=test', false],
             ['addlink', [], '/admin/add-shaare', true],
-            ['addlink', [], '/login', false],
+            ['addlink', [], '/login?returnurl=/admin/add-shaare', false],
             ['login', [], '/login', true],
             ['login', [], '/login', false],
             ['logout', [], '/admin/logout', true],

--- a/tests/legacy/LegacyControllerTest.php
+++ b/tests/legacy/LegacyControllerTest.php
@@ -94,6 +94,8 @@ class LegacyControllerTest extends TestCase
             ['opensearch', [], '/open-search', true],
             ['dailyrss', [], '/daily-rss', false],
             ['dailyrss', [], '/daily-rss', true],
+            ['configure', [], '/login?returnurl=/subfolder/admin/configure', false],
+            ['configure', [], '/admin/configure', true],
         ];
     }
 }


### PR DESCRIPTION
Makes sure that the user is properly redirected to the bookmark form after login, even with legacy routes.

ping @mro

EDIT: added redirection from `?do=configure` in the same PR.