### PR TITLE
Fix documentation build

### DIFF
--- a/doc/custom_theme/main.html
+++ b/doc/custom_theme/main.html
@@ -2,7 +2,7 @@
 
 {#
 The entry point for the ReadTheDocs Theme.
- 
+
 Any theme customisations should override this file to redefine blocks defined in
 the various templates. The custom theme should only need to define a main.html
 which `{% extends "base.html" %}` and defines various blocks which will replace
@@ -14,7 +14,7 @@ the blocks defined in base.html and its included child templates.
 <meta http-equiv="X-UA-Compatible" content="IE=edge">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-{%- if 'media.readthedocs.org' not in config.extra_css[0] %}
+{%- if config.extra_css|length and 'media.readthedocs.org' not in config.extra_css[0] %}
 <meta name="robots" content="noindex, nofollow">
 {%- endif %}
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -12,7 +12,7 @@ site_dir: doc/html
 # - https://github.com/rtfd/readthedocs.org/issues/4314
 # strict: true
 
-pages:
+nav:
 - Home: index.md
 - Setup:
     - Server configuration: Server-configuration.md


### PR DESCRIPTION
  - pages parameters has been deprecated and renamed by nav
  - the build fails with an empty extra_css array