### PR TITLE
doc/Makefile: remove references to composer update

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -85,6 +85,10 @@ all_tests: test locale_test_de_DE locale_test_en_US locale_test_fr_FR
 	@# --text doesn't work with phpunit 4.* (v5 requires PHP 5.6)
 	@#$(BIN)/phpcov merge --text coverage/txt coverage
 
+### download 3rd-party PHP libraries, including dev dependencies
+composer_dependencies_dev: clean
+	composer install --prefer-dist
+
 ##
 # Custom release archive generation
 #

--- a/doc/md/dev/Unit-tests.md
+++ b/doc/md/dev/Unit-tests.md
@@ -10,21 +10,16 @@ You can either use:
 - a local version, downloadable [here](https://getcomposer.org/download/).
 
 ```bash
-# system-wide version
-$ composer install
-$ composer update
-
-# local version
-$ php composer.phar self-update
-$ php composer.phar install
-$ php composer.phar update
+# for Debian-based distros
+sudo apt install composer
 ```
+
 
 ## Install Shaarli dev dependencies
 
 ```bash
 $ cd /path/to/shaarli
-$ composer update
+$ make composer_dependencies_dev
 ```
 
 ## Install and enable Xdebug to generate PHPUnit coverage reports
@@ -34,7 +29,7 @@ $ composer update
 
 ```bash
 # for Debian-based distros:
-sudo aptitude install php5-xdebug
+sudo apt install php-xdebug
 
 # for ArchLinux:
 pacman -S xdebug


### PR DESCRIPTION
doc/Makefile: remove references to composer update
- add make composer_dependencies_dev Makefile target and use this instead
- fix composer initial installation procedure
- fix php-xdebug install instructions
