### PR TITLE
Ensure tags are unique when adding and deleting them from bookmarks.

### DIFF
--- a/application/bookmark/Bookmark.php
+++ b/application/bookmark/Bookmark.php
@@ -524,7 +524,7 @@ class Bookmark
      */
     public function addTag(string $tag): self
     {
-        return $this->setTags(array_merge($this->getTags(), [$tag]));
+        return $this->setTags(array_unique(array_merge($this->getTags(), [$tag])));
     }
 
     /**
@@ -534,7 +534,7 @@ class Bookmark
      */
     public function deleteTag(string $tag): void
     {
-        if (($pos = array_search($tag, $this->tags ?? [])) !== false) {
+        while (($pos = array_search($tag, $this->tags ?? [])) !== false) {
             unset($this->tags[$pos]);
             $this->tags = array_values($this->tags);
         }

--- a/tests/bookmark/BookmarkTest.php
+++ b/tests/bookmark/BookmarkTest.php
@@ -263,6 +263,63 @@ class BookmarkTest extends TestCase
     }
 
     /**
+     * Test addTag() and DeleteTag() 
+     */
+
+    public function testAddDeleteTags()
+    {
+        $bookmark = new Bookmark();
+
+        $bookmark->addTag('tag1');
+        $this->assertEquals(
+            [
+                'tag1',
+            ],
+            $bookmark->getTags()
+        );
+
+        // Ignore if tag is already present
+        $bookmark->addTag('tag2');
+        $bookmark->addTag('tag1');
+        $this->assertEquals(
+            [
+                'tag1',
+                'tag2',
+            ],
+            $bookmark->getTags()
+        );
+
+        // Ignore deleting tags not present
+        $bookmark->deleteTag('tag5');
+        $this->assertEquals(
+            [
+                'tag1',
+                'tag2',
+            ],
+            $bookmark->getTags()
+        );
+
+        // Delete multiples
+        $bookmark->setTags( ['tag3', 'tag1', 'tag4', 'tag3', 'tag3', 'tag4'] );
+        $bookmark->deleteTag( 'tag3' );
+        $this->assertEquals(
+            [
+                'tag1',
+                'tag4',
+                'tag4',
+            ],
+            $bookmark->getTags()
+        );
+        $bookmark->deleteTag( 'tag4' );
+        $this->assertEquals(
+            [
+                'tag1',
+            ],
+            $bookmark->getTags()
+        );
+    }
+
+    /**
      * Test setTagsString() with exotic data
      */
     public function testSetTagsString()

--- a/tests/bookmark/BookmarkTest.php
+++ b/tests/bookmark/BookmarkTest.php
@@ -263,7 +263,7 @@ class BookmarkTest extends TestCase
     }
 
     /**
-     * Test addTag() and DeleteTag() 
+     * Test addTag() and DeleteTag()
      */
 
     public function testAddDeleteTags()
@@ -300,8 +300,8 @@ class BookmarkTest extends TestCase
         );
 
         // Delete multiples
-        $bookmark->setTags( ['tag3', 'tag1', 'tag4', 'tag3', 'tag3', 'tag4'] );
-        $bookmark->deleteTag( 'tag3' );
+        $bookmark->setTags(['tag3', 'tag1', 'tag4', 'tag3', 'tag3', 'tag4']);
+        $bookmark->deleteTag('tag3');
         $this->assertEquals(
             [
                 'tag1',
@@ -310,7 +310,7 @@ class BookmarkTest extends TestCase
             ],
             $bookmark->getTags()
         );
-        $bookmark->deleteTag( 'tag4' );
+        $bookmark->deleteTag('tag4');
         $this->assertEquals(
             [
                 'tag1',


### PR DESCRIPTION
I didn't see any issues relating to this, but shouldn't tags be unique? The new feature to bulk add tags is great, but I don't want to accidently add a tag twice if I select a shaare that already includes the tag.