### PR TITLE
Multi-stage Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,35 +1,40 @@
 # Stage 1:
-# - Copy Shaarli sources
-# - Build documentation
-FROM python:3-alpine as docs
-ADD . /usr/src/app/shaarli
-RUN cd /usr/src/app/shaarli \
-    && apk add --no-cache gcc musl-dev \
-    && pip install --no-cache-dir mkdocs \
-    && mkdocs build --clean
-
-# Stage 2:
 # - Resolve PHP dependencies with Composer
 FROM composer:latest as composer
-COPY --from=docs /usr/src/app/shaarli /app/shaarli
-RUN cd shaarli \
-    && composer --prefer-dist --no-dev install
+COPY composer.json composer.lock /tmp/shaarli/
+WORKDIR /tmp/shaarli
+RUN composer --prefer-dist --no-dev install
+
+# Stage 2:
+# - Frontend dependencies
+FROM node:12-alpine as app
+COPY --chown=nginx:nginx . /tmp/shaarli/
+WORKDIR /tmp/shaarli
+RUN yarn install \
+    && yarn run build \
+    && rm -rf ./node_modules
 
 # Stage 3:
-# - Frontend dependencies
-FROM node:12-alpine as node
-COPY --from=composer /app/shaarli shaarli
-RUN cd shaarli \
-    && yarn install \
-    && yarn run build \
-    && rm -rf node_modules
+# - Build documentation
+FROM python:3-alpine as docs
+
+COPY mkdocs.yml /tmp/shaarli/
+COPY --chown=nginx:nginx doc /tmp/shaarli/doc/
+WORKDIR /tmp/shaarli/
+RUN pip install --no-cache-dir mkdocs \
+    && mkdocs build --clean
 
 # Stage 4:
 # - Shaarli image
-FROM alpine:3.12
 LABEL maintainer="Shaarli Community"
 
-RUN apk --update --no-cache add \
+FROM alpine:3.14 as php
+WORKDIR /var/www
+
+# Invalidation cache while new release
+COPY --chown=nginx:nginx shaarli_version.php /var/www/shaarli/
+
+RUN apk --update add \
         ca-certificates \
         nginx \
         php7 \
@@ -48,20 +53,22 @@ RUN apk --update --no-cache add \
         php7-zlib \
         s6
 
-COPY .docker/nginx.conf /etc/nginx/nginx.conf
-COPY .docker/php-fpm.conf /etc/php7/php-fpm.conf
-COPY .docker/services.d /etc/services.d
+COPY --chown=nginx:nginx .docker/nginx.conf /etc/nginx/nginx.conf
+COPY --chown=nginx:nginx .docker/php-fpm.conf /etc/php7/php-fpm.conf
+COPY --chown=nginx:nginx .docker/services.d /etc/services.d
 
 RUN rm -rf /etc/php7/php-fpm.d/www.conf \
     && sed -i 's/post_max_size.*/post_max_size = 10M/' /etc/php7/php.ini \
     && sed -i 's/upload_max_filesize.*/upload_max_filesize = 10M/' /etc/php7/php.ini
 
+COPY --chown=nginx:nginx --from=composer /tmp/shaarli /var/www/shaarli/
+COPY --chown=nginx:nginx --from=app /tmp/shaarli /var/www/shaarli/
+COPY --chown=nginx:nginx --from=docs /tmp/shaarli /var/www/shaarli/
 
-WORKDIR /var/www
-COPY --from=node /shaarli shaarli
+# disabled due to https://github.com/docker/for-linux/issues/388
+#RUN chown -R nginx:nginx /var/www/shaarli/
 
-RUN chown -R nginx:nginx . \
-    && ln -sf /dev/stdout /var/log/nginx/shaarli.access.log \
+RUN ln -sf /dev/stdout /var/log/nginx/shaarli.access.log \
     && ln -sf /dev/stderr /var/log/nginx/shaarli.error.log
 
 VOLUME /var/www/shaarli/cache


### PR DESCRIPTION
I expect it to improve slow `docker build` locally.

`alpine:3.14` updated. FYI:
https://wiki.alpinelinux.org/wiki/Release_Notes_for_Alpine_3.13.0
https://wiki.alpinelinux.org/wiki/Release_Notes_for_Alpine_3.14.0

I expect the `COPY --chown=nginx:nginx shaarli_version.php /var/www/shaarli/` ensure a clean cache for release. Although this may not be effective for `dev` branches, and an inconsistent results for the developer local. I still want to pass a variable or `if`, only erase in cloud builds.

If the `&& rm -rf ./node_modules` be removed, it will build quickly, but the docker image size + 50MiB, which seems not easy to solve.