### PR TITLE
Correction: pubsubhubbub hub link in RSS / Atom.

### DIFF
--- a/tpl/default/feed.atom.html
+++ b/tpl/default/feed.atom.html
@@ -8,7 +8,7 @@
   <link rel="self" href="{$self_link}#" />
   <link rel="search" type="application/opensearchdescription+xml" href="{$index_url}open-search#"
         title="Shaarli search - {$shaarlititle}" />
-  {loop="$plugins_feed_header"}
+  {loop="$feed_plugins_header"}
     {$value}
   {/loop}
   <author>

--- a/tpl/default/feed.rss.html
+++ b/tpl/default/feed.rss.html
@@ -10,7 +10,7 @@
     <atom:link rel="self" href="{$self_link}" />
     <atom:link rel="search" type="application/opensearchdescription+xml" href="{$index_url}open-search#"
                title="Shaarli search - {$shaarlititle}" />
-    {loop="$plugins_feed_header"}
+    {loop="$feed_plugins_header"}
       {$value}
     {/loop}
     {loop="$links"}


### PR DESCRIPTION
The hub link variable is wrong in default template (this correction) but OK in the vintage one.