### PR TITLE
Inject current template name in templates

### DIFF
--- a/application/front/controller/visitor/ShaarliVisitorController.php
+++ b/application/front/controller/visitor/ShaarliVisitorController.php
@@ -56,6 +56,10 @@ abstract class ShaarliVisitorController
 
     protected function render(string $template): string
     {
+        // Legacy key that used to be injected by PluginManager
+        $this->assignView('_PAGE_', $template);
+        $this->assignView('template', $template);
+
         $this->assignView('linkcount', $this->container->bookmarkService->count(BookmarkFilter::$ALL));
         $this->assignView('privateLinkcount', $this->container->bookmarkService->count(BookmarkFilter::$PRIVATE));
 

--- a/tests/front/controller/visitor/ShaarliVisitorControllerTest.php
+++ b/tests/front/controller/visitor/ShaarliVisitorControllerTest.php
@@ -93,6 +93,9 @@ class ShaarliVisitorControllerTest extends TestCase
 
         static::assertSame('templateName', $render);
 
+        static::assertSame('templateName', $this->assignedValues['_PAGE_']);
+        static::assertSame('templateName', $this->assignedValues['template']);
+
         static::assertSame(10, $this->assignedValues['linkcount']);
         static::assertSame(5, $this->assignedValues['privateLinkcount']);
         static::assertSame(['error'], $this->assignedValues['plugin_errors']);


### PR DESCRIPTION
Use either legacy key `_PAGE_` or new `template` one.

Related to https://github.com/kalvn/Shaarli-Material/issues/118