### PR TITLE
Fix: bulk add - private status

### DIFF
--- a/assets/common/js/shaare-batch.js
+++ b/assets/common/js/shaare-batch.js
@@ -4,7 +4,11 @@ const sendBookmarkForm = (basePath, formElement) => {
 
   const formData = new FormData();
   [...inputs].forEach((input) => {
-    formData.append(input.getAttribute('name'), input.value);
+    if (input.getAttribute('type') === 'checkbox') {
+      formData.append(input.getAttribute('name'), input.checked);
+    } else {
+      formData.append(input.getAttribute('name'), input.value);
+    }
   });
 
   return new Promise((resolve, reject) => {


### PR DESCRIPTION
Use 'checked' attribute instead of 'value' for checkboxes. 'value' always returns 'on'.

Fixes #1684