### PR TITLE
Add Okteto cloud instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,11 @@ It runs the latest development version of Shaarli and is updated/reset daily.
 
 Login: `demo`; Password: `demo`
 
+### Deploy on Okteto cloud 
+[![Develop on Okteto](https://okteto.com/develop-okteto.svg)](https://cloud.okteto.com/deploy?repository=https://github.com/shaarli/Shaarli)
+
+You can log in to Okteto service via Github account, one-key to deploy this application for evaluate / develop. Free, credit not required. Application sleeping after 24 hours inactive, *namespaces will be deleted after 15 days of inactivity.* for free plan.
+
 ### License
 
 Shaarli is [Free Software](http://en.wikipedia.org/wiki/Free_software). See [COPYING](COPYING) for a detail of the contributors and licenses for each individual component.

--- a/doc/md/Community-and-related-software.md
+++ b/doc/md/Community-and-related-software.md
@@ -43,6 +43,8 @@ See [Theming](Theming) for a list of community-contributed themes, and an instal
 - [Shaarli app for Cloudron](https://git.cloudron.io/cloudron/shaarli-app) - Effortlessly run Shaarli with the help of [Cloudron](https://cloudron.io/) [![Install](https://cloudron.io/img/button.svg)](https://cloudron.io/button.html?app=com.github.shaarli)
 - [Shaarli_ynh](https://github.com/YunoHost-Apps/shaarli_ynh) - Shaarli is available as a [Yunohost](https://yunohost.org) app [![Install Shaarli with YunoHost](https://install-app.yunohost.org/install-with-yunohost.png)](https://install-app.yunohost.org/?app=shaarli)
 - [pelican](https://blog.getpelican.com) static blog generator plugin to auto-post articles on a Shaarli instance: [shaarli_poster](https://github.com/getpelican/pelican-plugins/tree/master/shaarli_poster)
+- [Okteto cloud](https://cloud.okteto.com/) - You can log in to Okteto service via Github account, deploy applications for evaluate / develop. Free, credit not required. The Developer [plan](https://okteto.com/pricing/index.html) (free) includes like 5GB storage, application sleeping after 24 hours inactive, *namespaces will be deleted after 15 days of inactivity.* It also provides cool features like [build projects in the cloud](https://okteto.com/docs/cloud/build/).
+[![Develop on Okteto](https://okteto.com/develop-okteto.svg)](https://cloud.okteto.com/deploy?repository=https://github.com/shaarli/Shaarli)
 
 
 ### Mobile Apps

--- a/okteto-stack.yml
+++ b/okteto-stack.yml
@@ -1,0 +1,22 @@
+---
+# Shaarli - Docker Compose example configuration
+# - https://shaarli.readthedocs.io/en/master/Docker/#docker-compose
+
+volumes:
+  shaarli-cache:
+  shaarli-data:
+
+endpoints:
+  - path: /
+    service: shaarli
+    port: 80
+
+services:
+  shaarli:
+    image: shaarli/shaarli
+    # build: ./
+    volumes:
+      - shaarli-cache:/var/www/shaarli/cache
+      - shaarli-data:/var/www/shaarli/data
+    ports:
+      - 80:80


### PR DESCRIPTION
It is very convenient and no fees. no conflict of interest.

1. The 24 hours inactivity seems to be a fixed point in time instead of the cycle.
2. I have an idea, if the project has an automatic backup / migration solution, it will be a low-cost program? I didn't find anything to stop this, except for a limited service SLA (maybe). If a WebDAV plugin is provided, it will be cool.
3. A small flaw, it uses the <project name - GitHub account name> in the domain name, which is a privacy issue for a very few users.
4. If you mind, free to remove or weaken the description from readme.md.
5. The volumes size setting is not touched.
5. I also tried the Cloudflare workers service, it provides free CDN and edge programming for limited resources. This can be used to hide the source site domain, site mask, etc.
7. By the way, do you want me to submit bigger or small PRs, or even directly commit to master. I'm still exploring the project and there are a lot of ideas.