### PR TITLE
Use basePath attribute

### DIFF
--- a/application/container/ContainerBuilder.php
+++ b/application/container/ContainerBuilder.php
@@ -65,7 +65,8 @@ class ContainerBuilder
         CookieManager $cookieManager,
         LoginManager $login,
         PluginManager $pluginManager,
-        LoggerInterface $logger
+		LoggerInterface $logger,
+		string $basePath = null
     ) {
         $this->conf = $conf;
         $this->session = $session;
@@ -73,6 +74,7 @@ class ContainerBuilder
         $this->cookieManager = $cookieManager;
         $this->pluginManager = $pluginManager;
         $this->logger = $logger;
+        $this->basePath = $basePath;
     }
 
     public function build(): ShaarliContainer

--- a/index.php
+++ b/index.php
@@ -97,7 +97,8 @@ $containerBuilder = new ContainerBuilder(
     $cookieManager,
     $loginManager,
     $pluginManager,
-    $logger
+	$logger,
+	$conf->get('general.root_url', null)
 );
 $container = $containerBuilder->build();
 $app = new App($container);

--- a/tests/container/ContainerBuilderTest.php
+++ b/tests/container/ContainerBuilderTest.php
@@ -62,7 +62,7 @@ class ContainerBuilderTest extends TestCase
             $this->cookieManager,
             $this->loginManager,
             $this->pluginManager,
-            $this->createMock(LoggerInterface::class)
+			$this->createMock(LoggerInterface::class)
         );
     }
 


### PR DESCRIPTION
The `basePath` attribute of the `ContainerBuilder` class is not used, meaning that we cannot run `Shaarli` with some complex server configuration.

With this pull request, the configuration `generate.root_url` can be used, and we can therefore have `Shaarli` on a specifc folder behind a reverse proxy, without the need to rewrite the body content (and the wrong URL asked by `Shaarli`).