### PR TITLE
New plugin hook: ability to add custom filters to Shaarli search engine

### DIFF
--- a/application/api/ApiMiddleware.php
+++ b/application/api/ApiMiddleware.php
@@ -145,6 +145,7 @@ class ApiMiddleware
     {
         $linkDb = new BookmarkFileService(
             $conf,
+            $this->container->get('pluginManager'),
             $this->container->get('history'),
             new FlockMutex(fopen(SHAARLI_MUTEX_FILE, 'r'), 2),
             true

--- a/application/bookmark/BookmarkFileService.php
+++ b/application/bookmark/BookmarkFileService.php
@@ -15,6 +15,7 @@ use Shaarli\Formatter\BookmarkMarkdownFormatter;
 use Shaarli\History;
 use Shaarli\Legacy\LegacyLinkDB;
 use Shaarli\Legacy\LegacyUpdater;
+use Shaarli\Plugin\PluginManager;
 use Shaarli\Render\PageCacheManager;
 use Shaarli\Updater\UpdaterUtils;
 
@@ -40,6 +41,9 @@ class BookmarkFileService implements BookmarkServiceInterface
     /** @var ConfigManager instance */
     protected $conf;
 
+    /** @var PluginManager */
+    protected $pluginManager;
+
     /** @var History instance */
     protected $history;
 
@@ -57,6 +61,7 @@ class BookmarkFileService implements BookmarkServiceInterface
      */
     public function __construct(
         ConfigManager $conf,
+        PluginManager $pluginManager,
         History $history,
         Mutex $mutex,
         bool $isLoggedIn
@@ -95,7 +100,8 @@ class BookmarkFileService implements BookmarkServiceInterface
             }
         }
 
-        $this->bookmarkFilter = new BookmarkFilter($this->bookmarks, $this->conf);
+        $this->pluginManager = $pluginManager;
+        $this->bookmarkFilter = new BookmarkFilter($this->bookmarks, $this->conf, $this->pluginManager);
     }
 
     /**

--- a/application/container/ContainerBuilder.php
+++ b/application/container/ContainerBuilder.php
@@ -95,6 +95,7 @@ class ContainerBuilder
         $container['bookmarkService'] = function (ShaarliContainer $container): BookmarkServiceInterface {
             return new BookmarkFileService(
                 $container->conf,
+                $container->pluginManager,
                 $container->history,
                 new FlockMutex(fopen(SHAARLI_MUTEX_FILE, 'r'), 2),
                 $container->loginManager->isLoggedIn()

--- a/doc/md/dev/Plugin-system.md
+++ b/doc/md/dev/Plugin-system.md
@@ -27,7 +27,6 @@ You should have the following tree view:
 |   |---| demo_plugin.php
 ```
 
-
 ### Plugin initialization
 
 At the beginning of Shaarli execution, all enabled plugins are loaded. At this point, the plugin system looks for an `init()` function in the <plugin_name>.php to execute and run it if it exists. This function must be named this way, and takes the `ConfigManager` as parameter.
@@ -209,6 +208,7 @@ If it's still not working, please [open an issue](https://github.com/shaarli/Sha
 | [save_link](#save_link) | Allow to alter the link being saved in the datastore. |
 | [delete_link](#delete_link) | Allow to do an action before a link is deleted from the datastore. |
 | [save_plugin_parameters](#save_plugin_parameters) | Allow to manipulate plugin parameters before they're saved. |
+| [filter_search_entry](#filter_search_entry) | Add custom filters to Shaarli search engine |
 
 
 #### render_header
@@ -564,6 +564,23 @@ So if the plugin has a parameter called `MYPLUGIN_PARAMETER`,
 the array will contain an entry with `MYPLUGIN_PARAMETER` as a key.
 
 Also [special data](#special-data).
+
+#### filter_search_entry
+
+Triggered for *every* bookmark when Shaarli's BookmarkService method `search()` is used.
+Any custom filter can be added to filter out bookmarks from search results.
+
+The hook **must** return either:
+  - `true` to keep bookmark entry in search result set
+  - `false` to discard bookmark entry in result set
+
+> Note: custom filters are called *before* default filters are applied.
+
+##### Parameters
+
+- `Shaarli\Bookmark\Bookmark` object: entry to evaluate
+- $context `array`: additional information provided depending on what search is currently used,
+the user request, etc.
 
 ## Guide for template designers
 

--- a/plugins/demo_plugin/demo_plugin.php
+++ b/plugins/demo_plugin/demo_plugin.php
@@ -17,6 +17,7 @@ require_once __DIR__ . '/DemoPluginController.php';
  * and check user status with _LOGGEDIN_.
  */
 
+use Shaarli\Bookmark\Bookmark;
 use Shaarli\Config\ConfigManager;
 use Shaarli\Plugin\PluginManager;
 use Shaarli\Render\TemplatePage;
@@ -263,6 +264,17 @@ function hook_demo_plugin_render_linklist($data)
     }
     $data['action_plugin'][] = $action;
 
+    // Action to trigger custom filter hiding bookmarks not containing 'e' letter in their description
+    $action = [
+        'attr' => [
+            'href' => '?e',
+            'title' => 'Hide bookmarks without "e" in their description.',
+        ],
+        'html' => 'e',
+        'on' => isset($_GET['e'])
+    ];
+    $data['action_plugin'][] = $action;
+
     // link_plugin (for each link)
     foreach ($data['links'] as &$value) {
         $value['link_plugin'][] = ' DEMO \o/';
@@ -484,6 +496,27 @@ function hook_demo_plugin_save_plugin_parameters($data)
     }
 
     return $data;
