### PR TITLE
Daily RSS - Remove relative description (today, yesterday)

### DIFF
--- a/application/front/controller/visitor/DailyController.php
+++ b/application/front/controller/visitor/DailyController.php
@@ -131,7 +131,7 @@ class DailyController extends ShaarliVisitorController
             $dataPerDay[$day] = [
                 'date' => $endDateTime,
                 'date_rss' => $endDateTime->format(DateTime::RSS),
-                'date_human' => DailyPageHelper::getDescriptionByType($type, $dayDateTime),
+                'date_human' => DailyPageHelper::getDescriptionByType($type, $dayDateTime, false),
                 'absolute_url' => $indexUrl . 'daily?' . $type . '=' . $day,
                 'links' => [],
             ];

--- a/application/helper/DailyPageHelper.php
+++ b/application/helper/DailyPageHelper.php
@@ -154,16 +154,20 @@ class DailyPageHelper
      * Get localized description of the time period depending on given datetime and type.
      * Example: for a month period, it returns `October, 2020`.
      *
-     * @param string             $type      month/week/day
-     * @param \DateTimeImmutable $requested DateTime extracted from request input
-     *                                      (should come from extractRequestedDateTime)
+     * @param string             $type            month/week/day
+     * @param \DateTimeImmutable $requested       DateTime extracted from request input
+     *                                            (should come from extractRequestedDateTime)
+     * @param bool               $includeRelative Include relative date description (today, yesterday, etc.)
      *
      * @return string Localized time period description
      *
      * @throws \Exception Type not supported.
      */
-    public static function getDescriptionByType(string $type, \DateTimeImmutable $requested): string
-    {
+    public static function getDescriptionByType(
+        string $type,
+        \DateTimeImmutable $requested,
+        bool $includeRelative = true
+    ): string {
         switch ($type) {
             case static::MONTH:
                 return $requested->format('F') . ', ' . $requested->format('Y');
@@ -172,9 +176,9 @@ class DailyPageHelper
                 return t('Week') . ' ' . $requested->format('W') . ' (' . format_date($requested, false) . ')';
             case static::DAY:
                 $out = '';
-                if ($requested->format('Ymd') === date('Ymd')) {
+                if ($includeRelative && $requested->format('Ymd') === date('Ymd')) {
                     $out = t('Today') . ' - ';
-                } elseif ($requested->format('Ymd') === date('Ymd', strtotime('-1 days'))) {
+                } elseif ($includeRelative && $requested->format('Ymd') === date('Ymd', strtotime('-1 days'))) {
                     $out = t('Yesterday') . ' - ';
                 }
                 return $out . format_date($requested, false);

--- a/tests/helper/DailyPageHelperTest.php
+++ b/tests/helper/DailyPageHelperTest.php
@@ -121,6 +121,19 @@ class DailyPageHelperTest extends TestCase
         static::assertEquals($expectedDescription, $description);
     }
 
+    /**
+     * @dataProvider getDescriptionsByTypeNotIncludeRelative
+     */
+    public function testGeDescriptionsByTypeNotIncludeRelative(
+        string $type,
+        \DateTimeImmutable $dateTime,
+        string $expectedDescription
+    ): void {
+        $description = DailyPageHelper::getDescriptionByType($type, $dateTime, false);
+
+        static::assertEquals($expectedDescription, $description);
+    }
+
     public function getDescriptionByTypeExceptionUnknownType(): void
     {
         $this->expectException(\Exception::class);
@@ -242,6 +255,20 @@ class DailyPageHelperTest extends TestCase
         return [
             [DailyPageHelper::DAY, $date = new \DateTimeImmutable(), 'Today - ' . $date->format('F j, Y')],
             [DailyPageHelper::DAY, $date = new \DateTimeImmutable('-1 day'), 'Yesterday - ' . $date->format('F j, Y')],
+            [DailyPageHelper::DAY, new \DateTimeImmutable('2020-10-09 04:05:06'), 'October 9, 2020'],
+            [DailyPageHelper::WEEK, new \DateTimeImmutable('2020-10-09 04:05:06'), 'Week 41 (October 5, 2020)'],
+            [DailyPageHelper::MONTH, new \DateTimeImmutable('2020-10-09 04:05:06'), 'October, 2020'],
+        ];
+    }
+
+    /**
+     * Data provider for testGeDescriptionsByTypeNotIncludeRelative() test method.
+     */
+    public function getDescriptionsByTypeNotIncludeRelative(): array
+    {
+        return [
+            [DailyPageHelper::DAY, $date = new \DateTimeImmutable(), $date->format('F j, Y')],
+            [DailyPageHelper::DAY, $date = new \DateTimeImmutable('-1 day'), $date->format('F j, Y')],
             [DailyPageHelper::DAY, new \DateTimeImmutable('2020-10-09 04:05:06'), 'October 9, 2020'],
             [DailyPageHelper::WEEK, new \DateTimeImmutable('2020-10-09 04:05:06'), 'Week 41 (October 5, 2020)'],
             [DailyPageHelper::MONTH, new \DateTimeImmutable('2020-10-09 04:05:06'), 'October, 2020'],


### PR DESCRIPTION
It is not useful for the RSS feed, as every new entry will be marked as 'yesterday', and requires an update the next day.