### PR TITLE
Add PATCH to the allowed Apache request methods

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -15,23 +15,7 @@ RewriteCond %{REQUEST_FILENAME} !-f
 RewriteCond %{REQUEST_FILENAME} !-d
 RewriteRule ^ index.php [QSA,L]
 
-<Limit GET POST PUT DELETE OPTIONS>
-  <IfModule version_module>
-    <IfVersion >= 2.4>
-       Require all granted
-    </IfVersion>
-    <IfVersion < 2.4>
-       Allow from all
-       Deny from none
-    </IfVersion>
-  </IfModule>
-
-  <IfModule !version_module>
-    Require all granted
-  </IfModule>
-</Limit>
-
-<LimitExcept GET POST PUT DELETE OPTIONS>
+<LimitExcept GET POST PUT DELETE PATCH OPTIONS>
   <IfModule version_module>
     <IfVersion >= 2.4>
        Require all denied


### PR DESCRIPTION
Fixes #1549 

I don't think either the Limit or LimitExcept block is necessary in the .htaccess file. Those are used mainly for limiting requests to specific users logged in via Apache or IP addresses. Apache internally determines which methods are expected by the URL. Having both a Limit and LimitExcept block is redundant, so I removed the Limit block. I added PATCH to the LimitExcept block to fix the issue with synchronizing thumbnails.