### PR TITLE
Change Zeichen to Token

### DIFF
--- a/inc/languages/de/LC_MESSAGES/shaarli.po
+++ b/inc/languages/de/LC_MESSAGES/shaarli.po
@@ -624,7 +624,7 @@ msgstr "Bildwand ist nicht verfügbar (Miniaturansichten sind deaktiviert)."
 
 #: application/front/exceptions/WrongTokenException.php:16
 msgid "Wrong token."
-msgstr "Falsches Zeichen."
+msgstr "Falsches Token."
 
 #: application/helper/ApplicationUtils.php:165
 #, php-format


### PR DESCRIPTION
I'd recommend to change the German translation. The word "Zeichen" is misleading in this case. It means something like string or character. The word "Token" fits better. In general I'd change the message to "Wrong XSRF token". This makes it more clear what happens here.