+}
+
+/**
+ * This hook is called when a search is performed, on every search entry.
+ * It allows to add custom filters, and filter out additional link.
+ *
+ * For exemple here, we hide all bookmarks not containing the letter 'e' in their description.
+ *
+ * @param Bookmark $bookmark Search entry. Note that this is a Bookmark object, and not a link array.
+ *                           It should NOT be altered.
+ * @param array    $context  Additional info on the search performed.
+ *
+ * @return bool True if the bookmark should be kept in the search result, false to discard it.
+ */
+function hook_demo_plugin_filter_search_entry(Bookmark $bookmark, array $context): bool
+{
+    if (isset($_GET['e'])) {
+        return strpos($bookmark->getDescription(), 'e') !== false;
+    }
+
+    return true;
 }
 
 /**

--- a/tests/PluginManagerTest.php
+++ b/tests/PluginManagerTest.php
@@ -2,6 +2,7 @@
 
 namespace Shaarli\Plugin;
 
+use Shaarli\Bookmark\Bookmark;
 use Shaarli\Config\ConfigManager;
 
 /**
@@ -158,5 +159,20 @@ class PluginManagerTest extends \Shaarli\TestCase
 
         $errors = $this->pluginManager->getErrors();
         static::assertSame(['test_route_invalid [plugin incompatibility]: trying to register invalid route.'], $errors);
+    }
+
+    public function testSearchFilterPlugin(): void
+    {
+        PluginManager::$PLUGINS_PATH = self::$pluginPath;
+        $this->pluginManager->load([self::$pluginName]);
+
+        static::assertNull($this->pluginManager->getFilterSearchEntryHooks());
+
+        static::assertTrue($this->pluginManager->filterSearchEntry(new Bookmark(), ['_result' => true]));
+
+        static::assertCount(1, $this->pluginManager->getFilterSearchEntryHooks());
+        static::assertSame('hook_test_filter_search_entry', $this->pluginManager->getFilterSearchEntryHooks()[0]);
+
+        static::assertFalse($this->pluginManager->filterSearchEntry(new Bookmark(), ['_result' => false]));
     }
 }

--- a/tests/api/ApiMiddlewareTest.php
+++ b/tests/api/ApiMiddlewareTest.php
@@ -3,6 +3,7 @@ namespace Shaarli\Api;
 
 use Shaarli\Config\ConfigManager;
 use Shaarli\History;
+use Shaarli\Plugin\PluginManager;
 use Slim\Container;
 use Slim\Http\Environment;
 use Slim\Http\Request;
@@ -56,6 +57,7 @@ class ApiMiddlewareTest extends \Shaarli\TestCase
         $this->container = new Container();
         $this->container['conf'] = $this->conf;
         $this->container['history'] = $history;
+        $this->container['pluginManager'] = new PluginManager($this->conf);
     }
 
     /**

--- a/tests/api/controllers/info/InfoTest.php
+++ b/tests/api/controllers/info/InfoTest.php
@@ -5,6 +5,7 @@ use malkusch\lock\mutex\NoMutex;
 use Shaarli\Bookmark\BookmarkFileService;
 use Shaarli\Config\ConfigManager;
 use Shaarli\History;
+use Shaarli\Plugin\PluginManager;
 use Shaarli\TestCase;
 use Slim\Container;
 use Slim\Http\Environment;
@@ -55,12 +56,18 @@ class InfoTest extends TestCase
         $this->conf->set('resource.datastore', self::$testDatastore);
         $this->refDB = new \ReferenceLinkDB();
         $this->refDB->write(self::$testDatastore);
-
+        $this->pluginManager = new PluginManager($this->conf);
         $history = new History('sandbox/history.php');
 
         $this->container = new Container();
         $this->container['conf'] = $this->conf;
-        $this->container['db'] = new BookmarkFileService($this->conf, $history, $mutex, true);
+        $this->container['db'] = new BookmarkFileService(
+            $this->conf,
+            $this->pluginManager,
+            $history,
+            $mutex,
+            true
+        );
         $this->container['history'] = null;
 
         $this->controller = new Info($this->container);

--- a/tests/api/controllers/links/DeleteLinkTest.php
+++ b/tests/api/controllers/links/DeleteLinkTest.php
@@ -7,6 +7,7 @@ use malkusch\lock\mutex\NoMutex;
 use Shaarli\Bookmark\BookmarkFileService;
 use Shaarli\Config\ConfigManager;
 use Shaarli\History;
+use Shaarli\Plugin\PluginManager;
 use Slim\Container;
 use Slim\Http\Environment;
 use Slim\Http\Request;
@@ -57,6 +58,9 @@ class DeleteLinkTest extends \Shaarli\TestCase
     /** @var NoMutex */
     protected $mutex;
 
+    /** @var PluginManager */
+    protected $pluginManager;
+
     /**
      * Before each test, instantiate a new Api with its config, plugins and bookmarks.
      */
@@ -70,7 +74,14 @@ class DeleteLinkTest extends \Shaarli\TestCase
         $refHistory = new \ReferenceHistory();
         $refHistory->write(self::$testHistory);
         $this->history = new History(self::$testHistory);
-        $this->bookmarkService = new BookmarkFileService($this->conf, $this->history, $this->mutex, true);
+        $this->pluginManager = new PluginManager($this->conf);
+        $this->bookmarkService = new BookmarkFileService(
+            $this->conf,
+            $this->pluginManager,
+            $this->history,
+            $this->mutex,
+            true
+        );
 
         $this->container = new Container();
         $this->container['conf'] = $this->conf;
