### PR TITLE
docker-compose.yml: pin traefik image to 1.7-alpine

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -33,7 +33,7 @@ services:
       traefik.frontend.rule: "Host:${SHAARLI_VIRTUAL_HOST}"
 
   traefik:
-    image: traefik
+    image: traefik:1.7-alpine
     command:
       - "--defaultentrypoints=http,https"
       - "--entrypoints=Name:http Address::80 Redirect.EntryPoint:https"


### PR DESCRIPTION
- fixes https://github.com/shaarli/Shaarli/issues/1493
- https://hub.docker.com/_/traefik/