### PR TITLE
trivial refine for messages

### DIFF
--- a/application/front/controller/admin/ShaarliAdminController.php
+++ b/application/front/controller/admin/ShaarliAdminController.php
@@ -59,7 +59,7 @@ abstract class ShaarliAdminController extends ShaarliVisitorController
     /**
      * Use the sessionManager to save the provided message using the proper type.
      *
-     * @param string $type successed/warnings/errors
+     * @param string $type successes/warnings/errors
      */
     protected function saveMessage(string $type, string $message): void
     {

--- a/application/security/SessionManager.php
+++ b/application/security/SessionManager.php
@@ -256,7 +256,7 @@ class SessionManager
     }
 
     /**
-     * Store a variable in user session.
+     * Delete a variable in user session.
      *
      * @param string $key   Session key
      *

--- a/doc/md/Backup-and-restore.md
+++ b/doc/md/Backup-and-restore.md
@@ -1,11 +1,11 @@
 ## Backup and restore
 
-All data and [configuration](Shaarli-configuration.md) is kept in the `data` directory. Backup this directory: 
+All data and [configuration](Shaarli-configuration.md) is kept in the `data` directory. Backup this directory:
 
 ```bash
 rsync -avzP my.server.com:/var/www/shaarli.mydomain.org/data ~/backups/shaarli-data-$(date +%Y-%m-%d_%H%M)
 ```
 
-It is strongly recommended to do periodic, automatic backups to a seperate machine. You can automate the command above using a cron job or full-featured backup solutions such as [rsnapshot](https://rsnapshot.org/)
+It is strongly recommended to do periodic, automatic backups to a separate machine. You can automate the command above using a cron job or full-featured backup solutions such as [rsnapshot](https://rsnapshot.org/)
 
-To restore a backup, simply put back the `data/` directory in place, owerwriting any existing files.
+To restore a backup, simply put back the `data/` directory in place, overwriting any existing files.

--- a/doc/md/dev/Development.md
+++ b/doc/md/dev/Development.md
@@ -160,7 +160,7 @@ See [`.github/workflows/`](https://github.com/shaarli/Shaarli/tree/master/.githu
 
 ### Documentation
 
-[mkdocs](https://www.mkdocs.org/) is used to convert markdown documentation to HTML pages. The [public documentation](https://shaarli.readthedocs.io/en/master/) website is rendered and hosted by [readthedocs.org](https://readthedocs.org/). A copy of the documentation is also included in prebuilt [release archives](https://github.com/shaarli/Shaarli/releases) (`doc/html/` path in your Shaarli installation). To generate the HTML documentation locally, install a recent version of Python `setuptools` and run    `make doc`.
+[mkdocs](https://www.mkdocs.org/) is used to convert markdown documentation to HTML pages. The [public documentation](https://shaarli.readthedocs.io/en/master/) website is rendered and hosted by [readthedocs.org](https://readthedocs.org/). A copy of the documentation is also included in prebuilt [release archives](https://github.com/shaarli/Shaarli/releases) (`doc/html/` path in your Shaarli installation). To generate the HTML documentation locally, install a recent version of Python `setuptools` and run the `make doc`.
 
 
 ## Static analysis
@@ -169,7 +169,7 @@ Patches should try to stick to the [PHP Standard Recommendations](http://www.php
 
 - [PSR-1](http://www.php-fig.org/psr/psr-1/) - Basic Coding Standard
 - [PSR-2](http://www.php-fig.org/psr/psr-2/) - Coding Style Guide
-- [PSR-12](http://www.php-fig.org/psr/psr-12/) - Extended Coding Style  Guide
+- [PSR-12](http://www.php-fig.org/psr/psr-12/) - Extended Coding Style Guide
 
 These are enforced on pull requests using our Continuous Integration tools with [PHP Code Sniffer](https://github.com/squizlabs/PHP_CodeSniffer).
 

--- a/doc/md/dev/Development.md
+++ b/doc/md/dev/Development.md
@@ -1,3 +1,4 @@
+
 # Development
 
 Please read [Contributing to Shaarli](https://github.com/shaarli/Shaarli/tree/master/CONTRIBUTING.md)
@@ -160,7 +161,7 @@ See [`.github/workflows/`](https://github.com/shaarli/Shaarli/tree/master/.githu
 
 ### Documentation
 
-[mkdocs](https://www.mkdocs.org/) is used to convert markdown documentation to HTML pages. The [public documentation](https://shaarli.readthedocs.io/en/master/) website is rendered and hosted by [readthedocs.org](https://readthedocs.org/). A copy of the documentation is also included in prebuilt [release archives](https://github.com/shaarli/Shaarli/releases) (`doc/html/` path in your Shaarli installation). To generate the HTML documentation locally, install a recent version of Python `setuptools` and run the `make doc`.
+[mkdocs](https://www.mkdocs.org/) is used to convert markdown documentation to HTML pages. The [public documentation](https://shaarli.readthedocs.io/en/master/) website is rendered and hosted by [readthedocs.org](https://readthedocs.org/). A copy of the documentation is also included in prebuilt [release archives](https://github.com/shaarli/Shaarli/releases) (`doc/html/` path in your Shaarli installation). To generate the HTML documentation locally, install a recent version of Python `setuptools` and run `make doc`.
 
 
 ## Static analysis

--- a/doc/md/dev/Unit-tests.md
+++ b/doc/md/dev/Unit-tests.md
@@ -40,7 +40,7 @@ zend_extension=xdebug.so
 
 ## Run unit tests
 
-Ensure tests pass successuflly:
+Ensure tests pass successfully:
 
 ```bash
 make test
@@ -110,7 +110,7 @@ Each image provides:
 - Shaarli PHP dependencies (OS packages)
 - test PHP dependencies (OS packages)
 - Composer
-- Tests that run inside the conatiner using a standard Linux user account (running tests as `root` would bypass permission checks and may hide issues)
+- Tests that run inside the container using a standard Linux user account (running tests as `root` would bypass permission checks and may hide issues)
 
 Build a test image:
 

--- a/plugins/wallabag/wallabag.php
+++ b/plugins/wallabag/wallabag.php
@@ -69,7 +69,7 @@ function hook_wallabag_render_linklist($data, $conf)
 function wallabag_dummy_translation()
 {
     // meta
-    t('For each link, add a QRCode icon.');
+    t("For each link, add a Wallabag icon to save it in your instance.");
     t('Wallabag API URL');
     t('Wallabag API version (1 or 2)');
 }

--- a/tpl/default/configure.html
+++ b/tpl/default/configure.html
@@ -49,7 +49,7 @@
         <div class="pure-u-lg-{$ratioLabel} pure-u-1">
           <div class="form-label">
             <label for="titleLink">
-              <span class="label-name">{'Theme'|t}</span>
+              <span class="label-name">{'Themes'|t}</span>
             </label>
           </div>
         </div>
@@ -95,7 +95,7 @@
         <div class="pure-u-lg-{$ratioLabel} pure-u-1">
           <div class="form-label">
             <label for="language">
-              <span class="label-name">{'Language'|t}</span>
+              <span class="label-name">{'Languages'|t}</span>
             </label>
           </div>
         </div>
@@ -222,7 +222,7 @@
         <div class="pure-u-lg-{$ratioLabel} pure-u-{$ratioLabelMobile}">
           <div class="form-label">
             <label for="updateCheck">
-              <span class="label-name">{'Check updates'|t}</span><br>
+              <span class="label-name">{'Check for updates'|t}</span><br>
               <span class="label-desc">{'Notify me when a new release is ready'|t}</span>
             </label>
           </div>
@@ -270,7 +270,7 @@
         <div class="pure-u-lg-{$ratioLabel} pure-u-1">
           <div class="form-label">
             <label for="apiSecret">
-              <span class="label-name">{'API secret'|t}</span><br>
+              <span class="label-name">{'REST API secret'|t}</span><br>
             </label>
           </div>
         </div>

--- a/tpl/default/install.html
+++ b/tpl/default/install.html
@@ -69,7 +69,7 @@
       <div class="pure-u-lg-{$ratioLabel} pure-u-1">
         <div class="form-label">
           <label for="language">
-            <span class="label-name">{'Language'|t}</span>
+            <span class="label-name">{'Languages'|t}</span>
           </label>
         </div>
       </div>
@@ -127,7 +127,7 @@
       <div class="pure-u-lg-{$ratioLabel} pure-u-7-8">
         <div class="form-label">
           <label for="update">
-            <span class="label-name">{'Check updates'|t}</span><br>
+            <span class="label-name">{'Check for updates'|t}</span><br>
             <span class="label-desc">
               {'Notify me when a new release is ready'|t}
             </span>

--- a/tpl/default/pluginsadmin.html
+++ b/tpl/default/pluginsadmin.html
@@ -10,7 +10,7 @@
   <div class="pure-g new-version-message pure-alert pure-alert-warning">
     <div class="pure-u-2-24"></div>
     <div class="pure-u-20-24">
-      {'You need to enable Javascript to change plugin loading order.'|t}
+      {'You have to enable JavaScript to change plugin loading order.'|t}
     </div>
   </div>
   <div class="clear"></div>

--- a/tpl/default/tools.html
+++ b/tpl/default/tools.html
@@ -65,7 +65,7 @@
 <div class="pure-g">
   <div class="pure-u-lg-1-3 pure-u-1-24"></div>
   <div class="pure-u-lg-1-3 pure-u-22-24 page-form page-form-light">
-    <h2 class="window-title">Bookmarklets</h2>
+    <h2 class="window-title">{'Bookmarklets'|t}</h2>
     <p>
       {'Drag one of these button to your bookmarks toolbar or right-click it and "Bookmark This Link"'|t},
       {'then click on the bookmarklet in any page you want to share.'|t}


### PR DESCRIPTION
fixes typo, plural form (unfortunately, this is not completed by `t()`), i18n.