@@ -105,7 +116,13 @@ class DeleteLinkTest extends \Shaarli\TestCase
         $this->assertEquals(204, $response->getStatusCode());
         $this->assertEmpty((string) $response->getBody());
 
-        $this->bookmarkService = new BookmarkFileService($this->conf, $this->history, $this->mutex, true);
+        $this->bookmarkService = new BookmarkFileService(
+            $this->conf,
+            $this->pluginManager,
+            $this->history,
+            $this->mutex,
+            true
+        );
         $this->assertFalse($this->bookmarkService->exists($id));
 
         $historyEntry = $this->history->getHistory()[0];

--- a/tests/api/controllers/links/GetLinkIdTest.php
+++ b/tests/api/controllers/links/GetLinkIdTest.php
@@ -7,6 +7,7 @@ use Shaarli\Bookmark\Bookmark;
 use Shaarli\Bookmark\BookmarkFileService;
 use Shaarli\Config\ConfigManager;
 use Shaarli\History;
+use Shaarli\Plugin\PluginManager;
 use Slim\Container;
 use Slim\Http\Environment;
 use Slim\Http\Request;
@@ -67,7 +68,14 @@ class GetLinkIdTest extends \Shaarli\TestCase
 
         $this->container = new Container();
         $this->container['conf'] = $this->conf;
-        $this->container['db'] = new BookmarkFileService($this->conf, $history, $mutex, true);
+        $pluginManager = new PluginManager($this->conf);
+        $this->container['db'] = new BookmarkFileService(
+            $this->conf,
+            $pluginManager,
+            $history,
+            $mutex,
+            true
+        );
         $this->container['history'] = null;
 
         $this->controller = new Links($this->container);

--- a/tests/api/controllers/links/GetLinksTest.php
+++ b/tests/api/controllers/links/GetLinksTest.php
@@ -7,6 +7,7 @@ use Shaarli\Bookmark\BookmarkFileService;
 use Shaarli\Bookmark\LinkDB;
 use Shaarli\Config\ConfigManager;
 use Shaarli\History;
+use Shaarli\Plugin\PluginManager;
 use Slim\Container;
 use Slim\Http\Environment;
 use Slim\Http\Request;
@@ -67,7 +68,14 @@ class GetLinksTest extends \Shaarli\TestCase
 
         $this->container = new Container();
         $this->container['conf'] = $this->conf;
-        $this->container['db'] = new BookmarkFileService($this->conf, $history, $mutex, true);
+        $pluginManager = new PluginManager($this->conf);
+        $this->container['db'] = new BookmarkFileService(
+            $this->conf,
+            $pluginManager,
+            $history,
+            $mutex,
+            true
+        );
         $this->container['history'] = null;
 
         $this->controller = new Links($this->container);

--- a/tests/api/controllers/links/PostLinkTest.php
+++ b/tests/api/controllers/links/PostLinkTest.php
@@ -7,6 +7,7 @@ use Shaarli\Bookmark\Bookmark;
 use Shaarli\Bookmark\BookmarkFileService;
 use Shaarli\Config\ConfigManager;
 use Shaarli\History;
+use Shaarli\Plugin\PluginManager;
 use Shaarli\TestCase;
 use Slim\Container;
 use Slim\Http\Environment;
@@ -81,8 +82,14 @@ class PostLinkTest extends TestCase
         $refHistory = new \ReferenceHistory();
         $refHistory->write(self::$testHistory);
         $this->history = new History(self::$testHistory);
-        $this->bookmarkService = new BookmarkFileService($this->conf, $this->history, $mutex, true);
-
+        $pluginManager = new PluginManager($this->conf);
+        $this->bookmarkService = new BookmarkFileService(
+            $this->conf,
+            $pluginManager,
+            $this->history,
+            $mutex,
+            true
+        );
         $this->container = new Container();
         $this->container['conf'] = $this->conf;
         $this->container['db'] = $this->bookmarkService;

--- a/tests/api/controllers/links/PutLinkTest.php
+++ b/tests/api/controllers/links/PutLinkTest.php
@@ -8,6 +8,7 @@ use Shaarli\Bookmark\Bookmark;
 use Shaarli\Bookmark\BookmarkFileService;
 use Shaarli\Config\ConfigManager;
 use Shaarli\History;
+use Shaarli\Plugin\PluginManager;
 use Slim\Container;
 use Slim\Http\Environment;
 use Slim\Http\Request;
@@ -73,8 +74,14 @@ class PutLinkTest extends \Shaarli\TestCase
         $refHistory = new \ReferenceHistory();
         $refHistory->write(self::$testHistory);
         $this->history = new History(self::$testHistory);
-        $this->bookmarkService = new BookmarkFileService($this->conf, $this->history, $mutex, true);
-
+        $pluginManager = new PluginManager($this->conf);
+        $this->bookmarkService = new BookmarkFileService(
+            $this->conf,
+            $pluginManager,
+            $this->history,
+            $mutex,
+            true
+        );
         $this->container = new Container();
         $this->container['conf'] = $this->conf;
         $this->container['db'] = $this->bookmarkService;

--- a/tests/api/controllers/tags/DeleteTagTest.php
+++ b/tests/api/controllers/tags/DeleteTagTest.php
@@ -8,6 +8,7 @@ use Shaarli\Bookmark\BookmarkFileService;
 use Shaarli\Bookmark\LinkDB;
 use Shaarli\Config\ConfigManager;
 use Shaarli\History;
