### PR TITLE
Fix: bulk add - delete existing link

### DIFF
--- a/application/front/controller/admin/ShaareManageController.php
+++ b/application/front/controller/admin/ShaareManageController.php
@@ -66,6 +66,10 @@ class ShaareManageController extends ShaarliAdminController
             return $response->write('<script>self.close();</script>');
         }
 
+        if ($request->getParam('source') === 'batch') {
+            return $response->withStatus(204);
+        }
+
         // Don't redirect to permalink after deletion.
         return $this->redirectFromReferer($request, $response, ['shaare/']);
     }

--- a/assets/common/js/shaare-batch.js
+++ b/assets/common/js/shaare-batch.js
@@ -26,9 +26,9 @@ const sendBookmarkForm = (basePath, formElement) => {
 const sendBookmarkDelete = (buttonElement, formElement) => (
   new Promise((resolve, reject) => {
     const xhr = new XMLHttpRequest();
-    xhr.open('GET', buttonElement.href);
+    xhr.open('GET', `${buttonElement.href}&source=batch`);
     xhr.onload = () => {
-      if (xhr.status !== 200) {
+      if (xhr.status !== 204) {
         alert(`An error occurred. Return code: ${xhr.status}`);
         reject();
       } else {


### PR DESCRIPTION
Do not send redirect response in bookmark delete controller if the request comes from bulk creation page.

Fixes #1683