### PR TITLE
Upgrade alpine from 3.8 to 3.10 in armhf Dockerfile

### DIFF
--- a/Dockerfile.armhf
+++ b/Dockerfile.armhf
@@ -1,7 +1,7 @@
 # Stage 1:
 # - Copy Shaarli sources
 # - Build documentation
-FROM arm32v6/alpine:3.8 as docs
+FROM arm32v6/alpine:3.10 as docs
 ADD . /usr/src/app/shaarli
 RUN apk --update --no-cache add py2-pip \
     && cd /usr/src/app/shaarli \
@@ -10,7 +10,7 @@ RUN apk --update --no-cache add py2-pip \
 
 # Stage 2:
 # - Resolve PHP dependencies with Composer
-FROM arm32v6/alpine:3.8 as composer
+FROM arm32v6/alpine:3.10 as composer
 COPY --from=docs /usr/src/app/shaarli /app/shaarli
 RUN apk --update --no-cache add php7-curl php7-mbstring php7-simplexml composer \
     && cd /app/shaarli \
@@ -18,7 +18,7 @@ RUN apk --update --no-cache add php7-curl php7-mbstring php7-simplexml composer 
 
 # Stage 3:
 # - Frontend dependencies
-FROM arm32v6/alpine:3.8 as node
+FROM arm32v6/alpine:3.10 as node
 COPY --from=composer /app/shaarli /shaarli
 RUN apk --update --no-cache add yarn nodejs-current python2 build-base \
     && cd /shaarli \
@@ -28,7 +28,7 @@ RUN apk --update --no-cache add yarn nodejs-current python2 build-base \
 
 # Stage 4:
 # - Shaarli image
-FROM arm32v6/alpine:3.8
+FROM arm32v6/alpine:3.10
 LABEL maintainer="Shaarli Community"
 
 RUN apk --update --no-cache add \


### PR DESCRIPTION
The Docker for armhf doesn't build anymore on Alpine 3.8, upgrading to 3.10.
Building works fine on a Rapsberry Pi 4 running Raspbian GNU/Linux 10 (buster)



This is the error with 3.8:
```
[2/4] Fetching packages...
error css-loader@4.3.0: The engine "node" is incompatible with this module. Expected version ">= 10.13.0".
error Found incompatible module
info Visit https://yarnpkg.com/en/docs/cli/install for documentation about this command.
The command '/bin/sh -c apk --update --no-cache add yarn nodejs-current python2 build-base     && cd /shaarli     && yarn install     && yarn run build     && rm -rf node_modules' returned a non-zero code: 1
```


Not upgrading to 3.11, due to this error:
```
2/4] Fetching packages...
error browserslist@4.14.3: The engine "node" is incompatible with this module. Expected version "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7". Got "13.1.0"
error Found incompatible module.
info Visit https://yarnpkg.com/en/docs/cli/install for documentation about this command.

The command '/bin/sh -c apk --update --no-cache add yarn nodejs-current python2 build-base     && cd /shaarli     && yarn install     && yarn run build     && rm -rf node_modules' returned a non-zero code: 1
```


Not upgrading to 3.12 either, due to this error:
```
ERROR: unsatisfiable constraints:
  py2-pip (missing):
    required by: world[py2-pip]
The command '/bin/sh -c apk --update --no-cache add py2-pip     && cd /usr/src/app/shaarli     && pip install --no-cache-dir mkdocs     && mkdocs build --clean' returned a non-zero code: 1
```
There's probably a way to have Python2 pip installed on 3.12, but I suppose other issues would arise (such as the one happening with 3.11), so only proposing to upgrade to 3.10 now. This would probably be looked at more in detail when merging the amd64 and arm/v7 Docker builds, see #1496.