### PR TITLE
Workaround for hoster (ionos)

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -10,8 +10,12 @@ RewriteRule ^(.git|doxygen|vendor) - [F]
 # fixes JWT token not correctly forwarded on some Apache/FastCGI setups
 RewriteCond %{HTTP:Authorization} ^(.*)
 RewriteRule .* - [e=HTTP_AUTHORIZATION:%1]
+# Alternative (if the 2 lines above don't work)
+# SetEnvIf Authorization .+ HTTP_AUTHORIZATION=$0
 
 # REST API
+# Ionos Hosting needs RewriteBase /
+# RewriteBase /
 RewriteCond %{REQUEST_FILENAME} !-f
 RewriteCond %{REQUEST_FILENAME} !-d
 RewriteRule ^ index.php [QSA,L]

--- a/application/api/ApiMiddleware.php
+++ b/application/api/ApiMiddleware.php
@@ -102,16 +102,16 @@ class ApiMiddleware
         if (! $request->hasHeader('Authorization') && !isset($this->container->environment['REDIRECT_HTTP_AUTHORIZATION'])) {
             throw new ApiAuthorizationException('JWT token not provided');
         }
-	
+
         if (empty($this->conf->get('api.secret'))) {
             throw new ApiAuthorizationException('Token secret must be set in Shaarli\'s administration');
         }
 
-	if (isset($this->container->environment['REDIRECT_HTTP_AUTHORIZATION'])) {
-	    $authorization = $this->container->environment['REDIRECT_HTTP_AUTHORIZATION'];
-	} else {
+        if (isset($this->container->environment['REDIRECT_HTTP_AUTHORIZATION'])) {
+            $authorization = $this->container->environment['REDIRECT_HTTP_AUTHORIZATION'];
+        } else {
             $authorization = $request->getHeaderLine('Authorization');
-	}
+        }
 
         if (! preg_match('/^Bearer (.*)/i', $authorization, $matches)) {
             throw new ApiAuthorizationException('Invalid JWT header');

--- a/application/api/ApiMiddleware.php
+++ b/application/api/ApiMiddleware.php
@@ -3,6 +3,7 @@ namespace Shaarli\Api;
 
 use Shaarli\Api\Exceptions\ApiAuthorizationException;
 use Shaarli\Api\Exceptions\ApiException;
+use Shaarli\Bookmark\BookmarkFileService;
 use Shaarli\Config\ConfigManager;
 use Slim\Container;
 use Slim\Http\Request;
@@ -70,7 +71,14 @@ class ApiMiddleware
             $response = $e->getApiResponse();
         }
 
