### PR TITLE
Makefile: remove static_analysis_summary from all: target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 
 BIN = vendor/bin
 
-all: static_analysis_summary check_permissions test
+all: check_permissions test
 
 ##
 # Docker test adapter


### PR DESCRIPTION
static_analysis_summary was removed in 37c9c6b#diff-b67911656ef5d18c4ae36cb6741b7965 but not from the all: target dependencies. Therefore running make all always fails.

fixes https://github.com/shaarli/Shaarli/issues/1459