### PR TITLE
Reviewed nginx configuration

### DIFF
--- a/.docker/nginx.conf
+++ b/.docker/nginx.conf
@@ -17,27 +17,13 @@ http {
     index index.html index.php;
 
     server {
-        listen       80;
-        root         /var/www/shaarli;
+        listen      80;
+        root        /var/www/shaarli;
 
         access_log  /var/log/nginx/shaarli.access.log;
         error_log   /var/log/nginx/shaarli.error.log;
 
-        location ~ /\. {
-            # deny access to dotfiles
-            access_log off;
-            log_not_found off;
-            deny all;
-        }
-
-        location ~ ~$ {
-            # deny access to temp editor files, e.g. "script.php~"
-            access_log off;
-            log_not_found off;
-            deny all;
-        }
-
-        location ~* \.(?:ico|css|js|gif|jpe?g|png)$ {
+        location ~* \.(?:ico|css|js|gif|jpe?g|png|ttf|oet|woff2?)$ {
             # cache static assets
             expires    max;
             add_header Pragma public;
@@ -49,30 +35,25 @@ http {
             alias /var/www/shaarli/images/favicon.ico;
         }
 
-        location / {
-            # Slim - rewrite URLs
-            try_files $uri /index.php$is_args$args;
+        location /doc/html/ {
+            default_type "text/html";
+            try_files $uri $uri/ $uri.html =404;
         }
 
-        location ~ (index)\.php$ {
+        location / {
+            # Slim - rewrite URLs & do NOT serve static files through this location
+            try_files _ /index.php$is_args$args;
+        }
+
+        location ~ index\.php$ {
             # Slim - split URL path into (script_filename, path_info)
             try_files $uri =404;
-            fastcgi_split_path_info ^(.+\.php)(/.+)$;
+            fastcgi_split_path_info ^(index.php)(/.+)$;
 
             # filter and proxy PHP requests to PHP-FPM
             fastcgi_pass   unix:/var/run/php-fpm.sock;
             fastcgi_index  index.php;
             include        fastcgi.conf;
-        }
-
-        location ~ /doc/ {
-            default_type "text/html";
-            try_files $uri $uri/ $uri.html =404;
-        }
-
-        location ~ \.php$ {
-            # deny access to all other PHP scripts
-            deny all;
         }
     }
 }

--- a/.dockerignore
+++ b/.dockerignore
@@ -2,7 +2,15 @@
 .dev
 .git
 .github
+.gitattributes
+.gitignore
+.travis.yml
 tests
+
+# Docker related resources are not needed inside the container
+.dockerignore
+Dockerfile
+Dockerfile.armhf
 
 # Docker Compose resources
 docker-compose.yml
@@ -12,6 +20,9 @@ cache/*
 data/*
 pagecache/*
 tmp/*
+
+# Shaarli's docs are created during the build
+doc/html/
 
 # Eclipse project files
 .settings

--- a/doc/md/Server-configuration.md
+++ b/doc/md/Server-configuration.md
@@ -296,7 +296,7 @@ server {
     location / {
         # default index file when no file URI is requested
         index index.php;
-        try_files $uri /index.php$is_args$args;
+        try_files _ /index.php$is_args$args;
     }
 
     location ~ (index)\.php$ {
@@ -309,23 +309,7 @@ server {
         include        fastcgi.conf;
     }
 
-    location ~ \.php$ {
-        # deny access to all other PHP scripts
-        # disable this if you host other PHP applications on the same virtualhost
-        deny all;
-    }
-
-    location ~ /\. {
-        # deny access to dotfiles
-        deny all;
-    }
-
-    location ~ ~$ {
-        # deny access to temp editor files, e.g. "script.php~"
-        deny all;
-    }
-
-    location ~ /doc/ {
+    location ~ /doc/html/ {
         default_type "text/html";
         try_files $uri $uri/ $uri.html =404;
     }
@@ -336,13 +320,12 @@ server {
     }
 
     # allow client-side caching of static files
-    location ~* \.(?:ico|css|js|gif|jpe?g|png)$ {
+    location ~* \.(?:ico|css|js|gif|jpe?g|png|ttf|oet|woff2?)$ {
         expires    max;
         add_header Cache-Control "public, must-revalidate, proxy-revalidate";
         # HTTP 1.0 compatibility
         add_header Pragma public;
     }
-
 }
 ```
 


### PR DESCRIPTION
Both in documentation and Docker image.

For security purpose, it no longer allow to access static files through
the main nginx *location*. Static files are served if their extension
matches the whitelist.

As a side effect, we no longer need specific restrictions, and
therefore it fixes the nginx part of #1608.