### PR TITLE
Fix translate Makefile target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -165,7 +165,13 @@ htmldoc:
 
 ### Generate Shaarli's translation compiled file (.mo)
 translate:
-	@for pofile in $(find inc/languages/ -name shaarli.po); do msgfmt "$pofile" -o "$(dirname "$pofile")/$(basename "$pofile" .po).mo"; done
+	@echo "----------------------"
+	@echo "Compile translation files"
+	@echo "----------------------"
+	@for pofile in `find inc/languages/ -name shaarli.po`; do \
+		echo "Compiling $$pofile"; \
+		msgfmt -v "$$pofile" -o "`dirname "$$pofile"`/`basename "$$pofile" .po`.mo"; \
+	done;
 
 ### Run ESLint check against Shaarli's JS files
 eslint:


### PR DESCRIPTION
The syntax was invalid and this target was not actually doing anything (it probably worked at some point in another context).

This change make sure that the .mo files are properly generated, even in unit tests context and fixes #1893