### PR TITLE
Update .htaccess

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -18,7 +18,7 @@ RewriteRule .* - [e=HTTP_AUTHORIZATION:%1]
 # RewriteBase /
 RewriteCond %{REQUEST_FILENAME} !-f
 RewriteCond %{REQUEST_FILENAME} !-d
-RewriteRule ^ index.php [QSA,L]
+RewriteRule . /Shaarli/index.php [L]
 
 <LimitExcept GET POST PUT DELETE PATCH OPTIONS>
   <IfModule version_module>


### PR DESCRIPTION
URL rewriting fails in v0.12.1 (tested w/ Ionos Shared Hosting).

The issue sits in line 21 in main .htaccess:
`RewriteRule ^ index.php [QSA,L]` has to be changed to `RewriteRule . /Shaarli/index.php [L]`

If Shaarli resides in a differently named folder, amend the above accordingly.