### PR TITLE
Simple and uniform localized website title

### DIFF
--- a/application/front/controller/visitor/InstallController.php
+++ b/application/front/controller/visitor/InstallController.php
@@ -131,7 +131,7 @@ class InstallController extends ShaarliVisitorController
         } else {
             $this->container->conf->set(
                 'general.title',
-                'Shared bookmarks on ' . escape(index_url($this->container->environment))
+                t('My links')
             );
         }
 

--- a/application/front/controller/visitor/InstallController.php
+++ b/application/front/controller/visitor/InstallController.php
@@ -131,7 +131,7 @@ class InstallController extends ShaarliVisitorController
         } else {
             $this->container->conf->set(
                 'general.title',
-                t('My links')
+                t('Shared Bookmarks')
             );
         }
 

--- a/tests/front/controller/visitor/InstallControllerTest.php
+++ b/tests/front/controller/visitor/InstallControllerTest.php
@@ -266,7 +266,7 @@ class InstallControllerTest extends TestCase
         static::assertSame('/subfolder/login', $result->getHeader('location')[0]);
 
         static::assertSame('UTC', $confSettings['general.timezone']);
-        static::assertSame('Shared bookmarks on http://shaarli/subfolder/', $confSettings['general.title']);
+        static::assertSame('My links', $confSettings['general.title']);
     }
 
     /**
@@ -299,6 +299,6 @@ class InstallControllerTest extends TestCase
         static::assertSame('/login', $result->getHeader('location')[0]);
 
         static::assertSame('UTC', $confSettings['general.timezone']);
-        static::assertSame('Shared bookmarks on http://shaarli/', $confSettings['general.title']);
+        static::assertSame('My links', $confSettings['general.title']);
     }
 }

--- a/tests/front/controller/visitor/InstallControllerTest.php
+++ b/tests/front/controller/visitor/InstallControllerTest.php
@@ -266,7 +266,7 @@ class InstallControllerTest extends TestCase
         static::assertSame('/subfolder/login', $result->getHeader('location')[0]);
 
         static::assertSame('UTC', $confSettings['general.timezone']);
-        static::assertSame('My links', $confSettings['general.title']);
+        static::assertSame('Shared Bookmarks', $confSettings['general.title']);
     }
 
     /**
@@ -299,6 +299,6 @@ class InstallControllerTest extends TestCase
         static::assertSame('/login', $result->getHeader('location')[0]);
 
         static::assertSame('UTC', $confSettings['general.timezone']);
-        static::assertSame('My links', $confSettings['general.title']);
+        static::assertSame('Shared Bookmarks', $confSettings['general.title']);
     }
 }


### PR DESCRIPTION
The actual title is not localized, but the /install page shows it as localized.
I propose change it into pure, because a domain name is lengthy and may leak privacy while a screenshot or behind reverse proxy.