### PR TITLE
Fix a crash when generating an atom feed with no bookmarks

### DIFF
--- a/application/bookmark/BookmarkFileService.php
+++ b/application/bookmark/BookmarkFileService.php
@@ -74,7 +74,7 @@ class BookmarkFileService implements BookmarkServiceInterface
         $this->isLoggedIn = $isLoggedIn;
 
         if (!$this->isLoggedIn && $this->conf->get('privacy.hide_public_links', false)) {
-            $this->bookmarks = [];
+            $this->bookmarks = new BookmarkArray();
         } else {
             try {
                 $this->bookmarks = $this->bookmarksIO->read();


### PR DESCRIPTION
When we try to access the atom feed and have no bookmarks, it raised the following exception :

```
Call to a member function reorder() on array /webroot/application/bookmark/BookmarkFileService.php:143
#0 /webroot/application/feed/FeedBuilder.php(106): Shaarli\Bookmark\BookmarkFileService->search(Array, 'public', false, false, true)
#1 /webroot/application/front/controller/visitor/FeedController.php(47): Shaarli\Feed\FeedBuilder->buildData('atom', Array)
#2 /webroot/application/front/controller/visitor/FeedController.php(20): Shaarli\Front\Controller\Visitor\FeedController->processRequest('atom', Object(Slim\Http\Request), Object(Slim\Http\Response))
#3 [internal function]: Shaarli\Front\Controller\Visitor\FeedController->atom(Object(Slim\Http\Request), Object(Slim\Http\Response), Array)
#4 /webroot/vendor/slim/slim/Slim/Handlers/Strategies/RequestResponse.php(40): call_user_func(Array, Object(Slim\Http\Request), Object(Slim\Http\Response), Array)
#5 /webroot/vendor/slim/slim/Slim/Route.php(281): Slim\Handlers\Strategies\RequestResponse->__invoke(Array, Object(Slim\Http\Request), Object(Slim\Http\Response), Array)
#6 /webroot/application/front/ShaarliMiddleware.php(55): Slim\Route->__invoke(Object(Slim\Http\Request), Object(Slim\Http\Response))
#7 [internal function]: Shaarli\Front\ShaarliMiddleware->__invoke(Object(Slim\Http\Request), Object(Slim\Http\Response), Object(Slim\Route))
#8 /webroot/vendor/slim/slim/Slim/DeferredCallable.php(57): call_user_func_array(Array, Array)
#9 [internal function]: Slim\DeferredCallable->__invoke(Object(Slim\Http\Request), Object(Slim\Http\Response), Object(Slim\Route))
#10 /webroot/vendor/slim/slim/Slim/MiddlewareAwareTrait.php(70): call_user_func(Object(Slim\DeferredCallable), Object(Slim\Http\Request), Object(Slim\Http\Response), Object(Slim\Route))
#11 /webroot/vendor/slim/slim/Slim/MiddlewareAwareTrait.php(117): Slim\Route->Slim\{closure}(Object(Slim\Http\Request), Object(Slim\Http\Response))
#12 /webroot/vendor/slim/slim/Slim/Route.php(268): Slim\Route->callMiddlewareStack(Object(Slim\Http\Request), Object(Slim\Http\Response))
#13 /webroot/vendor/slim/slim/Slim/App.php(503): Slim\Route->run(Object(Slim\Http\Request), Object(Slim\Http\Response))
#14 /webroot/vendor/slim/slim/Slim/MiddlewareAwareTrait.php(117): Slim\App->__invoke(Object(Slim\Http\Request), Object(Slim\Http\Response))
#15 /webroot/vendor/slim/slim/Slim/App.php(392): Slim\App->callMiddlewareStack(Object(Slim\Http\Request), Object(Slim\Http\Response))
#16 /webroot/vendor/slim/slim/Slim/App.php(297): Slim\App->process(Object(Slim\Http\Request), Object(Slim\Http\Response))
#17 /webroot/index.php(177): Slim\App->run(true)
#18 {main}
```