### PR TITLE
doc: apache: explicitly set index.php as DirectoryIndex

### DIFF
--- a/doc/md/Server-configuration.md
+++ b/doc/md/Server-configuration.md
@@ -199,6 +199,8 @@ sudo nano /etc/apache2/sites-available/shaarli.mydomain.org.conf
         Require all denied
     </FilesMatch>
 
+    DirectoryIndex index.php
+
     <Files "index.php">
         Require all granted
     </Files>


### PR DESCRIPTION
WIthout this directive apache will try other default/global DirectoryIndex files resulting in useless file access/error messages in logs

```
[Sun Mar 07 14:04:25.383960 2021] [authz_core:error] [pid 946:tid 139985284290304] [client 10.0.0.1:42616] AH01630: client denied by server configuration: /var/www/links.example.org/index.html
[Sun Mar 07 14:04:25.384293 2021] [authz_core:error] [pid 946:tid 139985284290304] [client 10.0.0.1:42616] AH01630: client denied by server configuration: /var/www/links.example.org/index.cgi
[Sun Mar 07 14:04:25.384465 2021] [authz_core:error] [pid 946:tid 139985284290304] [client 10.0.0.1:42616] AH01630: client denied by server configuration: /var/www/links.example.org/index.pl
```