### PR TITLE
Include php-simplexml in Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -44,6 +44,7 @@ RUN apk --update --no-cache add \
         php7-openssl \
         php7-session \
         php7-xml \
+        php7-simplexml \
         php7-zlib \
         s6
 


### PR DESCRIPTION
Composer 2.0 is now blocking everything if requirements are not met