### PR TITLE
doc: installation/tests: clarify build tools installation procedure

### DIFF
--- a/doc/md/Installation.md
+++ b/doc/md/Installation.md
@@ -20,6 +20,11 @@ These components are required to build Shaarli:
 - [yarn](https://yarnpkg.com/lang/en/docs/install/) to build frontend dependencies.
 - [python3-virtualenv](https://pypi.python.org/pypi/virtualenv) to build local HTML documentation.
 
+```bash
+# example from a Debian-based build machine
+sudo apt install composer yarnpkg python3-virtualenv
+```
+
 Clone the repository, either pointing to:
 
 - any [tagged release](https://github.com/shaarli/Shaarli/releases)

--- a/doc/md/dev/Unit-tests.md
+++ b/doc/md/dev/Unit-tests.md
@@ -1,6 +1,6 @@
 # Unit tests
 
-Shaarli uses the [PHPUnit](https://phpunit.de/) test framework; it can be installed with [Composer](https://getcomposer.org/), which is a dependency management tool.
+Shaarli uses the [PHPUnit](https://phpunit.de/) test framework; it can be installed with [Composer](../Installation.md#from-sources), which is a dependency management tool.
 
 ## Install composer
 


### PR DESCRIPTION
- don't repeat link to getcomposer.org
- add an example of installing build dependencies on Debian