+use Shaarli\Plugin\PluginManager;
 use Slim\Container;
 use Slim\Http\Environment;
 use Slim\Http\Request;
@@ -55,6 +56,9 @@ class DeleteTagTest extends \Shaarli\TestCase
      */
     protected $controller;
 
+    /** @var PluginManager */
+    protected $pluginManager;
+
     /** @var NoMutex */
     protected $mutex;
 
@@ -71,7 +75,14 @@ class DeleteTagTest extends \Shaarli\TestCase
         $refHistory = new \ReferenceHistory();
         $refHistory->write(self::$testHistory);
         $this->history = new History(self::$testHistory);
-        $this->bookmarkService = new BookmarkFileService($this->conf, $this->history, $this->mutex, true);
+        $this->pluginManager = new PluginManager($this->conf);
+        $this->bookmarkService = new BookmarkFileService(
+            $this->conf,
+            $this->pluginManager,
+            $this->history,
+            $this->mutex,
+            true
+        );
 
         $this->container = new Container();
         $this->container['conf'] = $this->conf;
@@ -107,7 +118,13 @@ class DeleteTagTest extends \Shaarli\TestCase
         $this->assertEquals(204, $response->getStatusCode());
         $this->assertEmpty((string) $response->getBody());
 
-        $this->bookmarkService = new BookmarkFileService($this->conf, $this->history, $this->mutex, true);
+        $this->bookmarkService = new BookmarkFileService(
+            $this->conf,
+            $this->pluginManager,
+            $this->history,
+            $this->mutex,
+            true
+        );
         $tags = $this->bookmarkService->bookmarksCountPerTag();
         $this->assertFalse(isset($tags[$tagName]));
 
@@ -141,7 +158,13 @@ class DeleteTagTest extends \Shaarli\TestCase
         $this->assertEquals(204, $response->getStatusCode());
         $this->assertEmpty((string) $response->getBody());
 
-        $this->bookmarkService = new BookmarkFileService($this->conf, $this->history, $this->mutex, true);
+        $this->bookmarkService = new BookmarkFileService(
+            $this->conf,
+            $this->pluginManager,
+            $this->history,
+            $this->mutex,
+            true
+        );
         $tags = $this->bookmarkService->bookmarksCountPerTag();
         $this->assertFalse(isset($tags[$tagName]));
         $this->assertTrue($tags[strtolower($tagName)] > 0);

--- a/tests/api/controllers/tags/GetTagNameTest.php
+++ b/tests/api/controllers/tags/GetTagNameTest.php
@@ -7,6 +7,7 @@ use Shaarli\Bookmark\BookmarkFileService;
 use Shaarli\Bookmark\LinkDB;
 use Shaarli\Config\ConfigManager;
 use Shaarli\History;
+use Shaarli\Plugin\PluginManager;
 use Slim\Container;
 use Slim\Http\Environment;
 use Slim\Http\Request;
@@ -46,6 +47,9 @@ class GetTagNameTest extends \Shaarli\TestCase
      */
     protected $controller;
 
+    /** @var PluginManager */
+    protected $pluginManager;
+
     /**
      * Number of JSON fields per link.
      */
@@ -65,7 +69,14 @@ class GetTagNameTest extends \Shaarli\TestCase
 
         $this->container = new Container();
         $this->container['conf'] = $this->conf;
-        $this->container['db'] = new BookmarkFileService($this->conf, $history, $mutex, true);
+        $this->pluginManager = new PluginManager($this->conf);
+        $this->container['db'] = new BookmarkFileService(
+            $this->conf,
+            $this->pluginManager,
+            $history,
+            $mutex,
+            true
+        );
         $this->container['history'] = null;
 
         $this->controller = new Tags($this->container);

--- a/tests/api/controllers/tags/GetTagsTest.php
+++ b/tests/api/controllers/tags/GetTagsTest.php
@@ -6,6 +6,7 @@ use Shaarli\Bookmark\BookmarkFileService;
 use Shaarli\Bookmark\LinkDB;
 use Shaarli\Config\ConfigManager;
 use Shaarli\History;
+use Shaarli\Plugin\PluginManager;
 use Slim\Container;
 use Slim\Http\Environment;
 use Slim\Http\Request;
@@ -50,6 +51,9 @@ class GetTagsTest extends \Shaarli\TestCase
      */
     protected $controller;
 
+    /** @var PluginManager */
+    protected $pluginManager;
+
     /**
      * Number of JSON field per link.
      */
@@ -66,9 +70,14 @@ class GetTagsTest extends \Shaarli\TestCase
         $this->refDB = new \ReferenceLinkDB();
         $this->refDB->write(self::$testDatastore);
         $history = new History('sandbox/history.php');
-
-        $this->bookmarkService = new BookmarkFileService($this->conf, $history, $mutex, true);
-
+        $this->pluginManager = new PluginManager($this->conf);
+        $this->bookmarkService = new BookmarkFileService(
+            $this->conf,
+            $this->pluginManager,
+            $history,
+            $mutex,
+            true
+        );
         $this->container = new Container();
         $this->container['conf'] = $this->conf;
         $this->container['db'] = $this->bookmarkService;

--- a/tests/api/controllers/tags/PutTagTest.php
+++ b/tests/api/controllers/tags/PutTagTest.php
@@ -8,6 +8,7 @@ use Shaarli\Bookmark\BookmarkFileService;
 use Shaarli\Bookmark\LinkDB;
 use Shaarli\Config\ConfigManager;
 use Shaarli\History;
