### PR TITLE
Docker-compose: fix SSL certificate + add parameter for Docker tag

### DIFF
--- a/doc/md/Docker.md
+++ b/doc/md/Docker.md
@@ -1,3 +1,4 @@
+
 # Docker
 
 [Docker](https://docs.docker.com/get-started/overview/) is an open platform for developing, shipping, and running applications
@@ -113,9 +114,11 @@ $ mkdir shaarli && cd shaarli
 # Download the latest version of Shaarli's docker-compose.yml
 $ curl -L https://raw.githubusercontent.com/shaarli/Shaarli/latest/docker-compose.yml -o docker-compose.yml
 # Create the .env file and fill in your VPS and domain information
-# (replace <MY_SHAARLI_DOMAIN> and <MY_CONTACT_EMAIL> with your actual information)
+# (replace <shaarli.mydomain.org>, <admin@mydomain.org> and <latest> with your actual information)
 $ echo 'SHAARLI_VIRTUAL_HOST=shaarli.mydomain.org' > .env
 $ echo 'SHAARLI_LETSENCRYPT_EMAIL=admin@mydomain.org' >> .env
+# Available Docker tags can be found at https://hub.docker.com/r/shaarli/shaarli/tags
+$ echo 'SHAARLI_DOCKER_TAG=latest' >> .env
 # Pull the Docker images
 $ docker-compose pull
 # Run!

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,12 +2,13 @@
 # Shaarli - Docker Compose example configuration
 #
 # See:
-# - https://shaarli.readthedocs.io/en/master/docker/shaarli-images/
-# - https://shaarli.readthedocs.io/en/master/guides/install-shaarli-with-debian9-and-docker/
+# - https://shaarli.readthedocs.io/en/master/Docker/#docker-compose
 #
 # Environment variables:
 # - SHAARLI_VIRTUAL_HOST      Fully Qualified Domain Name for the Shaarli instance
 # - SHAARLI_LETSENCRYPT_EMAIL Contact email for certificate renewal
+# - SHAARLI_DOCKER_TAG        Shaarli docker tag to use
+#                             See: https://hub.docker.com/r/shaarli/shaarli/tags
 version: '3'
 
 networks:
@@ -20,7 +21,7 @@ volumes:
 
 services:
   shaarli:
-    image: shaarli/shaarli:master
+    image: shaarli/shaarli:${SHAARLI_DOCKER_TAG}
     build: ./
     networks:
       - http-proxy
@@ -40,7 +41,7 @@ services:
       - "--entrypoints=Name:https Address::443 TLS"
       - "--retry"
       - "--docker"
-      - "--docker.domain=docker.localhost"
+      - "--docker.domain=${SHAARLI_VIRTUAL_HOST}"
       - "--docker.exposedbydefault=true"
       - "--docker.watch=true"
       - "--acme"


### PR DESCRIPTION
Use envvar SHAARLI_VIRTUAL_HOST for Traefik's docker.domain parameter instead of localhost (I'm not sure if did work at some point).

Add an environment variable to choose which Docker tag to use instead of using master by default.

Fixes #1632

(EDIT: tested on a fresh EC2 instance)