### PR TITLE
Fix: synchronous metadata retrieval is failing in strict mode

### DIFF
--- a/application/front/controller/admin/ShaarePublishController.php
+++ b/application/front/controller/admin/ShaarePublishController.php
@@ -227,7 +227,7 @@ class ShaarePublishController extends ShaarliAdminController
 
     protected function buildFormData(array $link, bool $isNew, Request $request): array
     {
-        $link['tags'] = strlen($link['tags']) > 0
+        $link['tags'] = $link['tags'] !== null && strlen($link['tags']) > 0
             ? $link['tags'] . $this->container->conf->get('general.tags_separator', ' ')
             : $link['tags']
         ;

--- a/application/http/MetadataRetriever.php
+++ b/application/http/MetadataRetriever.php
@@ -60,10 +60,15 @@ class MetadataRetriever
             $title = mb_convert_encoding($title, 'utf-8', $charset);
         }
 
-        return [
+        return array_map([$this, 'cleanMetadata'], [
             'title' => $title,
             'description' => $description,
             'tags' => $tags,
-        ];
+        ]);
+    }
+
+    protected function cleanMetadata($data): ?string
+    {
+        return !is_string($data) || empty(trim($data)) ? null : trim($data);
     }
 }

--- a/tests/http/MetadataRetrieverTest.php
+++ b/tests/http/MetadataRetrieverTest.php
@@ -41,7 +41,7 @@ class MetadataRetrieverTest extends TestCase
         $remoteCharset = 'utf-8';
 
         $expectedResult = [
-            'title' => $remoteTitle,
+            'title' => trim($remoteTitle),
             'description' => $remoteDesc,
             'tags' => $remoteTags,
         ];


### PR DESCRIPTION
Metadata can now only be string or null.

Fixes #1653