-        return $response;
+        return $response
+            ->withHeader('Access-Control-Allow-Origin', '*')
+            ->withHeader(
+                'Access-Control-Allow-Headers',
+                'X-Requested-With, Content-Type, Accept, Origin, Authorization'
+            )
+            ->withHeader('Access-Control-Allow-Methods', 'GET, POST, PUT, DELETE, OPTIONS')
+        ;
     }
 
     /**
@@ -99,7 +107,9 @@ class ApiMiddleware
      */
     protected function checkToken($request)
     {
-        if (! $request->hasHeader('Authorization') && !isset($this->container->environment['REDIRECT_HTTP_AUTHORIZATION'])) {
+        if (!$request->hasHeader('Authorization')
+            && !isset($this->container->environment['REDIRECT_HTTP_AUTHORIZATION'])
+        ) {
             throw new ApiAuthorizationException('JWT token not provided');
         }
 
@@ -121,7 +131,7 @@ class ApiMiddleware
     }
 
     /**
-     * Instantiate a new LinkDB including private links,
+     * Instantiate a new LinkDB including private bookmarks,
      * and load in the Slim container.
      *
      * FIXME! LinkDB could use a refactoring to avoid this trick.
@@ -130,10 +140,10 @@ class ApiMiddleware
      */
     protected function setLinkDb($conf)
     {
-        $linkDb = new \Shaarli\Bookmark\LinkDB(
-            $conf->get('resource.datastore'),
-            true,
-            $conf->get('privacy.hide_public_links')
+        $linkDb = new BookmarkFileService(
+            $conf,
+            $this->container->get('history'),
+            true
         );
         $this->container['db'] = $linkDb;
     }

--- a/application/api/ApiMiddleware.php
+++ b/application/api/ApiMiddleware.php
@@ -107,7 +107,7 @@ class ApiMiddleware
      */
     protected function checkToken($request)
     {
-        if (! $request->hasHeader('Authorization')) {
+        if (! $request->hasHeader('Authorization') && !isset($_SERVER['REDIRECT_HTTP_AUTHORIZATION'])) {
             throw new ApiAuthorizationException('JWT token not provided');
         }
 
@@ -115,7 +115,11 @@ class ApiMiddleware
             throw new ApiAuthorizationException('Token secret must be set in Shaarli\'s administration');
         }
 
-        $authorization = $request->getHeaderLine('Authorization');
+	if (isset($_SERVER['REDIRECT_HTTP_AUTHORIZATION'])) {
+	    $authorization = $_SERVER['REDIRECT_HTTP_AUTHORIZATION'];
+	} else {
+            $authorization = $request->getHeaderLine('Authorization');
+	}
 
         if (! preg_match('/^Bearer (.*)/i', $authorization, $matches)) {
             throw new ApiAuthorizationException('Invalid JWT header');

--- a/tests/api/ApiMiddlewareTest.php
+++ b/tests/api/ApiMiddlewareTest.php
@@ -67,6 +67,53 @@ class ApiMiddlewareTest extends \PHPUnit\Framework\TestCase
     }
 
     /**
+     * Invoke the middleware with a valid token
+     */
+    public function testInvokeMiddlewareWithValidToken(): void
+    {
+        $next = function (Request $request, Response $response): Response {
+            return $response;
+        };
+        $mw = new ApiMiddleware($this->container);
+        $env = Environment::mock([
+            'REQUEST_METHOD' => 'GET',
+            'REQUEST_URI' => '/echo',
+            'HTTP_AUTHORIZATION'=> 'Bearer ' . ApiUtilsTest::generateValidJwtToken('NapoleonWasALizard'),
+        ]);
+        $request = Request::createFromEnvironment($env);
+        $response = new Response();
+        /** @var Response $response */
+        $response = $mw($request, $response, $next);
+
+        $this->assertEquals(200, $response->getStatusCode());
+    }
+
+    /**
+     * Invoke the middleware with a valid token
+     * Using specific Apache CGI redirected authorization.
+     */
+    public function testInvokeMiddlewareWithValidTokenFromRedirectedHeader(): void
+    {
+        $next = function (Request $request, Response $response): Response {
+            return $response;
+        };
+
+        $token = 'Bearer ' . ApiUtilsTest::generateValidJwtToken('NapoleonWasALizard');
+        $this->container->environment['REDIRECT_HTTP_AUTHORIZATION'] = $token;
+        $mw = new ApiMiddleware($this->container);
+        $env = Environment::mock([
+            'REQUEST_METHOD' => 'GET',
+            'REQUEST_URI' => '/echo',
+        ]);
+        $request = Request::createFromEnvironment($env);
+        $response = new Response();
+        /** @var Response $response */
+        $response = $mw($request, $response, $next);
+
+        $this->assertEquals(200, $response->getStatusCode());
+    }
+
+    /**
      * Invoke the middleware with the API disabled:
      * should return a 401 error Unauthorized.
      */


### PR DESCRIPTION
The hoster writes the environment variable with bearer token to
`REDIRECT_HTTP_AUTHORIZATION` and I need to provide `RewriteBase /` to
`.htaccess`

### `.htaccess`

Additionally the JWT workaround does not work:
`RewriteCond %{HTTP:Authorization} ^(.*)`                                                                                                     
`RewriteRule .* - [e=HTTP_AUTHORIZATION:%1]`

but

`SetEnvIf Authorization .+ HTTP_AUTHORIZATION=$0`

helped.