### PR TITLE
Fix: bulk add redirection with ending slash

### DIFF
--- a/assets/common/js/shaare-batch.js
+++ b/assets/common/js/shaare-batch.js
@@ -100,7 +100,7 @@ const redirectIfEmptyBatch = (basePath, formElements, path) => {
         });
 
         Promise.all(promises).then(() => {
-          window.location.href = basePath || '/';
+          window.location.href = `${basePath}/`;
         });
       });
     });


### PR DESCRIPTION
Otherwise cookie may not be store under the right subfolder, thus generating tokens in the wrong session file.

Fixes #1690