### PR TITLE
Fix warning if the encoding retrieved from external headers is invalid

### DIFF
--- a/application/bookmark/LinkUtils.php
+++ b/application/bookmark/LinkUtils.php
@@ -26,7 +26,7 @@ function html_extract_title($html)
  */
 function header_extract_charset($header)
 {
-    preg_match('/charset="?([^; ]+)/i', $header, $match);
+    preg_match('/charset=["\']?([^; "\']+)/i', $header, $match);
     if (! empty($match[1])) {
         return strtolower(trim($match[1]));
     }

--- a/application/front/controller/admin/ManageShaareController.php
+++ b/application/front/controller/admin/ManageShaareController.php
@@ -69,7 +69,7 @@ class ManageShaareController extends ShaarliAdminController
                         $retrieveDescription
                     )
                 );
-                if (! empty($title) && strtolower($charset) !== 'utf-8') {
+                if (! empty($title) && strtolower($charset) !== 'utf-8' && mb_check_encoding($charset)) {
                     $title = mb_convert_encoding($title, 'utf-8', $charset);
                 }
             }

--- a/tests/bookmark/LinkUtilsTest.php
+++ b/tests/bookmark/LinkUtilsTest.php
@@ -43,6 +43,19 @@ class LinkUtilsTest extends TestCase
     }
 
     /**
+     * Test headers_extract_charset() when the charset is found with odd quotes.
+     */
+    public function testHeadersExtractExistentCharsetWithQuotes()
+    {
+        $charset = 'x-MacCroatian';
+        $headers = 'text/html; charset="' . $charset . '"otherstuff="test"';
+        $this->assertEquals(strtolower($charset), header_extract_charset($headers));
+
+        $headers = 'text/html; charset=\'' . $charset . '\'otherstuff="test"';
+        $this->assertEquals(strtolower($charset), header_extract_charset($headers));
+    }
+
+    /**
      * Test headers_extract_charset() when the charset is not found.
      */
     public function testHeadersExtractNonExistentCharset()


### PR DESCRIPTION
Also fixed the regex to support this failing header: `charset="utf-8"\r\n"`