### PR TITLE
build and push docker images using Github Actions

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -4,7 +4,6 @@
 .github
 .gitattributes
 .gitignore
-.travis.yml
 tests
 
 # Docker related resources are not needed inside the container

--- a/.github/workflows/docker-latest.yml
+++ b/.github/workflows/docker-latest.yml
@@ -1,0 +1,25 @@
+name: Build/push Docker image (master/latest)
+on:
+  push:
+    branches: [ master ]
+jobs:
+  docker-build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+      - name: Login to DockerHub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - name: Build and push
+        id: docker_build
+        uses: docker/build-push-action@v2
+        with:
+          push: true
+          tags: shaarli/shaarli:latest
+      - name: Image digest
+        run: echo ${{ steps.docker_build.outputs.digest }}

--- a/.github/workflows/docker-tags.yml
+++ b/.github/workflows/docker-tags.yml
@@ -1,0 +1,31 @@
+name: Build/push Docker image (tags/releases)
+on:
+  push:
+    tags:
+      - "v*.*.*"
+    branches:
+      - "v*.*"
+      - release
+jobs:
+  docker-build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Get the tag name
+        run: echo "REF=${GITHUB_REF##*/}" >> $GITHUB_ENV
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+      - name: Login to DockerHub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - name: Build and push
+        id: docker_build
+        uses: docker/build-push-action@v2
+        with:
+          push: true
+          tags: shaarli/shaarli:${{ env.REF }}
+      - name: Image digest
+        run: echo ${{ steps.docker_build.outputs.digest }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [v0.12.2]() - UNRELEASED
 
+> The `:master` Docker image is deprecated, please use `:latest` instead.
+> The `:stable` Docker image is deprecated, please use `:release` instead.
+
 ## [v0.12.1](https://github.com/shaarli/Shaarli/releases/tag/v0.12.0) - 2020-11-12
 
 > nginx ([#1628](https://github.com/shaarli/Shaarli/pull/1628)) and Apache ([#1630](https://github.com/shaarli/Shaarli/pull/1630)) configurations have been reviewed. It is recommended that you

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ _It is designed to be personal (single-user), fast and handy._
 [![](https://img.shields.io/travis/shaarli/Shaarli/latest.svg?label=latest)](https://travis-ci.org/shaarli/Shaarli)
 &bull;
 [![](https://img.shields.io/badge/master-v0.12.x-blue.svg)](https://github.com/shaarli/Shaarli)
-[![](https://cloud.drone.io/api/badges/shaarli/Shaarli/status.svg?ref=refs/heads/master)](https://cloud.drone.io/shaarli/Shaarli)
+[![](https://github.com/shaarli/Shaarli/actions/workflows/ci.yml/badge.svg)](https://github.com/shaarli/Shaarli/actions)
 
 [![Join the chat at https://gitter.im/shaarli/Shaarli](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/shaarli/Shaarli)
 [![Bountysource](https://www.bountysource.com/badge/team?team_id=19583&style=bounties_received)](https://www.bountysource.com/teams/shaarli/issues)

--- a/doc/md/Docker.md
+++ b/doc/md/Docker.md
@@ -41,9 +41,10 @@ docker run hello-world
 
 Shaarli images are available on [DockerHub](https://hub.docker.com/r/shaarli/shaarli/) `shaarli/shaarli`:
 
-- `latest`: latest branch (last release)
-- `stable`: stable branch (last release in previous major version)
-- `master`: master branch (development branch)
+- `latest`: master (development) branch
+- `vX.Y.Z`: shaarli [releases](https://github.com/shaarli/Shaarli/releases)
+- `release`: always points to the last release
+- `stable` and `master`: **deprecated**. These tags are no longer maintained and may be removed without notice
 
 These images are built automatically on DockerHub and rely on:
 

--- a/doc/md/dev/Development.md
+++ b/doc/md/dev/Development.md
@@ -143,17 +143,19 @@ A [`Makefile`](https://github.com/shaarli/Shaarli/blob/master/Makefile) is avail
 
 ### Continuous Integration
 
-[Drone CI](https://cloud.drone.io/shaarli/Shaarli) is a Continuous Integration build server, that runs a build:
+[Github Actions](https://github.com/shaarli/Shaarli/actions) is a Continuous Integration build server, that runs a build:
 
 - each time a commit is pushed to any branch
 - each time a Pull Request is submitted or updated
 
-After all jobs have finished, Drone returns the results to GitHub:
+After all jobs have finished, Github Actions returns the results to GitHub:
 
-- a status icon represents the result for the `master` branch: [![Build Status](https://cloud.drone.io/api/badges/shaarli/Shaarli/status.svg?ref=refs/heads/master)](https://cloud.drone.io/shaarli/Shaarli)
-- Pull Requests are updated with the Drone build result.
+- a status icon represents the result for the `master` branch: [![Build Status](https://github.com/shaarli/Shaarli/actions/workflows/ci.yml/badge.svg)](https://github.com/shaarli/Shaarli/actions)
+- Pull Requests are updated with the Github Actions build result.
 
-See [`.drone.yml`](https://github.com/shaarli/Shaarli/blob/master/.drone.yml).
+Github Actions is also used to build and push [Docker](../Docker.md) images to <https://hub.docker.com/r/shaarli/shaarli> for the `master` branch and on every git `tag`/[release](https://github.com/shaarli/Shaarli/releases).
+
+See [`.github/workflows/`](https://github.com/shaarli/Shaarli/tree/master/.github/workflows).
 
 
 ### Documentation


### PR DESCRIPTION
- push images to https://hub.docker.com/r/shaarli/shaarli/tags using a personal access token (access tokens are not available for organizations)
- push an image tagged `:latest` for builds on `master`
- push an image with the same tag as the git tag for `v*.*.*` tags, and for the `release` branch
- update documentation (remove references to Travis/Drone CI
- deprecate stable and master Docker tags (ref. https://github.com/shaarli/Shaarli/issues/1453)
- add deprecation notices to CHANGELOG.md
- fixes https://github.com/shaarli/Shaarli/issues/1762

_Tested and working on https://github.com/nodiscc/Shaarli/actions before I removed the `DOCKERHUB_USERNAME/TOKEN` secrets to prevent accidentally pushing to the shaarli/shaarli registry. I entered my own Personal Access token in https://github.com/shaarli/Shaarli/settings/secrets/actions because tokens are not supported for organizations, the token has to be from one of the dockerhub org `owners`, and all 3 free seats are already taken. I don't use my dockerhub account for anything serious so I don't mind sharing the token._