+use Shaarli\Plugin\PluginManager;
 use Slim\Container;
 use Slim\Http\Environment;
 use Slim\Http\Request;
@@ -55,6 +56,9 @@ class PutTagTest extends \Shaarli\TestCase
      */
     protected $controller;
 
+    /** @var PluginManager */
+    protected $pluginManager;
+
     /**
      * Number of JSON field per link.
      */
@@ -73,7 +77,14 @@ class PutTagTest extends \Shaarli\TestCase
         $refHistory = new \ReferenceHistory();
         $refHistory->write(self::$testHistory);
         $this->history = new History(self::$testHistory);
-        $this->bookmarkService = new BookmarkFileService($this->conf, $this->history, $mutex, true);
+        $this->pluginManager = new PluginManager($this->conf);
+        $this->bookmarkService = new BookmarkFileService(
+            $this->conf,
+            $this->pluginManager,
+            $this->history,
+            $mutex,
+            true
+        );
 
         $this->container = new Container();
         $this->container['conf'] = $this->conf;

--- a/tests/bookmark/BookmarkFileServiceTest.php
+++ b/tests/bookmark/BookmarkFileServiceTest.php
@@ -14,6 +14,7 @@ use Shaarli\Bookmark\Exception\BookmarkNotFoundException;
 use Shaarli\Config\ConfigManager;
 use Shaarli\Formatter\BookmarkMarkdownFormatter;
 use Shaarli\History;
+use Shaarli\Plugin\PluginManager;
 use Shaarli\TestCase;
 
 /**
@@ -56,6 +57,9 @@ class BookmarkFileServiceTest extends TestCase
     /** @var NoMutex */
     protected $mutex;
 
