### PR TITLE
Fix ReadItLater checkbox label on bulk add

### DIFF
--- a/plugins/readitlater/readitlater.php
+++ b/plugins/readitlater/readitlater.php
@@ -65,8 +65,11 @@ function hook_readitlater_render_editlink(array $data, ConfigManager $conf): arr
     // Load HTML into a string
     $html = file_get_contents(PluginManager::$PLUGINS_PATH . '/readitlater/readitlater_editlink.html');
 
+    // Random ID for batch shaare (multiple inputs on the same page)
+    $random = uniqid();
+
      // Replace value in HTML if it exists in $data
-    $html = sprintf($html, $default ? 'checked' : '');
+    $html = sprintf($html, $random, $default ? 'checked' : '', $random);
 
     // field_plugin
     $data['edit_link_plugin'][] = $html;

--- a/plugins/readitlater/readitlater_editlink.html
+++ b/plugins/readitlater/readitlater_editlink.html
@@ -1,1 +1,1 @@
-<input type="checkbox" name="readitlater" id="readitlater" %s /><label for="readitlater"> Read it later</label><br>
+<input type="checkbox" name="readitlater" id="readitlater_%s" %s /><label for="readitlater_%s"> Read it later</label><br>

--- a/tests/plugins/PluginReadItLaterTest.php
+++ b/tests/plugins/PluginReadItLaterTest.php
@@ -278,7 +278,7 @@ class PluginQrcodeTest extends TestCase
         ];
         $data = hook_readitlater_render_editlink($originalData, $this->confDefaultTheme);
 
-        static::assertMatchesRegularExpression(
+        static::assertRegExp(
             '#<input type="checkbox" name="readitlater" id="readitlater_[a-z0-9]+"  />#',
             $data['edit_link_plugin'][0]
         );
@@ -288,7 +288,7 @@ class PluginQrcodeTest extends TestCase
 
         $data = hook_readitlater_render_editlink($originalData, $this->confDefaultTheme);
 
-        static::assertMatchesRegularExpression(
+        static::assertRegExp(
             '#<input type="checkbox" name="readitlater" id="readitlater_[a-z0-9]+"  />#',
             $data['edit_link_plugin'][0]
         );
@@ -307,7 +307,7 @@ class PluginQrcodeTest extends TestCase
         ];
         $data = hook_readitlater_render_editlink($originalData, $this->confDefaultTheme);
 
-        static::assertMatchesRegularExpression(
+        static::assertRegExp(
             '#<input type="checkbox" name="readitlater" id="readitlater_[a-z0-9]+" checked />#',
             $data['edit_link_plugin'][0]
         );

--- a/tests/plugins/PluginReadItLaterTest.php
+++ b/tests/plugins/PluginReadItLaterTest.php
@@ -278,8 +278,8 @@ class PluginQrcodeTest extends TestCase
         ];
         $data = hook_readitlater_render_editlink($originalData, $this->confDefaultTheme);
 
-        static::assertContainsPolyfill(
-            '<input type="checkbox" name="readitlater" id="readitlater"  />',
+        static::assertMatchesRegularExpression(
+            '#<input type="checkbox" name="readitlater" id="readitlater_[a-z0-9]+"  />#',
             $data['edit_link_plugin'][0]
         );
 
@@ -288,8 +288,8 @@ class PluginQrcodeTest extends TestCase
 
         $data = hook_readitlater_render_editlink($originalData, $this->confDefaultTheme);
 
-        static::assertContainsPolyfill(
-            '<input type="checkbox" name="readitlater" id="readitlater"  />',
+        static::assertMatchesRegularExpression(
+            '#<input type="checkbox" name="readitlater" id="readitlater_[a-z0-9]+"  />#',
             $data['edit_link_plugin'][0]
         );
     }
@@ -307,8 +307,8 @@ class PluginQrcodeTest extends TestCase
         ];
         $data = hook_readitlater_render_editlink($originalData, $this->confDefaultTheme);
 
-        static::assertContainsPolyfill(
-            '<input type="checkbox" name="readitlater" id="readitlater" checked />',
+        static::assertMatchesRegularExpression(
+            '#<input type="checkbox" name="readitlater" id="readitlater_[a-z0-9]+" checked />#',
             $data['edit_link_plugin'][0]
         );
     }


### PR DESCRIPTION
Adds a random string to the HTML ID so it can be unique in batch more, where there are multiple checkboxes in the same form.