### PR TITLE
Support using Shaarli without URL rewriting

### DIFF
--- a/application/front/controller/visitor/ShaarliVisitorController.php
+++ b/application/front/controller/visitor/ShaarliVisitorController.php
@@ -106,6 +106,7 @@ abstract class ShaarliVisitorController
             'target' => $template,
             'loggedin' => $this->container->loginManager->isLoggedIn(),
             'basePath' => $this->container->basePath,
+            'rootPath' => preg_replace('#/index\.php$#', '', $this->container->basePath),
             'bookmarkService' => $this->container->bookmarkService
         ];
     }

--- a/application/plugin/PluginManager.php
+++ b/application/plugin/PluginManager.php
@@ -104,6 +104,7 @@ class PluginManager
             'target' => '_PAGE_',
             'loggedin' => '_LOGGEDIN_',
             'basePath' => '_BASE_PATH_',
+            'rootPath' => '_ROOT_PATH_',
             'bookmarkService' => '_BOOKMARK_SERVICE_',
         ];
 

--- a/application/render/PageBuilder.php
+++ b/application/render/PageBuilder.php
@@ -174,10 +174,12 @@ class PageBuilder
             }
         }
 
+        $rootPath = preg_replace('#/index\.php$#', '', $basePath);
         $this->assign('base_path', $basePath);
+        $this->assign('root_path', $rootPath);
         $this->assign(
             'asset_path',
-            $basePath . '/' .
+            $rootPath . '/' .
             rtrim($this->conf->get('resource.raintpl_tpl', 'tpl'), '/') . '/' .
             $this->conf->get('resource.theme', 'default')
         );

--- a/doc/md/Server-configuration.md
+++ b/doc/md/Server-configuration.md
@@ -377,7 +377,7 @@ use `https://shaarli.mydomain.org/index.php/`.
 
 **Recommended:**
   * after installation, in the configuration page, set your header link to `/index.php/`.
-  * in you `config.json.php` set `general.root_url` to
+  * in your configuration file `config.json.php` set `general.root_url` to
     `https://shaarli.mydomain.org/index.php/`.
 
 ## Allow import of large browser bookmarks export

--- a/doc/md/Server-configuration.md
+++ b/doc/md/Server-configuration.md
@@ -362,7 +362,23 @@ sudo systemctl reload nginx
 
 If Shaarli is hosted on a server behind a [reverse proxy](https://en.wikipedia.org/wiki/Reverse_proxy) (i.e. there is a proxy server between clients and the web server hosting Shaarli), configure it accordingly. See [Reverse proxy](Reverse-proxy.md) configuration.
 
+## Using Shaarli without URL rewriting
 
+By default, Shaarli uses Slim framework's URL, which requires
+URL rewriting.
+
+If you can't use URL rewriting for any reason (not supported by
+your web server, shared hosting, etc.), you *can* use Shaarli
+without URL rewriting.
+
+You just need to prefix your URL by `/index.php/`.
+Example: instead of accessing `https://shaarli.mydomain.org/`,
+use `https://shaarli.mydomain.org/index.php/`.
+
+**Recommended:**
+  * after installation, in the configuration page, set your header link to `/index.php/`.
+  * in you `config.json.php` set `general.root_url` to
+    `https://shaarli.mydomain.org/index.php/`.
 
 ## Allow import of large browser bookmarks export
 

--- a/doc/md/dev/Plugin-system.md
+++ b/doc/md/dev/Plugin-system.md
@@ -148,11 +148,16 @@ If a file needs to be included in server end, use simple relative path:
 `PluginManager::$PLUGINS_PATH . '/mything/template.html'`.
 
 If it needs to be included in front end side (e.g. an image),
-the relative path must be prefixed with special data `_BASE_PATH_`:
-`($data['_BASE_PATH_'] ?? '') . '/' . PluginManager::$PLUGINS_PATH . '/mything/picture.png`.
+the relative path must be prefixed with special data:
+
+  * if it's a link that will need to be processed by Shaarli, use `_BASE_PATH_`:
+    for e.g. `$data['_BASE_PATH_'] . '/admin/tools`.
+  * if you want to include an asset, you need to add the root URL (base path without `/index.php`, for people using Shaarli without URL rewriting), then use `_ROOT_PATH_`:
+    for e.g
+`$['_ROOT_PATH_'] . '/' . PluginManager::$PLUGINS_PATH . '/mything/picture.png`.
 
 Note that special placeholders for CSS and JS files (respectively `css_files` and `js_files`) are already prefixed
