### PR TITLE
WIP: use github actions for continuous integration

### DIFF
--- a/.github/wokflows/ci.yml
+++ b/.github/wokflows/ci.yml
@@ -1,0 +1,13 @@
+name: CI
+
+on: push
+
+jobs:
+  build-test:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - uses: php-actions/composer@v1 # or alternative dependency management
+    - uses: php-actions/phpunit@v1
+


### PR DESCRIPTION
- run phpunit tests on ubuntu-latest
- https://github.com/marketplace/actions/phpunit-php-actions
- https://github.com/php-actions/example-phpunit
- https://docs.github.com/en/free-pro-team@latest/actions/reference/workflow-syntax-for-github-actions#jobsjob_idruns-on