### PR TITLE
WIP: deprecate `stable` and `latest` branches, rename to `release`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,6 +78,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Add manual configuration for root URL
 - Added PATCH to the allowed Apache request methods.
 - REST API: compatibility with ionos Apache's headers
+- Added `release` branch/Docker image which always points to the latest [release](https://github.com/shaarli/Shaarli/releases)
 
 ### Changed
 - Introduce Bookmark object and Service layer
@@ -91,6 +92,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Improve default bookmarks after install
 - Upgrade all front end dependencies and webpack build
 - Default theme: Make tag cloud/list views buttons more obvious
+- `:latest` Docker image tag now points to the development (`master`) version of Shaarli. Users of the `:latest` Docker image are advised to switch to the `:release` image which always points to the latest release.
 
 ### Fixed
 - Undefined index: thumbnail in daily page
@@ -123,6 +125,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
   - emojione & twemoji removed
 - Makefile: remove static_analysis_summary from all: target
 - doc/Makefile: remove references to composer update
+- Removed support for the `stable` release branch/Docker image. Users of the `stable` branch/image are advised to switch to the `release` version which always points to the latest release.
+- Removed support for the `latest` branch, now known as `release`
 
 ## [v0.11.1](https://github.com/shaarli/Shaarli/releases/tag/v0.11.1) - 2019-08-03
 

--- a/README.md
+++ b/README.md
@@ -6,13 +6,8 @@ _Do you want to share the links you discover?_
 _Shaarli is a minimalist link sharing service that you can install on your own server._
 _It is designed to be personal (single-user), fast and handy._
 
-[![](https://img.shields.io/badge/stable-v0.11.1-blue.svg)](https://github.com/shaarli/Shaarli/releases/tag/v0.11.1)
-[![](https://img.shields.io/travis/shaarli/Shaarli/stable.svg?label=stable)](https://travis-ci.org/shaarli/Shaarli)
-&bull;
-[![](https://img.shields.io/badge/latest-v0.12.1-blue.svg)](https://github.com/shaarli/Shaarli/releases/tag/v0.12.1)
-[![](https://img.shields.io/travis/shaarli/Shaarli/latest.svg?label=latest)](https://travis-ci.org/shaarli/Shaarli)
-&bull;
-[![](https://img.shields.io/badge/master-v0.12.x-blue.svg)](https://github.com/shaarli/Shaarli)
+[![](https://img.shields.io/badge/latest%20release-v0.12.1-blue.svg)](https://github.com/shaarli/Shaarli/releases/tag/v0.12.1)
+[![](https://img.shields.io/travis/shaarli/Shaarli/release.svg?label=stable)](https://travis-ci.org/shaarli/Shaarli)
 [![](https://img.shields.io/travis/shaarli/Shaarli.svg?label=master)](https://travis-ci.org/shaarli/Shaarli)
 
 [![Join the chat at https://gitter.im/shaarli/Shaarli](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/shaarli/Shaarli)

--- a/application/config/ConfigManager.php
+++ b/application/config/ConfigManager.php
@@ -372,7 +372,7 @@ class ConfigManager
         $this->setEmpty('general.tags_separator', ' ');
 
         $this->setEmpty('updates.check_updates', true);
-        $this->setEmpty('updates.check_updates_branch', 'latest');
+        $this->setEmpty('updates.check_updates_branch', 'release');
         $this->setEmpty('updates.check_updates_interval', 86400);
 
         $this->setEmpty('feed.rss_permalinks', true);

--- a/application/helper/ApplicationUtils.php
+++ b/application/helper/ApplicationUtils.php
@@ -16,6 +16,7 @@ class ApplicationUtils
     public static $VERSION_FILE = 'shaarli_version.php';
 
     private static $GIT_URL = 'https://raw.githubusercontent.com/shaarli/Shaarli';
+    public static $GIT_RAW_URL = 'https://raw.githubusercontent.com/shaarli/Shaarli'; 
     private static $GIT_BRANCHES = array('latest', 'stable');
     private static $VERSION_START_TAG = '<?php /* ';
     private static $VERSION_END_TAG = ' */ ?>';

--- a/application/helper/ApplicationUtils.php
+++ b/application/helper/ApplicationUtils.php
@@ -15,23 +15,22 @@ class ApplicationUtils
      */
     public static $VERSION_FILE = 'shaarli_version.php';
 
-    public static $GITHUB_URL = 'https://github.com/shaarli/Shaarli';
-    public static $GIT_RAW_URL = 'https://raw.githubusercontent.com/shaarli/Shaarli';
-    public static $GIT_BRANCHES = ['latest', 'stable'];
+    private static $GIT_URL = 'https://raw.githubusercontent.com/shaarli/Shaarli';
+    private static $GIT_BRANCHES = array('latest', 'stable');
     private static $VERSION_START_TAG = '<?php /* ';
     private static $VERSION_END_TAG = ' */ ?>';
 
     /**
-     * Gets the latest version code from the Git repository
+     * Gets the latest release version code from the Git repository
      *
      * The code is read from the raw content of the version file on the Git server.
      *
-     * @param string $url     URL to reach to get the latest version.
+     * @param string $url     URL to reach to get the latest release version.
      * @param int    $timeout Timeout to check the URL (in seconds).
      *
      * @return mixed the version code from the repository if available, else 'false'
      */
-    public static function getLatestGitVersionCode($url, $timeout = 2)
+    public static function getLatestReleaseGitVersionCode($url, $timeout = 2)
     {
         list($headers, $data) = get_http_response($url, $timeout);
 
@@ -54,7 +53,7 @@ class ApplicationUtils
     public static function getVersion($remote, $timeout = 2)
     {
         if (startsWith($remote, 'http')) {
-            if (($data = static::getLatestGitVersionCode($remote, $timeout)) === false) {
+            if (($data = static::getLatestReleaseGitVersionCode($remote, $timeout)) === false) {
                 return false;
             }
         } else {
@@ -83,7 +82,7 @@ class ApplicationUtils
      *   to avoid intempestive connection attempts.
      *
      * @param string $currentVersion the current version code
-     * @param string $updateFile     the file where to store the latest version code
+     * @param string $updateFile     the file where to store the latest release version code
      * @param int    $checkInterval  the minimum interval between update checks (in seconds
      * @param bool   $enableCheck    whether to check for new versions
      * @param bool   $isLoggedIn     whether the user is logged in
@@ -99,7 +98,7 @@ class ApplicationUtils
         $checkInterval,
         $enableCheck,
         $isLoggedIn,
-        $branch = 'stable'
+        $branch = 'release'
     ) {
         // Do not check versions for visitors
         // Do not check if the user doesn't want to
@@ -126,21 +125,21 @@ class ApplicationUtils
 
         // Late Static Binding allows overriding within tests
         // See http://php.net/manual/en/language.oop5.late-static-bindings.php
-        $latestVersion = static::getVersion(
+        $latestReleaseVersion = static::getVersion(
             self::$GIT_RAW_URL . '/' . $branch . '/' . self::$VERSION_FILE
         );
 
-        if (!$latestVersion) {
+        if (!$latestReleaseVersion) {
             // Only update the file's modification date
             file_put_contents($updateFile, $currentVersion);
             return false;
         }
 
         // Update the file's content and modification date
-        file_put_contents($updateFile, $latestVersion);
+        file_put_contents($updateFile, $latestReleaseVersion);
 
-        if (version_compare($latestVersion, $currentVersion) == 1) {
-            return $latestVersion;
+        if (version_compare($latestReleaseVersion, $currentVersion) == 1) {
+            return $latestReleaseVersion;
         }
 
         return false;

--- a/application/legacy/LegacyUpdater.php
+++ b/application/legacy/LegacyUpdater.php
@@ -419,43 +419,20 @@ class LegacyUpdater
     /**
      * Update updates.check_updates_branch setting.
      *
-     * If the current major version digit matches the latest branch
-     * major version digit, we set the branch to `latest`,
-     * otherwise we'll check updates on the `stable` branch.
-     *
      * No update required for the dev version.
+     *
+     * Always set the branch to `release`
      *
      * Note: due to hardcoded URL and lack of dependency injection, this is not unit testable.
      *
-     * FIXME! This needs to be removed when we switch to first digit major version
-     *        instead of the second one since the versionning process will change.
      */
     public function updateMethodCheckUpdateRemoteBranch()
     {
-        if (SHAARLI_VERSION === 'dev' || $this->conf->get('updates.check_updates_branch') === 'latest') {
+        if (SHAARLI_VERSION === 'dev' || $this->conf->get('updates.check_updates_branch') === 'master') {
             return true;
         }
 
-        // Get latest branch major version digit
-        $latestVersion = ApplicationUtils::getLatestGitVersionCode(
-            'https://raw.githubusercontent.com/shaarli/Shaarli/latest/shaarli_version.php',
-            5
-        );
-        if (preg_match('/(\d+)\.\d+$/', $latestVersion, $matches) === false) {
-            return false;
-        }
-        $latestMajor = $matches[1];
-
-        // Get current major version digit
-        preg_match('/(\d+)\.\d+$/', SHAARLI_VERSION, $matches);
-        $currentMajor = $matches[1];
-
-        if ($currentMajor === $latestMajor) {
-            $branch = 'latest';
-        } else {
-            $branch = 'stable';
-        }
-        $this->conf->set('updates.check_updates_branch', $branch);
+        $this->conf->set('updates.check_updates_branch', 'release');
         $this->conf->write($this->isLoggedIn);
         return true;
     }

--- a/doc/md/Docker.md
+++ b/doc/md/Docker.md
@@ -39,11 +39,11 @@ docker run hello-world
 
 ## Get and run a Shaarli image
 
-Shaarli images are available on [DockerHub](https://hub.docker.com/r/shaarli/shaarli/) `shaarli/shaarli`:
+Shaarli images are available on [DockerHub](https://hub.docker.com/r/shaarli/shaarli/):
 
-- `latest`: latest branch (last release)
-- `stable`: stable branch (last release in previous major version)
-- `master`: master branch (development branch)
+- `shaarli/shaarli:vX.Y.Z`: where `X.Y.Z` is any  [tagged release](https://github.com/shaarli/Shaarli/releases)
+- `shaarli/shaarli:release`: latest tagged release
+- `shaarli/shaarli:latest`: master branch (development version)
 
 These images are built automatically on DockerHub and rely on:
 
@@ -57,7 +57,7 @@ Here is an example of how to run Shaarli latest image using Docker:
 
 ```bash
 # download the 'latest' image from dockerhub
-docker pull shaarli/shaarli
+docker pull shaarli/shaarli:latest
 
 # create persistent data volumes/directories on the host
 docker volume create shaarli-data
@@ -91,13 +91,15 @@ docker ps -a | grep myshaarli # verify th container has been destroyed
 
 After running `docker run` command, your Shaarli instance should be available on the host machine at [localhost:8000](http://localhost:8000). In order to access your instance through a reverse proxy, we recommend using our [Docker Compose](#docker-compose) build.
 
+
 ## Docker Compose
 
-A [Compose file](https://docs.docker.com/compose/compose-file/) is a common format for defining and running multi-container Docker applications.
+A [Compose file](https://docs.docker.com/compose/compose-file/) is a common format for defining and running multi-container Docker applications. It can be used to run a persistent/autostarted Shaarli service using [Docker Compose](https://docs.docker.com/compose/) or in a [Docker stack](https://docs.docker.com/engine/reference/commandline/stack_deploy/).
 
-A `docker-compose.yml` file can be used to run a persistent/autostarted shaarli service using [Docker Compose](https://docs.docker.com/compose/) or in a [Docker stack](https://docs.docker.com/engine/reference/commandline/stack_deploy/).
-
-Shaarli provides configuration file for Docker Compose, that will setup a Shaarli instance, a [Træfik](https://containo.us/traefik/) instance (reverse proxy) with [Let's Encrypt](https://letsencrypt.org/) certificates, a Docker network, and volumes for Shaarli data and Træfik TLS configuration and certificates.
+Shaarli provides a `docker-compose.yml` file, that will setup:
+- a Shaarli instance
+- a [Træfik](https://containo.us/traefik/) instance (reverse proxy) with [Let's Encrypt](https://letsencrypt.org/) certificates
+- a Docker network, and volumes for data/configuration/certificates persistence.
 
 Download docker-compose from the [release page](https://docs.docker.com/compose/install/):
 
@@ -126,6 +128,8 @@ $ docker-compose up -d
 ```
 
 After a few seconds, you should be able to access your Shaarli instance at [https://shaarli.mydomain.org](https://shaarli.mydomain.org) (replace your own domain name).
+
+The default docker-compose.yml file runs the `:latest` (development version) Shaarli image. You can edit the file to point to [another Shaarli image](#get-and-run-a-shaarli-image) if needed.
 
 ## Running dockerized Shaarli as a systemd service
 

--- a/doc/md/Installation.md
+++ b/doc/md/Installation.md
@@ -23,13 +23,13 @@ These components are required to build Shaarli:
 Clone the repository, either pointing to:
 
 - any [tagged release](https://github.com/shaarli/Shaarli/releases)
-- `latest`: the latest tagged release
+- `release`: the latest tagged release
 - `master`: development branch
 
 ```bash
 # clone the branch/tag of your choice
-$ git clone -b latest https://github.com/shaarli/Shaarli.git /home/me/Shaarli
-# OR download/extract the tar.gz/zip: wget https://github.com/shaarli/Shaarli/archive/latest.tar.gz...
+$ git clone -b release https://github.com/shaarli/Shaarli.git /home/me/Shaarli
+# OR download/extract the tar.gz/zip: wget https://github.com/shaarli/Shaarli/archive/release.tar.gz...
 
 # enter the directory
 $ cd /home/me/Shaarli

--- a/doc/md/Shaarli-configuration.md
+++ b/doc/md/Shaarli-configuration.md
@@ -64,7 +64,7 @@ Some settings can be configured directly from a web browser by accesing the `Too
         "default_private_links": true,
         "enable_thumbnails": true,
         "enable_localcache": true,
-        "check_updates_branch": "stable",
+        "check_updates_branch": "release",
         "check_updates_interval": 86400,
         "enabled_plugins": [
             "markdown",
@@ -97,7 +97,7 @@ Some settings can be configured directly from a web browser by accesing the `Too
     },
     "updates": {
         "check_updates": true,
-        "check_updates_branch": "stable",
+        "check_updates_branch": "release",
         "check_updates_interval": 86400
     },
     "feed": {
@@ -213,7 +213,7 @@ Must be an associative array: `translation domain => translation path`.
 ### Updates
 
 - **check_updates**: Enable or disable update check to the git repository.
-- **check_updates_branch**: Git branch used to check updates (e.g. `stable` or `master`).
+- **check_updates_branch**: Git branch used to check updates (only `release` is supported).
 - **check_updates_interval**: Look for new version every N seconds (default: every day).
 
 ### Privacy

--- a/doc/md/Upgrade-and-migration.md
+++ b/doc/md/Upgrade-and-migration.md
@@ -127,22 +127,22 @@ Receiving objects: 100% (3015/3015), 2.59 MiB | 918.00 KiB/s, done.
 Resolving deltas: 100% (1899/1899), completed with 48 local objects.
 From https://github.com/shaarli/Shaarli
  * [new branch]      master     -> origin/master
- * [new branch]      stable     -> origin/stable
+ * [new branch]      release     -> origin/release
 [...]
  * [new tag]         v0.6.4     -> v0.6.4
  * [new tag]         v0.7.0     -> v0.7.0
 ```
 
-### Step 2: use the stable community branch
+### Step 2: use the release community branch
 
 ```bash
-$ git checkout origin/stable -b stable
-Branch stable set up to track remote branch stable from origin.
-Switched to a new branch 'stable'
+$ git checkout origin/release -b release
+Branch release set up to track remote branch release from origin.
+Switched to a new branch 'release'
 
 $ git branch -vv
   master 029f75f [sebsauvage/master] Update README.md
-* stable 890afc3 [origin/stable] Merge pull request #509 from ArthurHoaro/v0.6.5
+* release 890afc3 [origin/release] Merge pull request #509 from ArthurHoaro/v0.6.5
 ```
 
 Shaarli >= `v0.8.x`: install/update third-party PHP dependencies using [Composer](https://getcomposer.org/):

--- a/doc/md/dev/Release-Shaarli.md
+++ b/doc/md/dev/Release-Shaarli.md
@@ -141,13 +141,13 @@ This will create `shaarli-v0.x.y-full.tar`, `shaarli-v0.x.y-full.zip`. These arc
 ### Update the `latest` branch
 
 ```bash
-# checkout the 'latest' branch
-git checkout latest
+# checkout the 'release' branch
+git checkout release
 # merge changes from your newly published release branch
 git merge v0.x.y
 # fix eventual conflicts with git mergetool...
 # run tests
 make test
-# push the latest branch
-git push upstream latest
+# push the 'release' branch
+git push upstream release
 ```

--- a/doc/md/dev/Versioning.md
+++ b/doc/md/dev/Versioning.md
@@ -3,34 +3,31 @@
 If you're maintaining a 3rd party tool for Shaarli (theme, plugin, etc.), It's important to understand how Shaarli branches work ensure your tool stays compatible.
 
 
+## `release` branch
+
+This branch points to the latest release. It recommended to use it to get the latest tested changes.
+
+
 ## `master` branch
 
 The `master` branch is the development branch. Any new change MUST go through this branch using Pull Requests.
 
-Remarks:
-
 - This branch shouldn't be used for production as it isn't necessary stable.
-- 3rd party aren't required to be compatible with the latest changes.
+- It is not guaranteed to be compatible with 3rd-party software/themes/plugins.
 - Official plugins, themes and libraries (contained within Shaarli organization repos) must be compatible with the master branch.
+
+
+## Releases
+
+For every release, we manually generate a .zip file which contains all Shaarli dependencies, making Shaarli's installation only one step.
 
 
 ## `v0.x` branch
 
 The `v0.x` branch points to the latest `v0.x.y` release.
 
-If a major bug affects the original `v0.x.0` release, we may [backport](https://en.wikipedia.org/wiki/Backporting) a fix for this bug from master, to the `v0.x` branch, and create a new bugfix release (eg. `v0.x.1`) from this branch.
+If a major bug affects the original `v0.x.0` release, we may [backport](https://en.wikipedia.org/wiki/Backporting) a fix for this bug from master, to the `v0.x` branch, and create a new bugfix release (eg. `v0.x.1`) from this branch. This allows users of the original release to upgrade to the fixed version, without having to upgrade to a completely new minor/major release.
 
-This allows users of the original release to upgrade to the fixed version, without having to upgrade to a completely new minor/major release.
-
-
-## `latest` branch
-
-This branch point the latest release. It recommended to use it to get the latest tested changes.
-
-
-## Releases
-
-For every release, we manually generate a .zip file which contains all Shaarli dependencies, making Shaarli's installation only one step.
 
 
 ## Advices on 3rd party git repos workflow
@@ -39,10 +36,11 @@ For every release, we manually generate a .zip file which contains all Shaarli d
 
 Any time a new Shaarli release is published, you should publish a new release of your repo if the changes affected you since the latest release (take a look at the [changelog](https://github.com/shaarli/Shaarli/releases) (*Draft* means not released yet) and the commit log (like [`tpl` folder](https://github.com/shaarli/Shaarli/commits/master/tpl/default) for themes)). You can either:
 
-   - use the Shaarli version number, with your repo version. For example, if Shaarli `v0.8.3` is released, publish a `v0.8.3-1` release, where `v0.8.3` states Shaarli compatibility and `-1` is your own version digit for the current Shaarli version.
-   - use your own versioning scheme, and state Shaarli compatibility in the release description.
+- use the Shaarli version number, with your repo version. For example, if Shaarli `v0.8.3` is released, publish a `v0.8.3-1` release, where `v0.8.3` states Shaarli compatibility and `-1` is your own version digit for the current Shaarli version.
+- use your own versioning scheme, and state Shaarli compatibility in the release description.
 
 Using this, any user will be able to pick the release matching his own Shaarli version.
+
 
 ### Major bugfix backport releases
 

--- a/tests/helper/ApplicationUtilsTest.php
+++ b/tests/helper/ApplicationUtilsTest.php
@@ -37,7 +37,7 @@ class ApplicationUtilsTest extends \Shaarli\TestCase
     }
 
     /**
-     * Retrieve the latest version code available on Git
+     * Retrieve the latest release version code available on Git
      *
      * Expected format: Semantic Versioning - major.minor.patch
      */
@@ -57,14 +57,14 @@ class ApplicationUtilsTest extends \Shaarli\TestCase
             self::$versionPattern,
             ApplicationUtils::getVersion(
                 'https://raw.githubusercontent.com/shaarli/Shaarli/'
-                .'latest/shaarli_version.php',
+                .'release/shaarli_version.php',
                 $testTimeout
             )
         );
     }
 
     /**
-     * Attempt to retrieve the latest version from an invalid File
+     * Attempt to retrieve the latest release version from an invalid File
      */
     public function testGetVersionCodeFromFile()
     {
@@ -76,7 +76,7 @@ class ApplicationUtilsTest extends \Shaarli\TestCase
     }
 
     /**
-     * Attempt to retrieve the latest version from an invalid File
+     * Attempt to retrieve the latest release version from an invalid File
      */
     public function testGetVersionCodeInvalidFile()
     {

--- a/tests/utils/config/configJson.json.php
+++ b/tests/utils/config/configJson.json.php
@@ -63,7 +63,7 @@
     },
     "updates": {
         "check_updates": false,
-        "check_updates_branch": "stable",
+        "check_updates_branch": "release",
         "check_updates_interval": 86400
     },
     "feed": {


### PR DESCRIPTION
 - always set the target branch for update checks to `release`
 - update documentation (docker image tags, versioning, release procedure, README badges, migration)
 - doc: mention that the default-docker compose file uses the `:latest` image, update docker-compose documentation
 - rename the `:master` docker image tag to `:latest`
 - clarify method/variable names
 - fixes https://github.com/shaarli/Shaarli/issues/1453