### PR TITLE
Display error details even with dev.debug set to false

### DIFF
--- a/application/front/controller/visitor/ErrorController.php
+++ b/application/front/controller/visitor/ErrorController.php
@@ -26,8 +26,14 @@ class ErrorController extends ShaarliVisitorController
             $response = $response->withStatus($throwable->getCode());
         } else {
             // Internal error (any other Throwable)
-            if ($this->container->conf->get('dev.debug', false)) {
-                $this->assignView('message', $throwable->getMessage());
+            if ($this->container->conf->get('dev.debug', false) || $this->container->loginManager->isLoggedIn()) {
+                $this->assignView('message', t('Error: ') . $throwable->getMessage());
+                $this->assignView(
+                    'text',
+                    '<a href="https://github.com/shaarli/Shaarli/issues/new">'
+                    . t('Please report it on Github.')
+                    . '</a>'
+                );
                 $this->assignView('stacktrace', exception2text($throwable));
             } else {
                 $this->assignView('message', t('An unexpected error occurred.'));
@@ -35,7 +41,6 @@ class ErrorController extends ShaarliVisitorController
 
             $response = $response->withStatus(500);
         }
-
 
         return $response->write($this->render('error'));
     }

--- a/assets/default/scss/shaarli.scss
+++ b/assets/default/scss/shaarli.scss
@@ -1266,11 +1266,15 @@ form {
     margin: 70px 0 25px;
   }
 
+  a {
+    color: var(--main-color);
+  }
+
   pre {
     margin: 0 20%;
     padding: 20px 0;
     text-align: left;
-    line-height: .7em;
+    line-height: 1em;
   }
 }
 

--- a/inc/languages/fr/LC_MESSAGES/shaarli.po
+++ b/inc/languages/fr/LC_MESSAGES/shaarli.po
@@ -1,8 +1,8 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Shaarli\n"
-"POT-Creation-Date: 2020-11-05 16:47+0100\n"
-"PO-Revision-Date: 2020-11-05 16:48+0100\n"
+"POT-Creation-Date: 2020-11-05 19:43+0100\n"
+"PO-Revision-Date: 2020-11-05 19:44+0100\n"
 "Last-Translator: \n"
 "Language-Team: Shaarli\n"
 "Language: fr_FR\n"
@@ -501,7 +501,15 @@ msgstr "mois"
 msgid "Monthly"
 msgstr "Mensuel"
 
-#: application/front/controller/visitor/ErrorController.php:33
+#: application/front/controller/visitor/ErrorController.php:30
+msgid "Error: "
+msgstr "Erreur : "
+
+#: application/front/controller/visitor/ErrorController.php:34
+msgid "Please report it on Github."
+msgstr "Merci de la rapporter sur Github."
+
+#: application/front/controller/visitor/ErrorController.php:39
 msgid "An unexpected error occurred."
 msgstr "Une erreur inattendue s'est produite."
 

--- a/tpl/default/error.html
+++ b/tpl/default/error.html
@@ -9,13 +9,17 @@
 <div id="pageError" class="page-error-container center">
   <h2>{$message}</h2>
 
+  <img src="{$asset_path}/img/sad_star.png#" alt="">
+
+  {if="!empty($text)"}
+  <p>{$text}</p>
+  {/if}
+
   {if="!empty($stacktrace)"}
       <pre>
         {$stacktrace}
       </pre>
   {/if}
-
-  <img src="{$asset_path}/img/sad_star.png#" alt="">
 </div>
 {include="page.footer"}
 </body>


### PR DESCRIPTION
It makes more sense to display the error even if it's unexpected.
Only for logged in users.

Fixes #1606