### PR TITLE
Dockerfile/Dockerfile.armhf: update base alpine image to v3.16

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,7 +26,7 @@ RUN cd shaarli \
 
 # Stage 4:
 # - Shaarli image
-FROM alpine:3.15
+FROM alpine:3.16
 LABEL maintainer="Shaarli Community"
 
 RUN apk --update --no-cache add \

--- a/Dockerfile.armhf
+++ b/Dockerfile.armhf
@@ -1,7 +1,7 @@
 # Stage 1:
 # - Copy Shaarli sources
 # - Build documentation
-FROM arm32v6/alpine:3.10 as docs
+FROM arm32v6/alpine:3.16 as docs
 ADD . /usr/src/app/shaarli
 RUN apk --update --no-cache add py2-pip \
     && cd /usr/src/app/shaarli \
@@ -10,7 +10,7 @@ RUN apk --update --no-cache add py2-pip \
 
 # Stage 2:
 # - Resolve PHP dependencies with Composer
-FROM arm32v6/alpine:3.10 as composer
+FROM arm32v6/alpine:3.16 as composer
 COPY --from=docs /usr/src/app/shaarli /app/shaarli
 RUN apk --update --no-cache add php7-curl php7-mbstring php7-simplexml composer \
     && cd /app/shaarli \
@@ -18,7 +18,7 @@ RUN apk --update --no-cache add php7-curl php7-mbstring php7-simplexml composer 
 
 # Stage 3:
 # - Frontend dependencies
-FROM arm32v6/alpine:3.10 as node
+FROM arm32v6/alpine:3.16 as node
 COPY --from=composer /app/shaarli /shaarli
 RUN apk --update --no-cache add yarn nodejs-current python2 build-base \
     && cd /shaarli \
@@ -28,7 +28,7 @@ RUN apk --update --no-cache add yarn nodejs-current python2 build-base \
 
 # Stage 4:
 # - Shaarli image
-FROM arm32v6/alpine:3.10
+FROM arm32v6/alpine:3.16
 LABEL maintainer="Shaarli Community"
 
 RUN apk --update --no-cache add \

--- a/doc/md/dev/Unit-tests.md
+++ b/doc/md/dev/Unit-tests.md
@@ -100,7 +100,7 @@ Unit tests can be run inside [Docker](../Docker.md) containers.
 
 Test Dockerfiles are located under `tests/docker/<distribution>/Dockerfile`, and can be used to build Docker images to run Shaarli test suites under commonLinux environments. Dockerfiles are provided for the following environments:
 
-- [`alpine36`](https://github.com/shaarli/Shaarli/blob/master/tests/docker/alpine36/Dockerfile) - [Alpine Linux 3.6](https://www.alpinelinux.org/downloads/)
+- [`alpine316`](https://github.com/shaarli/Shaarli/blob/master/tests/docker/alpine36/Dockerfile) - [Alpine Linux 3.16](https://www.alpinelinux.org/downloads/)
 - [`debian8`](https://github.com/shaarli/Shaarli/blob/master/tests/docker/debian8/Dockerfile) - [Debian 8 Jessie](https://www.debian.org/DebianJessie) (oldoldstable)
 - [`debian9`](https://github.com/shaarli/Shaarli/blob/master/tests/docker/debian9/Dockerfile) - [Debian 9 Stretch](https://wiki.debian.org/DebianStretch) (oldstable)
 - [`ubuntu16`](https://github.com/shaarli/Shaarli/blob/master/tests/docker/ubuntu16/Dockerfile) - [Ubuntu 16.04 Xenial Xerus](http://releases.ubuntu.com/16.04/) (old LTS)

--- a/tests/docker/alpine316/Dockerfile
+++ b/tests/docker/alpine316/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.6
+FROM alpine:3.16
 MAINTAINER Shaarli Community
 
 RUN apk --update --no-cache add \


### PR DESCRIPTION
- https://hub.docker.com/_/alpine
- https://hub.docker.com/r/arm32v6/alpine/
- related https://github.com/shaarli/Shaarli/issues/1757
- related https://github.com/shaarli/Shaarli/issues/1855