### PR TITLE
Allow to fill in the user timezone and related fixes

### DIFF
--- a/tpl/default/configure.html
+++ b/tpl/default/configure.html
@@ -127,7 +127,7 @@
         <div class="pure-u-lg-{$ratioInput} pure-u-1 ">
           <div class="form-input">
             <div class="timezone">
-              <select id="continent" name="continent">
+              <select id="continent" name="continent" title="{'Continent'|t}">
                 {loop="$continents"}
                   {if="$key !== 'selected'"}
                     <option value="{$value}" {if="$continents.selected === $value"}selected{/if}>
@@ -136,7 +136,7 @@
                   {/if}
                 {/loop}
               </select>
-              <select id="city" name="city">
+              <select id="city" name="city" title="{'City'|t}">
                 {loop="$cities"}
                   {if="$key !== 'selected'"}
                     <option value="{$value.city}"
@@ -147,6 +147,7 @@
                   {/if}
                 {/loop}
               </select>
+              <button type="button" class="button" onclick="autofillTimeZone_alert()">{'Auto detect'|t}</button>
             </div>
           </div>
         </div>

--- a/tpl/default/install.html
+++ b/tpl/default/install.html
@@ -98,7 +98,7 @@
       <div class="pure-u-lg-{$ratioInput} pure-u-1">
         <div class="form-input">
           <div class="timezone">
-            <select id="continent" name="continent">
+            <select id="continent" name="continent" title="{'Continent'|t}">
               {loop="$continents"}
                 {if="$key !== 'selected'"}
                   <option value="{$value}" {if="$continents.selected === $value"}selected{/if}>
@@ -107,7 +107,7 @@
                 {/if}
               {/loop}
             </select>
-            <select id="city" name="city">
+            <select id="city" name="city" title="{'City'|t}">
               {loop="$cities"}
                 {if="$key !== 'selected'"}
                   <option value="{$value.city}"
@@ -118,6 +118,7 @@
                 {/if}
               {/loop}
             </select>
+            <button type="button" class="button" onclick="autofillTimeZone_alert()">{'Auto detect'|t}</button>
           </div>
         </div>
       </div>

--- a/tpl/default/page.footer.html
+++ b/tpl/default/page.footer.html
@@ -43,3 +43,49 @@
 <input type="hidden" name="tags_separator" value="{$tags_separator}" id="tags_separator" />
 
 <script src="{$asset_path}/js/shaarli.min.js?v={$version_hash}#"></script>
