### PR TITLE
Fix broken css/js files on individual shaare pages

### DIFF
--- a/plugins/qrcode/qrcode.php
+++ b/plugins/qrcode/qrcode.php
@@ -42,7 +42,7 @@ function hook_qrcode_render_linklist($data)
 function hook_qrcode_render_footer($data)
 {
     if ($data['_PAGE_'] == TemplatePage::LINKLIST) {
-        $data['js_files'][] =  PluginManager::$PLUGINS_PATH . '/qrcode/shaarli-qrcode.js';
+        $data['js_files'][] =  ($data['_BASE_PATH_'] ?? '') . '/' . PluginManager::$PLUGINS_PATH . '/qrcode/shaarli-qrcode.js';
     }
 
     return $data;
@@ -58,7 +58,7 @@ function hook_qrcode_render_footer($data)
 function hook_qrcode_render_includes($data)
 {
     if ($data['_PAGE_'] == TemplatePage::LINKLIST) {
-        $data['css_files'][] = PluginManager::$PLUGINS_PATH . '/qrcode/qrcode.css';
+        $data['css_files'][] = ($data['_BASE_PATH_'] ?? '') . '/' . PluginManager::$PLUGINS_PATH . '/qrcode/qrcode.css';
     }
 
     return $data;


### PR DESCRIPTION
This PR fixes individual shaare pages (e.g., `/shaare/o3Fv-w`) as the relative path is no longer working:

![image](https://user-images.githubusercontent.com/21174107/92324783-168d7380-f045-11ea-8ca2-7067fba06e6f.png)
