### PR TITLE
docker: latest: replace dev in shaarli_version.php with the latest commit hash

### DIFF
--- a/.github/workflows/docker-latest.yml
+++ b/.github/workflows/docker-latest.yml
@@ -16,18 +16,24 @@ jobs:
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
-      -
-        name: Login to GitHub Container Registry
+      - name: Login to GitHub Container Registry
         uses: docker/login-action@v2
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Set shaarli version to the latest commit hash
+        run: sed -i "s/dev/$(git rev-parse --short HEAD)/" shaarli_version.php
+
       - name: Build and push
         id: docker_build
         uses: docker/build-push-action@v3
         with:
+          context: .
           push: true
           tags: |
             shaarli/shaarli:latest


### PR DESCRIPTION
- fixes https://github.com/shaarli/Shaarli/issues/1676
- second commit reverts changes used for testing/verifying the version string replacement
- testing was successful using `docker run --entrypoint /bin/cat nodiscc/shaarli:latest shaarli/shaarli_version.php` (returns `<?php /* c4a5ef5 */ ?>`)