### PR TITLE
Fix PHP 8 incompatibility with debug mode enabled

### DIFF
--- a/index.php
+++ b/index.php
@@ -48,7 +48,12 @@ if ($conf->get('dev.debug', false)) {
     // See all errors (for debugging only)
     error_reporting(-1);
 
-    set_error_handler(function ($errno, $errstr, $errfile, $errline, array $errcontext) {
+    set_error_handler(function ($errno, $errstr, $errfile, $errline, array $errcontext = []) {
+        // Skip PHP 8 deprecation warning with Pimple.
+        if (strpos($errfile, 'src/Pimple/Container.php') !== -1 && strpos($errstr, 'ArrayAccess::') !== -1) {
+            return error_log($errstr);
+        }
+
         throw new ErrorException($errstr, 0, $errno, $errfile, $errline);
     });
 }


### PR DESCRIPTION
One parameter has been removed from set_error_handler. 
Also, there is a warning triggered on every page with a Pimple incompatibility.