### PR TITLE
Reviewed Apache configuration

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -13,7 +13,7 @@ RewriteRule .* - [e=HTTP_AUTHORIZATION:%1]
 # Alternative (if the 2 lines above don't work)
 # SetEnvIf Authorization .+ HTTP_AUTHORIZATION=$0
 
-# REST API
+# Slim URL Redirection
 # Ionos Hosting needs RewriteBase /
 # RewriteBase /
 RewriteCond %{REQUEST_FILENAME} !-f

--- a/doc/md/Server-configuration.md
+++ b/doc/md/Server-configuration.md
@@ -193,19 +193,24 @@ sudo nano /etc/apache2/sites-available/shaarli.mydomain.org.conf
         Require all granted
     </Directory>
 
-    <LocationMatch "/\.">
-        # Prevent accessing dotfiles
-        RedirectMatch 404 ".*"
-    </LocationMatch>
+    # BE CAREFUL: directives order matter!
 
-    <LocationMatch "\.(?:ico|css|js|gif|jpe?g|png)$">
+    <FilesMatch ".*\.(?!(ico|css|js|gif|jpe?g|png|ttf|oet|woff2?)$)[^\.]*$">
+        Require all denied
+    </FilesMatch>
+
+    <Files "index.php">
+        Require all granted
+    </Files>
+
+    <FilesMatch "\.(?:ico|css|js|gif|jpe?g|png|ttf|oet|woff2)$">
         # allow client-side caching of static files
         Header set Cache-Control "max-age=2628000, public, must-revalidate, proxy-revalidate"
-    </LocationMatch>
+    </FilesMatch>
+
 
     # serve the Shaarli favicon from its custom location
     Alias favicon.ico /var/www/shaarli.mydomain.org/images/favicon.ico
-
 </VirtualHost>
 ```
 


### PR DESCRIPTION
(in documentation)

For security purpose, block access to any static file not matching the list of allowed extensions.
It allows us to remove the specific restriction on dotfiles, and fix Apache part of #1608.

Tested with AWS build of HTTPD: Apache/2.4.46.

I'm not super confident in my Apache config skills, so if you have some time to test it @nodiscc, @kcaran, or anyone running an Apache instance, it would be greatly appreciated:

  - every assets should load properly, including custom `data/user.css`
  - other static files such as `README.md`, `yarn.lock`, `data/log.txt`, etc. should not be accessible.
  - searching for private tags (starting with a dot) should work properly.