### PR TITLE
Fix: redirect to referrer after bookmark deletion

### DIFF
--- a/application/front/controller/admin/ShaareManageController.php
+++ b/application/front/controller/admin/ShaareManageController.php
@@ -66,8 +66,8 @@ class ShaareManageController extends ShaarliAdminController
             return $response->write('<script>self.close();</script>');
         }
 
-        // Don't redirect to where we were previously because the datastore has changed.
-        return $this->redirect($response, '/');
+        // Don't redirect to permalink after deletion.
+        return $this->redirectFromReferer($request, $response, ['shaare/']);
     }
 
     /**

--- a/tests/front/controller/admin/ShaareManageControllerTest/DeleteBookmarkTest.php
+++ b/tests/front/controller/admin/ShaareManageControllerTest/DeleteBookmarkTest.php
@@ -38,6 +38,8 @@ class DeleteBookmarkTest extends TestCase
     {
         $parameters = ['id' => '123'];
 
+        $this->container->environment['HTTP_REFERER'] = 'http://shaarli/subfolder/shaare/abcdef';
+
         $request = $this->createMock(Request::class);
         $request
             ->method('getParam')
@@ -89,6 +91,8 @@ class DeleteBookmarkTest extends TestCase
     public function testDeleteMultipleBookmarks(): void
     {
         $parameters = ['id' => '123 456 789'];
+
+        $this->container->environment['HTTP_REFERER'] = 'http://shaarli/subfolder/?searchtags=abcdef';
 
         $request = $this->createMock(Request::class);
         $request
@@ -152,7 +156,7 @@ class DeleteBookmarkTest extends TestCase
         $result = $this->controller->deleteBookmark($request, $response);
 
         static::assertSame(302, $result->getStatusCode());
-        static::assertSame(['/subfolder/'], $result->getHeader('location'));
+        static::assertSame(['/subfolder/?searchtags=abcdef'], $result->getHeader('location'));
     }
 
     /**


### PR DESCRIPTION
Except if the referer points to a permalink (which has been deleted).

Fixes #1622