### PR TITLE
Removed PHP_EOL in configuration file

### DIFF
--- a/application/config/ConfigJson.php
+++ b/application/config/ConfigJson.php
@@ -73,7 +73,7 @@ class ConfigJson implements ConfigIO
      */
     public static function getPhpHeaders()
     {
-        return '<?php /*'. PHP_EOL;
+        return '<?php /*'. "\n";
     }
 
     /**
@@ -85,6 +85,6 @@ class ConfigJson implements ConfigIO
      */
     public static function getPhpSuffix()
     {
-        return PHP_EOL . '*/ ?>';
+        return "\n" . '*/ ?>';
     }
 }

--- a/application/config/ConfigJson.php
+++ b/application/config/ConfigJson.php
@@ -19,7 +19,7 @@ class ConfigJson implements ConfigIO
         $data = file_get_contents($filepath);
         $data = str_replace(self::getPhpHeaders(), '', $data);
         $data = str_replace(self::getPhpSuffix(), '', $data);
-        $data = json_decode($data, true);
+        $data = json_decode(trim($data), true);
         if ($data === null) {
             $errorCode = json_last_error();
             $error  = sprintf(
@@ -73,7 +73,7 @@ class ConfigJson implements ConfigIO
      */
     public static function getPhpHeaders()
     {
-        return '<?php /*'. "\n";
+        return '<?php /*';
     }
 
     /**
@@ -85,6 +85,6 @@ class ConfigJson implements ConfigIO
      */
     public static function getPhpSuffix()
     {
-        return "\n" . '*/ ?>';
+        return '*/ ?>';
     }
 }


### PR DESCRIPTION
i was getting error 

```
An error occurred while parsing JSON configuration file (data/config.json.php): error code #4
➜ Syntax error
Please check your JSON syntax (without PHP comment tags) using a JSON lint tool such as jsonlint.com.
```
after debug i found 
```php
        $data = str_replace(self::getPhpHeaders(), '', $data);
        $data = str_replace(self::getPhpSuffix(), '', $data);
```
doesn't removing php header and php suffix

cause of this issue was PHP_EOL represents the endline character for the current system. if my  ```config.json.php```  was encoded with unix ( LF ) and php running on windows windows encoding ( CR LF ) is not same as unix encoding ( LF ) so ```str_replace``` doesn't replace strin  then it causes issue.