+    /** @var PluginManager */
+    protected $pluginManager;
+
     /**
      * Instantiates public and private LinkDBs with test data
      *
@@ -93,8 +97,21 @@ class BookmarkFileServiceTest extends TestCase
         $this->refDB = new \ReferenceLinkDB();
         $this->refDB->write(self::$testDatastore);
         $this->history = new History('sandbox/history.php');
-        $this->publicLinkDB = new BookmarkFileService($this->conf, $this->history, $this->mutex, false);
-        $this->privateLinkDB = new BookmarkFileService($this->conf, $this->history, $this->mutex, true);
+        $this->pluginManager = new PluginManager($this->conf);
+        $this->publicLinkDB = new BookmarkFileService(
+            $this->conf,
+            $this->pluginManager,
+            $this->history,
+            $this->mutex,
+            false
+        );
+        $this->privateLinkDB = new BookmarkFileService(
+            $this->conf,
+            $this->pluginManager,
+            $this->history,
+            $this->mutex,
+            true
+        );
     }
 
     /**
@@ -111,7 +128,13 @@ class BookmarkFileServiceTest extends TestCase
         $db = self::getMethod('migrate');
         $db->invokeArgs($this->privateLinkDB, []);
 
-        $db = new \FakeBookmarkService($this->conf, $this->history, $this->mutex, true);
+        $db = new \FakeBookmarkService(
+            $this->conf,
+            $this->pluginManager,
+            $this->history,
+            $this->mutex,
+            true
+        );
         $this->assertInstanceOf(BookmarkArray::class, $db->getBookmarks());
         $this->assertEquals($this->refDB->countLinks(), $db->count());
     }
@@ -180,7 +203,13 @@ class BookmarkFileServiceTest extends TestCase
         $this->assertEquals($updated, $bookmark->getUpdated());
 
         // reload from file
-        $this->privateLinkDB = new BookmarkFileService($this->conf, $this->history, $this->mutex, true);
+        $this->privateLinkDB = new \FakeBookmarkService(
+            $this->conf,
+            $this->pluginManager,
+            $this->history,
+            $this->mutex,
+            true
+        );
 
         $bookmark = $this->privateLinkDB->get(43);
         $this->assertEquals(43, $bookmark->getId());
@@ -218,7 +247,13 @@ class BookmarkFileServiceTest extends TestCase
         $this->assertNull($bookmark->getUpdated());
 
         // reload from file
-        $this->privateLinkDB = new BookmarkFileService($this->conf, $this->history, $this->mutex, true);
+        $this->privateLinkDB = new BookmarkFileService(
+            $this->conf,
+            $this->pluginManager,
+            $this->history,
+            $this->mutex,
+            true
+        );
 
         $bookmark = $this->privateLinkDB->get(43);
         $this->assertEquals(43, $bookmark->getId());
@@ -248,7 +283,13 @@ class BookmarkFileServiceTest extends TestCase
         $this->assertEquals(43, $bookmark->getId());
 
         // reload from file
-        $this->privateLinkDB = new BookmarkFileService($this->conf, $this->history, $this->mutex, true);
+        $this->privateLinkDB = new BookmarkFileService(
+            $this->conf,
+            $this->pluginManager,
+            $this->history,
+            $this->mutex,
+            true
+        );
 
         $this->privateLinkDB->get(43);
     }
@@ -309,7 +350,13 @@ class BookmarkFileServiceTest extends TestCase
         $this->assertTrue(new \DateTime('5 seconds ago') < $bookmark->getUpdated());
 
         // reload from file
-        $this->privateLinkDB = new BookmarkFileService($this->conf, $this->history, $this->mutex, true);
+        $this->privateLinkDB = new BookmarkFileService(
+            $this->conf,
+            $this->pluginManager,
+            $this->history,
+            $this->mutex,
+            true
+        );
 
         $bookmark = $this->privateLinkDB->get(42);
         $this->assertEquals(42, $bookmark->getId());
@@ -350,7 +397,13 @@ class BookmarkFileServiceTest extends TestCase
         $this->assertTrue(new \DateTime('5 seconds ago') < $bookmark->getUpdated());
 
         // reload from file
-        $this->privateLinkDB = new BookmarkFileService($this->conf, $this->history, $this->mutex, true);
+        $this->privateLinkDB = new BookmarkFileService(
+            $this->conf,
+            $this->pluginManager,
+            $this->history,
+            $this->mutex,
+            true
+        );
 
         $bookmark = $this->privateLinkDB->get(42);
         $this->assertEquals(42, $bookmark->getId());
@@ -383,7 +436,13 @@ class BookmarkFileServiceTest extends TestCase
         $this->assertEquals($title, $bookmark->getTitle());
 
         // reload from file
-        $this->privateLinkDB = new BookmarkFileService($this->conf, $this->history, $this->mutex, true);
+        $this->privateLinkDB = new BookmarkFileService(
+            $this->conf,
+            $this->pluginManager,
+            $this->history,
+            $this->mutex,
+            true
+        );
 
         $bookmark = $this->privateLinkDB->get(42);
         $this->assertEquals(42, $bookmark->getId());
@@ -436,7 +495,13 @@ class BookmarkFileServiceTest extends TestCase
         $this->assertEquals(43, $bookmark->getId());
 
         // reload from file
-        $this->privateLinkDB = new BookmarkFileService($this->conf, $this->history, $this->mutex, true);
+        $this->privateLinkDB = new BookmarkFileService(
+            $this->conf,
+            $this->pluginManager,
+            $this->history,
+            $this->mutex,
+            true
+        );
 
         $bookmark = $this->privateLinkDB->get(43);
         $this->assertEquals(43, $bookmark->getId());
@@ -456,7 +521,13 @@ class BookmarkFileServiceTest extends TestCase
         $this->assertEquals($title, $bookmark->getTitle());
 
         // reload from file
-        $this->privateLinkDB = new BookmarkFileService($this->conf, $this->history, $this->mutex, true);
+        $this->privateLinkDB = new BookmarkFileService(
+            $this->conf,
+            $this->pluginManager,
+            $this->history,
+            $this->mutex,
+            true
+        );
 
         $bookmark = $this->privateLinkDB->get(42);
         $this->assertEquals(42, $bookmark->getId());
@@ -488,7 +559,13 @@ class BookmarkFileServiceTest extends TestCase
         $this->assertEquals($title, $bookmark->getTitle());
 
         // reload from file
-        $this->privateLinkDB = new BookmarkFileService($this->conf, $this->history, $this->mutex, true);
+        $this->privateLinkDB = new BookmarkFileService(
+            $this->conf,
+            $this->pluginManager,
+            $this->history,
+            $this->mutex,
+            true
+        );
 
         $bookmark = $this->privateLinkDB->get(42);
         $this->assertEquals(42, $bookmark->getId());
@@ -514,7 +591,13 @@ class BookmarkFileServiceTest extends TestCase
         $this->assertInstanceOf(BookmarkNotFoundException::class, $exception);
 
         // reload from file
-        $this->privateLinkDB = new BookmarkFileService($this->conf, $this->history, $this->mutex, true);
+        $this->privateLinkDB = new BookmarkFileService(
+            $this->conf,
+            $this->pluginManager,
+            $this->history,
+            $this->mutex,
+            true
+        );
 
         $this->privateLinkDB->get(42);
     }
@@ -607,7 +690,7 @@ class BookmarkFileServiceTest extends TestCase
 
         $conf = new ConfigManager('tests/utils/config/configJson');
         $conf->set('resource.datastore', 'null/store.db');
-        new BookmarkFileService($conf, $this->history, $this->mutex, true);
+        new BookmarkFileService($conf, $this->pluginManager, $this->history, $this->mutex, true);
     }
 
     /**
@@ -617,7 +700,7 @@ class BookmarkFileServiceTest extends TestCase
     {
         unlink(self::$testDatastore);
         $this->assertFileNotExists(self::$testDatastore);
-        new BookmarkFileService($this->conf, $this->history, $this->mutex, true);
+        new BookmarkFileService($this->conf, $this->pluginManager, $this->history, $this->mutex, true);
         $this->assertFileExists(self::$testDatastore);
 
         // ensure the correct data has been written
@@ -631,7 +714,7 @@ class BookmarkFileServiceTest extends TestCase
     {
         unlink(self::$testDatastore);
         $this->assertFileNotExists(self::$testDatastore);
-        $db = new \FakeBookmarkService($this->conf, $this->history, $this->mutex, false);
+        $db = new \FakeBookmarkService($this->conf, $this->pluginManager, $this->history, $this->mutex, false);
         $this->assertFileNotExists(self::$testDatastore);
         $this->assertInstanceOf(BookmarkArray::class, $db->getBookmarks());
         $this->assertCount(0, $db->getBookmarks());
@@ -664,13 +747,13 @@ class BookmarkFileServiceTest extends TestCase
      */
     public function testSave()
     {
-        $testDB = new BookmarkFileService($this->conf, $this->history, $this->mutex, true);
+        $testDB = new BookmarkFileService($this->conf, $this->pluginManager, $this->history, $this->mutex, true);
         $dbSize = $testDB->count();
 
         $bookmark = new Bookmark();
         $testDB->add($bookmark);
 
-        $testDB = new BookmarkFileService($this->conf, $this->history, $this->mutex, true);
+        $testDB = new BookmarkFileService($this->conf, $this->pluginManager, $this->history, $this->mutex, true);
         $this->assertEquals($dbSize + 1, $testDB->count());
     }
 