+<script>
+function autofillTimeZone() {
+  try {
+    curZoneName = Intl.DateTimeFormat().resolvedOptions().timeZone
+    cur = curZoneName.split('/');
+    continent = cur[0];
+    cur.shift()
+    city = cur.join('/');
+    conEl = document.querySelector('#continent');
+    cityEl = document.querySelector('#city');
+    conEl.value = continent;
+    conEl.dispatchEvent(new Event('change')); // set value attribute doesn't trigger the change or input event.
+    cityEl.value = city;
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+// e.g. old browsers.
+function autofillTimeZone_alert() {
+  if(!autofillTimeZone()) {
+    alert('Automatic detection and filling failed!'); // TODO: i18n
+  }
+}
+
+// Update the select list, otherwise it is old.
+function citiesUpdates() {
+  conEl = document.querySelector('#continent');
+  cityEls = document.querySelectorAll('#city>option');
+  conEl.addEventListener('change', () => {
+    let newConName = conEl.value;
+    let firstSelected = false;
+    for (let el of cityEls) {
+      let show = el.dataset.continent == newConName;
+      el.className = show ? "" : "hidden";
+      if (!firstSelected && show) { // Ensure the selected visible
+        el.selected = true;
+        firstSelected = true;
+      }
+    }
+    cityEl = document.querySelector('#city');
+  });
+}
+document.addEventListener("DOMContentLoaded", citiesUpdates);
+</script>

--- a/tpl/vintage/configure.html
+++ b/tpl/vintage/configure.html
@@ -48,7 +48,7 @@
       <tr>
         <td><b>Timezone:</b></td>
         <td>
-          <select id="continent" name="continent">
+          <select id="continent" name="continent" title="{'Continent'|t}">
             {loop="$continents"}
               {if="$key !== 'selected'"}
                 <option value="{$value}" {if="$continents.selected === $value"}selected{/if}>
@@ -57,7 +57,7 @@
               {/if}
             {/loop}
           </select>
-          <select id="city" name="city">
+          <select id="city" name="city" title="{'City'|t}">
             {loop="$cities"}
               {if="$key !== 'selected'"}
                 <option value="{$value.city}"
@@ -68,6 +68,7 @@
               {/if}
             {/loop}
           </select>
+          <button type="button" class="button" onclick="autofillTimeZone_alert()">{'Auto detect'|t}</button>
         </td>
       </tr>
 

--- a/tpl/vintage/install.html
+++ b/tpl/vintage/install.html
@@ -12,7 +12,7 @@
             <tr>
                 <td><b>Timezone:</b></td>
                 <td>
-                    <select id="continent" name="continent">
+                    <select id="continent" name="continent" title="{'Continent'|t}">
                         {loop="$continents"}
                         {if="$key !== 'selected'"}
                         <option value="{$value}" {if="$continents.selected === $value"}selected{/if}>
@@ -21,7 +21,7 @@
                         {/if}
                         {/loop}
                     </select>
-                    <select id="city" name="city">
+                    <select id="city" name="city" title="{'City'|t}">
                         {loop="$cities"}
                         {if="$key !== 'selected'"}
                         <option value="{$value.city}"
@@ -32,6 +32,7 @@
                         {/if}
                         {/loop}
                     </select>
+                    <button type="button" class="button" onclick="autofillTimeZone_alert()">{'Auto detect'|t}</button>
                 </td>
             </tr>
             <tr><td><b>Page title:</b></td><td><input type="text" name="title" size="30"></td></tr>

--- a/tpl/vintage/page.footer.html
+++ b/tpl/vintage/page.footer.html
@@ -36,3 +36,49 @@
 <input type="hidden" name="tags_separator" value="{$tags_separator}" id="tags_separator" />
 
 <script src="{$asset_path}/js/shaarli.min.js#"></script>
+<script>
+function autofillTimeZone() {
+  try {
+    curZoneName = Intl.DateTimeFormat().resolvedOptions().timeZone
+    cur = curZoneName.split('/');
+    continent = cur[0];
+    cur.shift()
+    city = cur.join('/');
+    conEl = document.querySelector('#continent');
+    cityEl = document.querySelector('#city');
+    conEl.value = continent;
+    conEl.dispatchEvent(new Event('change')); // set value attribute doesn't trigger the change or input event.
+    cityEl.value = city;
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+// e.g. old browsers.
+function autofillTimeZone_alert() {
+  if(!autofillTimeZone()) {
+    alert('Automatic detection and filling failed!'); // TODO: i18n
+  }
+}
+
+// Update the select list, otherwise it is old.
+function citiesUpdates() {
+  conEl = document.querySelector('#continent');
+  cityEls = document.querySelectorAll('#city>option');
+  conEl.addEventListener('change', () => {
+    let newConName = conEl.value;
+    let firstSelected = false;
+    for (let el of cityEls) {
+      let show = el.dataset.continent == newConName;
+      el.className = show ? "" : "hidden";
+      if (!firstSelected && show) { // Ensure the selected visible
+        el.selected = true;
+        firstSelected = true;
+      }
+    }
+    cityEl = document.querySelector('#city');
+  });
+}
+document.addEventListener("DOMContentLoaded", citiesUpdates);
+</script>


### PR DESCRIPTION
Add a button to quickly fill in the time zone from the user browser / system.
It also solves a problem, the cities list will not update while the second time selection of any continent.

Unresolved: 
Ugly coding. No code sharing (reuse).