### PR TITLE
Add an additional free disk space check before saving the datastore

### DIFF
--- a/application/bookmark/exception/InvalidWritableDataException.php
+++ b/application/bookmark/exception/InvalidWritableDataException.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Shaarli\Bookmark\Exception;
+
+class InvalidWritableDataException extends \Exception
+{
+    /**
+     * InvalidWritableDataException constructor.
+     */
+    public function __construct()
+    {
+        $this->message = 'Couldn\'t generate bookmark data to store in the datastore. Skipping file writing.';
+    }
+}

--- a/application/bookmark/exception/NotEnoughSpaceException.php
+++ b/application/bookmark/exception/NotEnoughSpaceException.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Shaarli\Bookmark\Exception;
+
+class NotEnoughSpaceException extends \Exception
+{
+    /**
+     * NotEnoughSpaceException constructor.
+     */
+    public function __construct()
+    {
+        $this->message = 'Not enough available disk space to save the datastore.';
+    }
+}


### PR DESCRIPTION
On every disk write operation, we check the available free disk space (+ slight marging of arbitrary 500kB), and if there is not enough space we do not attempt to write anything.

This should prevent most case of corrupted datastore becoming an empty file due to full HDD.

Fixes #1810