### PR TITLE
build: use the yarnpkg command instead of yarn

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,10 +70,10 @@ jobs:
           node-version: '14.x'
 
       - name: Yarn install
-        run: yarn install
+        run: yarnpkg install
 
       - name: Verify successful frontend builds
-        run: yarn run build
+        run: yarnpkg run build
 
       - name: JS static analysis
         run: make eslint

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,8 +20,8 @@ RUN cd shaarli \
 FROM node:12-alpine as node
 COPY --from=composer /app/shaarli shaarli
 RUN cd shaarli \
-    && yarn install \
-    && yarn run build \
+    && yarnpkg install \
+    && yarnpkg run build \
     && rm -rf node_modules
 
 # Stage 4:

--- a/Dockerfile.armhf
+++ b/Dockerfile.armhf
@@ -22,8 +22,8 @@ FROM arm32v6/alpine:3.10 as node
 COPY --from=composer /app/shaarli /shaarli
 RUN apk --update --no-cache add yarn nodejs-current python2 build-base \
     && cd /shaarli \
-    && yarn install \
-    && yarn run build \
+    && yarnpkg install \
+    && yarnpkg run build \
     && rm -rf node_modules
 
 # Stage 4:

--- a/Makefile
+++ b/Makefile
@@ -106,11 +106,11 @@ composer_dependencies: clean
 
 ### download 3rd-party frontend libraries
 frontend_dependencies:
-	yarn install
+	yarnpkg install
 
 ### Build frontend dependencies
 build_frontend: frontend_dependencies
-	yarn run build
+	yarnpkg run build
 
 ### generate a release tarball and include 3rd-party dependencies and translations
 release_tar: composer_dependencies htmldoc translate build_frontend
@@ -169,10 +169,10 @@ translate:
 
 ### Run ESLint check against Shaarli's JS files
 eslint:
-	@yarn run eslint -c .dev/.eslintrc.js assets/vintage/js/
-	@yarn run eslint -c .dev/.eslintrc.js assets/default/js/
-	@yarn run eslint -c .dev/.eslintrc.js assets/common/js/
+	@yarnpkg run eslint -c .dev/.eslintrc.js assets/vintage/js/
+	@yarnpkg run eslint -c .dev/.eslintrc.js assets/default/js/
+	@yarnpkg run eslint -c .dev/.eslintrc.js assets/common/js/
 
 ### Run CSSLint check against Shaarli's SCSS files
 sasslint:
-	@yarn run stylelint --config .dev/.stylelintrc.js 'assets/default/scss/*.scss'
+	@yarnpkg run stylelint --config .dev/.stylelintrc.js 'assets/default/scss/*.scss'


### PR DESCRIPTION
- yarnpkg is always aliased to the proper yarn binary on all distributions
- yarn command does not always point to yarn package managed (Debian)