@@ -680,7 +763,7 @@ class BookmarkFileServiceTest extends TestCase
     public function testCountHiddenPublic()
     {
         $this->conf->set('privacy.hide_public_links', true);
-        $linkDB = new BookmarkFileService($this->conf, $this->history, $this->mutex, false);
+        $linkDB = new BookmarkFileService($this->conf, $this->pluginManager, $this->history, $this->mutex, false);
 
         $this->assertEquals(0, $linkDB->count());
     }
@@ -906,7 +989,13 @@ class BookmarkFileServiceTest extends TestCase
         $bookmark->addAdditionalContentEntry('private_key', $privateKey);
         $this->privateLinkDB->save();
 
-        $this->privateLinkDB = new BookmarkFileService($this->conf, $this->history, $this->mutex, false);
+        $this->privateLinkDB = new BookmarkFileService(
+            $this->conf,
+            $this->pluginManager,
+            $this->history,
+            $this->mutex,
+            false
+        );
         $bookmark = $this->privateLinkDB->findByHash($hash, $privateKey);
 
         static::assertSame(6, $bookmark->getId());
@@ -1152,7 +1241,13 @@ class BookmarkFileServiceTest extends TestCase
     public function testGetLatestEmptyDatastore(): void
     {
         unlink($this->conf->get('resource.datastore'));
-        $this->publicLinkDB = new BookmarkFileService($this->conf, $this->history, $this->mutex, false);
+        $this->publicLinkDB = new BookmarkFileService(
+            $this->conf,
+            $this->pluginManager,
+            $this->history,
+            $this->mutex,
+            false
+        );
 
         $bookmark = $this->publicLinkDB->getLatest();
 

--- a/tests/bookmark/BookmarkInitializerTest.php
+++ b/tests/bookmark/BookmarkInitializerTest.php
@@ -5,6 +5,7 @@ namespace Shaarli\Bookmark;
 use malkusch\lock\mutex\NoMutex;
 use Shaarli\Config\ConfigManager;
 use Shaarli\History;
+use Shaarli\Plugin\PluginManager;
 use Shaarli\TestCase;
 
 /**
@@ -38,6 +39,9 @@ class BookmarkInitializerTest extends TestCase
     /** @var NoMutex */
     protected $mutex;
 
+    /** @var PluginManager */
+    protected $pluginManager;
+
     /**
      * Initialize an empty BookmarkFileService
      */
@@ -51,8 +55,15 @@ class BookmarkInitializerTest extends TestCase
         copy('tests/utils/config/configJson.json.php', self::$testConf .'.json.php');
         $this->conf = new ConfigManager(self::$testConf);
         $this->conf->set('resource.datastore', self::$testDatastore);
+        $this->pluginManager = new PluginManager($this->conf);
         $this->history = new History('sandbox/history.php');
-        $this->bookmarkService = new BookmarkFileService($this->conf, $this->history, $this->mutex, true);
+        $this->bookmarkService = new BookmarkFileService(
+            $this->conf,
+            $this->pluginManager,
+            $this->history,
+            $this->mutex,
+            true
+        );
 
         $this->initializer = new BookmarkInitializer($this->bookmarkService);
     }
