### PR TITLE
Search highlight: do not use special characters for tokens

### DIFF
--- a/application/formatter/BookmarkDefaultFormatter.php
+++ b/application/formatter/BookmarkDefaultFormatter.php
@@ -12,8 +12,8 @@ namespace Shaarli\Formatter;
  */
 class BookmarkDefaultFormatter extends BookmarkFormatter
 {
-    public const SEARCH_HIGHLIGHT_OPEN = '||O_HIGHLIGHT';
-    public const SEARCH_HIGHLIGHT_CLOSE = '||C_HIGHLIGHT';
+    public const SEARCH_HIGHLIGHT_OPEN = 'SHAARLI_O_HIGHLIGHT';
+    public const SEARCH_HIGHLIGHT_CLOSE = 'SHAARLI_C_HIGHLIGHT';
 
     /**
      * @inheritdoc


### PR DESCRIPTION
It messes with Markdown syntax (tables in this case).

Fixes #1729