### PR TITLE
Improve bookmark metadata formatting for Netscape exports

### DIFF
--- a/tpl/default/export.bookmarks.html
+++ b/tpl/default/export.bookmarks.html
@@ -5,6 +5,6 @@
      Do Not Edit! -->{ignore}The RainTPL loop is formatted to avoid generating extra newlines{/ignore}
 <TITLE>{$pagetitle}</TITLE>
 <H1>Shaarli export of {$selection} bookmarks on {$date}</H1>
-<DL><p>{loop="links"}
-<DT><A HREF="{$value.url}" ADD_DATE="{$value.timestamp}" {if="$value.updated_timestamp"}LAST_MODIFIED="{$value.updated_timestamp}" {/if}PRIVATE="{$value.private}" TAGS="{$value.taglist}">{$value.title}</A>{if="$value.description"}{$eol}<DD>{$value.description}{/if}{/loop}
+<DL><p>{loop="links"}{$private=intval($value.private)}
+<DT><A HREF="{$value.url}" ADD_DATE="{$value.timestamp}" {if="$value.updated_timestamp"}LAST_MODIFIED="{$value.updated_timestamp}" {/if}PRIVATE="{$private}" TAGS="{$value.taglist}">{$value.title}</A>{if="$value.description"}{$eol}<DD>{$value.description}{/if}{/loop}
 </DL><p>

--- a/tpl/default/export.bookmarks.html
+++ b/tpl/default/export.bookmarks.html
@@ -6,5 +6,5 @@
 <TITLE>{$pagetitle}</TITLE>
 <H1>Shaarli export of {$selection} bookmarks on {$date}</H1>
 <DL><p>{loop="links"}
-<DT><A HREF="{$value.url}" ADD_DATE="{$value.timestamp}" PRIVATE="{$value.private}" TAGS="{$value.taglist}">{$value.title}</A>{if="$value.description"}{$eol}<DD>{$value.description}{/if}{/loop}
+<DT><A HREF="{$value.url}" ADD_DATE="{$value.timestamp}" {if="$value.updated_timestamp"}LAST_MODIFIED="{$value.updated_timestamp}" {/if}PRIVATE="{$value.private}" TAGS="{$value.taglist}">{$value.title}</A>{if="$value.description"}{$eol}<DD>{$value.description}{/if}{/loop}
 </DL><p>

--- a/tpl/vintage/export.bookmarks.html
+++ b/tpl/vintage/export.bookmarks.html
@@ -5,6 +5,6 @@
      Do Not Edit! -->{ignore}The RainTPL loop is formatted to avoid generating extra newlines{/ignore}
 <TITLE>{$pagetitle}</TITLE>
 <H1>Shaarli export of {$selection} bookmarks on {$date}</H1>
-<DL><p>{loop="$links"}
-<DT><A HREF="{$value.url}" ADD_DATE="{$value.timestamp}" {if="$value.updated_timestamp"}LAST_MODIFIED="{$value.updated_timestamp}" {/if}PRIVATE="{$value.private}" TAGS="{$value.taglist}">{$value.title}</A>{if="$value.description"}{$eol}<DD>{$value.description}{/if}{/loop}
+<DL><p>{loop="links"}{$private=intval($value.private)}
+<DT><A HREF="{$value.url}" ADD_DATE="{$value.timestamp}" {if="$value.updated_timestamp"}LAST_MODIFIED="{$value.updated_timestamp}" {/if}PRIVATE="{$private}" TAGS="{$value.taglist}">{$value.title}</A>{if="$value.description"}{$eol}<DD>{$value.description}{/if}{/loop}
 </DL><p>

--- a/tpl/vintage/export.bookmarks.html
+++ b/tpl/vintage/export.bookmarks.html
@@ -6,5 +6,5 @@
 <TITLE>{$pagetitle}</TITLE>
 <H1>Shaarli export of {$selection} bookmarks on {$date}</H1>
 <DL><p>{loop="$links"}
-<DT><A HREF="{$value.url}" ADD_DATE="{$value.timestamp}" PRIVATE="{$value.private}" TAGS="{$value.taglist}">{$value.title}</A>{if="$value.description"}{$eol}<DD>{$value.description}{/if}{/loop}
+<DT><A HREF="{$value.url}" ADD_DATE="{$value.timestamp}" {if="$value.updated_timestamp"}LAST_MODIFIED="{$value.updated_timestamp}" {/if}PRIVATE="{$value.private}" TAGS="{$value.taglist}">{$value.title}</A>{if="$value.description"}{$eol}<DD>{$value.description}{/if}{/loop}
 </DL><p>


### PR DESCRIPTION
### Changed
- When a bookmark's update date is set, set the `LAST_MODIFIED` attribute
- Ensure the `PRIVATE` attribute contains an integer value

### Diff
Default bookmarks exported from the current `master` version (extract with `<DT><A>` elements):

```xml
<DT><A HREF="/shaare/f6PbvA" ADD_DATE="1654256014" PRIVATE="" TAGS="shaarli,help">Shaarli - The personal, minimalist, super-fast, database free, bookmarking service</A>
<DT><A HREF="/shaare/poWYsQ" ADD_DATE="1654256014" PRIVATE="1" TAGS="shaarli,help">Note: Shaare descriptions</A>
<DT><A HREF="https://www.youtube.com/watch?v=DVEUcbPkb-c" ADD_DATE="1654256014" PRIVATE="1" TAGS="shaarli,help,thumbnail">Calm Jazz Music - YouTube (private bookmark with thumbnail demo)</A>
```

Default bookmarks exported from the PR branch (extract with `<DT><A>` elements):

```xml
<DT><A HREF="/shaare/WJe-Cw" ADD_DATE="1654255845" PRIVATE="0" TAGS="shaarli,help">Shaarli - The personal, minimalist, super-fast, database free, bookmarking service</A>
<DT><A HREF="/shaare/gbH9Bg" ADD_DATE="1654255845" PRIVATE="1" TAGS="shaarli,help">Note: Shaare descriptions</A>
<DT><A HREF="https://www.youtube.com/watch?v=DVEUcbPkb-c" ADD_DATE="1654255845" LAST_MODIFIED="1654255845" PRIVATE="1" TAGS="shaarli,help,thumbnail">Calm Jazz Music - YouTube (private bookmark with thumbnail demo)</A>
```