@@ -64,7 +75,13 @@ class BookmarkInitializerTest extends TestCase
     {
         $refDB = new \ReferenceLinkDB();
         $refDB->write(self::$testDatastore);
-        $this->bookmarkService = new BookmarkFileService($this->conf, $this->history, $this->mutex, true);
+        $this->bookmarkService = new BookmarkFileService(
+            $this->conf,
+            $this->pluginManager,
+            $this->history,
+            $this->mutex,
+            true
+        );
         $this->initializer = new BookmarkInitializer($this->bookmarkService);
 
         $this->initializer->initialize();
@@ -95,7 +112,13 @@ class BookmarkInitializerTest extends TestCase
         $this->bookmarkService->save();
 
         // Reload from file
-        $this->bookmarkService = new BookmarkFileService($this->conf, $this->history, $this->mutex, true);
+        $this->bookmarkService = new BookmarkFileService(
+            $this->conf,
+            $this->pluginManager,
+            $this->history,
+            $this->mutex,
+            true
+        );
         $this->assertEquals($refDB->countLinks() + 3, $this->bookmarkService->count());
 
         $bookmark = $this->bookmarkService->get(43);
@@ -126,7 +149,13 @@ class BookmarkInitializerTest extends TestCase
     public function testInitializeNonExistentDataStore(): void
     {
         $this->conf->set('resource.datastore', static::$testDatastore . '_empty');
-        $this->bookmarkService = new BookmarkFileService($this->conf, $this->history, $this->mutex, true);
+        $this->bookmarkService = new BookmarkFileService(
+            $this->conf,
+            $this->pluginManager,
+            $this->history,
+            $this->mutex,
+            true
+        );
 
         $this->initializer->initialize();
 

--- a/tests/feed/FeedBuilderTest.php
+++ b/tests/feed/FeedBuilderTest.php
@@ -11,6 +11,7 @@ use Shaarli\Bookmark\LinkDB;
 use Shaarli\Config\ConfigManager;
 use Shaarli\Formatter\FormatterFactory;
 use Shaarli\History;
+use Shaarli\Plugin\PluginManager;
 use Shaarli\TestCase;
 
 /**
@@ -55,8 +56,15 @@ class FeedBuilderTest extends TestCase
         $refLinkDB->write(self::$testDatastore);
         $history = new History('sandbox/history.php');
         $factory = new FormatterFactory($conf, true);
+        $pluginManager = new PluginManager($conf);
         self::$formatter = $factory->getFormatter();
-        self::$bookmarkService = new BookmarkFileService($conf, $history, $mutex, true);
+        self::$bookmarkService = new BookmarkFileService(
+            $conf,
+            $pluginManager,
+            $history,
+            $mutex,
+            true
+        );
 
         self::$serverInfo = array(
             'HTTPS' => 'Off',

--- a/tests/netscape/BookmarkExportTest.php
+++ b/tests/netscape/BookmarkExportTest.php
@@ -8,6 +8,7 @@ use Shaarli\Config\ConfigManager;
 use Shaarli\Formatter\BookmarkFormatter;
 use Shaarli\Formatter\FormatterFactory;
 use Shaarli\History;
+use Shaarli\Plugin\PluginManager;
 use Shaarli\TestCase;
 
 require_once 'tests/utils/ReferenceLinkDB.php';
@@ -47,6 +48,9 @@ class BookmarkExportTest extends TestCase
      */
     protected static $history;
 
+    /** @var PluginManager */
+    protected static $pluginManager;
+
     /**
      * @var NetscapeBookmarkUtils
      */
@@ -63,7 +67,14 @@ class BookmarkExportTest extends TestCase
         static::$refDb = new \ReferenceLinkDB();
         static::$refDb->write(static::$testDatastore);
         static::$history = new History('sandbox/history.php');
-        static::$bookmarkService = new BookmarkFileService(static::$conf, static::$history, $mutex, true);
+        static::$pluginManager = new PluginManager(static::$conf);
+        static::$bookmarkService = new BookmarkFileService(
+            static::$conf,
+            static::$pluginManager,
+            static::$history,
+            $mutex,
+            true
+        );
         $factory = new FormatterFactory(static::$conf, true);
         static::$formatter = $factory->getFormatter('raw');
     }

--- a/tests/netscape/BookmarkImportTest.php
+++ b/tests/netscape/BookmarkImportTest.php
@@ -10,6 +10,7 @@ use Shaarli\Bookmark\BookmarkFileService;
 use Shaarli\Bookmark\BookmarkFilter;
 use Shaarli\Config\ConfigManager;
 use Shaarli\History;
+use Shaarli\Plugin\PluginManager;
 use Shaarli\TestCase;
 use Slim\Http\UploadedFile;
 
@@ -71,6 +72,9 @@ class BookmarkImportTest extends TestCase
      */
     protected $netscapeBookmarkUtils;
 
+    /** @var PluginManager */
+    protected $pluginManager;
+
     /**
      * @var string Save the current timezone.
      */
@@ -99,7 +103,14 @@ class BookmarkImportTest extends TestCase
         $this->conf->set('resource.page_cache', $this->pagecache);
         $this->conf->set('resource.datastore', self::$testDatastore);
         $this->history = new History(self::$historyFilePath);
-        $this->bookmarkService = new BookmarkFileService($this->conf, $this->history, $mutex, true);
+        $this->pluginManager = new PluginManager($this->conf);
+        $this->bookmarkService = new BookmarkFileService(
+            $this->conf,
+            $this->pluginManager,
+            $this->history,
+            $mutex,
+            true
+        );
         $this->netscapeBookmarkUtils = new NetscapeBookmarkUtils($this->bookmarkService, $this->conf, $this->history);
     }
 

--- a/tests/plugins/test/test.php
+++ b/tests/plugins/test/test.php
@@ -1,5 +1,7 @@
 <?php
 
+use Shaarli\Bookmark\Bookmark;
+
 /**
  * Hook for test.
  *
@@ -42,4 +44,9 @@ function test_register_routes(): array
             'callable' => 'postFunction',
         ],
     ];
+}
+
+function hook_test_filter_search_entry(Bookmark $bookmark, array $context): bool
+{
+    return $context['_result'];
 }

--- a/tests/updater/UpdaterTest.php
+++ b/tests/updater/UpdaterTest.php
@@ -7,6 +7,7 @@ use Shaarli\Bookmark\BookmarkFileService;
 use Shaarli\Bookmark\BookmarkServiceInterface;
 use Shaarli\Config\ConfigManager;
 use Shaarli\History;
+use Shaarli\Plugin\PluginManager;
 use Shaarli\TestCase;
 
 
@@ -51,7 +52,13 @@ class UpdaterTest extends TestCase
 
         copy('tests/utils/config/configJson.json.php', self::$configFile .'.json.php');
         $this->conf = new ConfigManager(self::$configFile);
-        $this->bookmarkService = new BookmarkFileService($this->conf, $this->createMock(History::class), $mutex, true);
+        $this->bookmarkService = new BookmarkFileService(
+            $this->conf,
+            $this->createMock(PluginManager::class),
+            $this->createMock(History::class),
+            $mutex,
+            true
+        );
         $this->updater = new Updater([], $this->bookmarkService, $this->conf, true);
     }
 


### PR DESCRIPTION
A new plugin hook has been added: hook_test_filter_search_entry
This hook allows to filter out bookmark with custom plugin code when a search is performed.

Related to #143