-with the base path in template files.
+with the root path in template files.
 
 ### It's not working!
 

--- a/plugins/archiveorg/archiveorg.php
+++ b/plugins/archiveorg/archiveorg.php
@@ -17,7 +17,8 @@ use Shaarli\Plugin\PluginManager;
 function hook_archiveorg_render_linklist($data)
 {
     $archive_html = file_get_contents(PluginManager::$PLUGINS_PATH . '/archiveorg/archiveorg.html');
-    $path = ($data['_BASE_PATH_'] ?? '') . '/' . PluginManager::$PLUGINS_PATH;
+    $rootPath = preg_replace('#/index\.php$#', '', $data['_BASE_PATH_'] ?? '');
+    $path = $rootPath . '/' . PluginManager::$PLUGINS_PATH;
 
     foreach ($data['links'] as &$value) {
         $isNote = startsWith($value['real_url'], '/shaare/');

--- a/plugins/archiveorg/archiveorg.php
+++ b/plugins/archiveorg/archiveorg.php
@@ -17,8 +17,7 @@ use Shaarli\Plugin\PluginManager;
 function hook_archiveorg_render_linklist($data)
 {
     $archive_html = file_get_contents(PluginManager::$PLUGINS_PATH . '/archiveorg/archiveorg.html');
-    $rootPath = preg_replace('#/index\.php$#', '', $data['_BASE_PATH_'] ?? '');
-    $path = $rootPath . '/' . PluginManager::$PLUGINS_PATH;
+    $path = ($data['_ROOT_PATH_'] ?? '') . '/' . PluginManager::$PLUGINS_PATH;
 
     foreach ($data['links'] as &$value) {
         $isNote = startsWith($value['real_url'], '/shaare/');

--- a/plugins/isso/isso.php
+++ b/plugins/isso/isso.php
@@ -54,7 +54,7 @@ function hook_isso_render_linklist($data, $conf)
         if ($conf->get('resource.theme') === 'default') {
             $button .= '<i class="linklist-plugin-icon fa fa-comment"></i>';
         } else {
-            $button .= '<img class="linklist-plugin-icon" src="plugins/isso/comment.png" ';
+            $button .= '<img class="linklist-plugin-icon" src="'. $data['_ROOT_PATH_'].'/plugins/isso/comment.png" ';
             $button .= 'title="Comment on this shaare" alt="Comments" />';
         }
         $button .= '</a></span>';

--- a/plugins/qrcode/qrcode.php
+++ b/plugins/qrcode/qrcode.php
@@ -19,8 +19,7 @@ function hook_qrcode_render_linklist($data)
 {
     $qrcode_html = file_get_contents(PluginManager::$PLUGINS_PATH . '/qrcode/qrcode.html');
 
-    $rootPath = preg_replace('#/index\.php$#', '', $data['_BASE_PATH_'] ?? '');
-    $path = $rootPath . '/' . PluginManager::$PLUGINS_PATH;
+    $path = ($data['_ROOT_PATH_'] ?? '') . '/' . PluginManager::$PLUGINS_PATH;
     foreach ($data['links'] as &$value) {
         $qrcode = sprintf(
             $qrcode_html,

--- a/plugins/qrcode/qrcode.php
+++ b/plugins/qrcode/qrcode.php
@@ -19,7 +19,8 @@ function hook_qrcode_render_linklist($data)
 {
     $qrcode_html = file_get_contents(PluginManager::$PLUGINS_PATH . '/qrcode/qrcode.html');
 
-    $path = ($data['_BASE_PATH_'] ?? '') . '/' . PluginManager::$PLUGINS_PATH;
+    $rootPath = preg_replace('#/index\.php$#', '', $data['_BASE_PATH_'] ?? '');
+    $path = $rootPath . '/' . PluginManager::$PLUGINS_PATH;
     foreach ($data['links'] as &$value) {
         $qrcode = sprintf(
             $qrcode_html,

--- a/plugins/wallabag/wallabag.php
+++ b/plugins/wallabag/wallabag.php
@@ -45,7 +45,7 @@ function hook_wallabag_render_linklist($data, $conf)
     $wallabagHtml = file_get_contents(PluginManager::$PLUGINS_PATH . '/wallabag/wallabag.html');
 
     $linkTitle = t('Save to wallabag');
-    $path = ($data['_BASE_PATH_'] ?? '') . '/' . PluginManager::$PLUGINS_PATH;
+    $path = ($data['_ROOT_PATH_'] ?? '') . '/' . PluginManager::$PLUGINS_PATH;
 
     foreach ($data['links'] as &$value) {
         $wallabag = sprintf(

--- a/tpl/default/daily.html
+++ b/tpl/default/daily.html
@@ -76,7 +76,7 @@
                   </div>
                   {if="$thumbnails_enabled && !empty($link.thumbnail)"}
                     <div class="daily-entry-thumbnail">
-                      <img data-src="{$link.thumbnail}#" class="b-lazy"
+                      <img data-src="{$root_path}/{$link.thumbnail}#" class="b-lazy"
                            src=""
                            alt="thumbnail" width="{$thumbnails_width}" height="{$thumbnails_height}" />
                     </div>

--- a/tpl/default/includes.html
+++ b/tpl/default/includes.html
@@ -12,10 +12,10 @@
   <link type="text/css" rel="stylesheet" href="{$asset_path}/css/markdown.min.css?v={$version_hash}#" />
 {/if}
 {loop="$plugins_includes.css_files"}
-  <link type="text/css" rel="stylesheet" href="{$base_path}/{$value}?v={$version_hash}#"/>
+  <link type="text/css" rel="stylesheet" href="{$root_path}/{$value}?v={$version_hash}#"/>
 {/loop}
 {if="is_file('data/user.css')"}
-  <link type="text/css" rel="stylesheet" href="{$base_path}/data/user.css#" />
+  <link type="text/css" rel="stylesheet" href="{$root_path}/data/user.css#" />
 {/if}
 <link rel="search" type="application/opensearchdescription+xml" href="{$base_path}/open-search#"
       title="Shaarli search - {$shaarlititle}" />

--- a/tpl/default/linklist.html
+++ b/tpl/default/linklist.html
@@ -140,7 +140,7 @@
                 <div class="thumbnail">
                   {ignore}RainTPL hack: put the 2 src on two different line to avoid path replace bug{/ignore}
                   <a href="{$value.real_url}" aria-hidden="true" tabindex="-1">
-                  <img data-src="{$base_path}/{$value.thumbnail}#" class="b-lazy"
+                  <img data-src="{$root_path}/{$value.thumbnail}#" class="b-lazy"
                     src=""
                     alt="" width="{$thumbnails_width}" height="{$thumbnails_height}" />
                   </a>

--- a/tpl/default/page.footer.html
+++ b/tpl/default/page.footer.html
@@ -10,7 +10,7 @@
     {/if}
     &middot;
     {'The personal, minimalist, super-fast, database free, bookmarking service'|t} {'by the Shaarli community'|t} &middot;
-    <a href="{$base_path}/doc/html/index.html" rel="nofollow">{'Documentation'|t}</a>
+    <a href="{$root_path}/doc/html/index.html" rel="nofollow">{'Documentation'|t}</a>
       {loop="$plugins_footer.text"}
           {$value}
       {/loop}
@@ -25,7 +25,7 @@
 {/loop}
 
 {loop="$plugins_footer.js_files"}
-	<script src="{$base_path}/{$value}#"></script>
+	<script src="{$root_path}/{$value}#"></script>
 {/loop}
 
 <div id="js-translations" class="hidden">

--- a/tpl/default/picwall.html
+++ b/tpl/default/picwall.html
@@ -31,7 +31,7 @@
       {loop="$linksToDisplay"}
         <div class="picwall-pictureframe" role="listitem">
           {ignore}RainTPL hack: put the 2 src on two different line to avoid path replace bug{/ignore}
-          <img data-src="{$value.thumbnail}#" class="b-lazy"
+          <img data-src="{$root_path}/{$value.thumbnail}#" class="b-lazy"
                src=""
                alt="" width="{$thumbnails_width}" height="{$thumbnails_height}" />
           <a href="{$value.real_url}"><span class="info">{$value.title}</span></a>

--- a/tpl/default/pluginsadmin.html
+++ b/tpl/default/pluginsadmin.html
@@ -117,7 +117,7 @@
 
       <div class="center more">
         {"More plugins available"|t}
-        <a href="doc/html/Community-&-Related-software/#third-party-plugins">{"in the documentation"|t}</a>.
+        <a href="{$root_path}/doc/html/Community-&-Related-software/#third-party-plugins">{"in the documentation"|t}</a>.
       </div>
       <div class="center">
         <input type="submit" value="{'Save'|t}" name="save">


### PR DESCRIPTION
   - Shaarli can be fully used by prefixing any URL with /index.php/
   - {$base_path} used in templates already works with this configuration
   - Assets path (outside of theme's assets) must be prefixed with {$root_url}/
   - Documentation section in « Server configuration »

Fixes #1590