### PR TITLE
doc: move OCI images hosting to ghcr.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,15 +7,12 @@ _Shaarli is a minimalist link sharing service that you can install on your own s
 _It is designed to be personal (single-user), fast and handy._
 
 [![](https://img.shields.io/badge/stable-v0.11.1-blue.svg)](https://github.com/shaarli/Shaarli/releases/tag/v0.11.1)
-&bull;
 [![](https://img.shields.io/badge/latest-v0.12.1-blue.svg)](https://github.com/shaarli/Shaarli/releases/tag/v0.12.1)
-&bull;
 [![](https://img.shields.io/badge/master-v0.12.x-blue.svg)](https://github.com/shaarli/Shaarli)
 [![](https://github.com/shaarli/Shaarli/actions/workflows/ci.yml/badge.svg)](https://github.com/shaarli/Shaarli/actions)
-
 [![Join the chat at https://gitter.im/shaarli/Shaarli](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/shaarli/Shaarli)
 [![Bountysource](https://www.bountysource.com/badge/team?team_id=19583&style=bounties_received)](https://www.bountysource.com/teams/shaarli/issues)
-[![Docker repository](https://img.shields.io/docker/pulls/shaarli/shaarli.svg)](https://hub.docker.com/r/shaarli/shaarli/)
+[![Docker repository](https://img.shields.io/docker/pulls/shaarli/shaarli.svg)](https://github.com/shaarli/Shaarli/pkgs/container/shaarli)
 
 ## Quickstart
 

--- a/doc/md/Docker.md
+++ b/doc/md/Docker.md
@@ -39,14 +39,14 @@ docker run hello-world
 
 ## Get and run a Shaarli image
 
-Shaarli images are available on [DockerHub](https://hub.docker.com/r/shaarli/shaarli/) `shaarli/shaarli`:
+Shaarli images are available on [GitHub Container Registry](https://github.com/shaarli/Shaarli/pkgs/container/shaarli) `ghcr.io/shaarli/shaarli`:
 
 - `latest`: master (development) branch
 - `vX.Y.Z`: shaarli [releases](https://github.com/shaarli/Shaarli/releases)
 - `release`: always points to the last release
 - `stable` and `master`: **deprecated**. These tags are no longer maintained and may be removed without notice
 
-These images are built automatically on DockerHub and rely on:
+These images are built automatically on Github Actions and rely on:
 
 - [Alpine Linux](https://www.alpinelinux.org/)
 - [PHP7-FPM](http://php-fpm.org/)
@@ -57,8 +57,8 @@ Additional Dockerfiles are provided for the `arm32v7` platform, relying on [Linu
 Here is an example of how to run Shaarli latest image using Docker:
 
 ```bash
-# download the 'latest' image from dockerhub
-docker pull shaarli/shaarli
+# download the 'latest' image from GitHub Container Registry
+docker pull ghcr.io/shaarli/shaarli
 
 # create persistent data volumes/directories on the host
 docker volume create shaarli-data
@@ -76,7 +76,7 @@ docker run --detach \
            --rm \
            --volume shaarli-data:/var/www/shaarli/data \
            --volume shaarli-cache:/var/www/shaarli/cache \
-           shaarli/shaarli:latest
+           ghcr.io/shaarli/shaarli:latest
 
 # verify that the container is running
 docker ps | grep myshaarli
@@ -118,7 +118,7 @@ $ curl -L https://raw.githubusercontent.com/shaarli/Shaarli/latest/docker-compos
 # (replace <shaarli.mydomain.org>, <admin@mydomain.org> and <latest> with your actual information)
 $ echo 'SHAARLI_VIRTUAL_HOST=shaarli.mydomain.org' > .env
 $ echo 'SHAARLI_LETSENCRYPT_EMAIL=admin@mydomain.org' >> .env
-# Available Docker tags can be found at https://hub.docker.com/r/shaarli/shaarli/tags
+# Available Docker tags can be found at https://github.com/shaarli/Shaarli/pkgs/container/shaarli/versions?filters%5Bversion_type%5D=tagged
 $ echo 'SHAARLI_DOCKER_TAG=latest' >> .env
 # Pull the Docker images
 $ docker-compose pull
@@ -154,7 +154,7 @@ ExecStart=/usr/bin/docker run \
   --hostname shaarli.${domainname} \
   -v /srv/docker-volumes-local/shaarli-data:/var/www/shaarli/data:rw \
   -v /etc/localtime:/etc/localtime:ro \
-  shaarli/shaarli:latest
+  ghcr.io/shaarli/shaarli:latest
 
 ExecStop=/usr/bin/docker rm -f ${hostname}-shaarli
 
@@ -179,9 +179,9 @@ journalctl -f
 
 ```bash
 # pull/update an image
-$ docker pull shaarli/shaarli:release
+$ docker pull ghcr.io/shaarli/shaarli:release
 # run a container from an image
-$ docker run shaarli/shaarli:latest
+$ docker run ghcr.io/shaarli/shaarli:latest
 # list available images
 $ docker images ls
 # list running containers
@@ -206,16 +206,15 @@ $ docker system prune
 - [Docker: using volumes](https://docs.docker.com/storage/volumes/)
 - [Dockerfile best practices](https://docs.docker.com/articles/dockerfile_best-practices/)
 - [Dockerfile reference](https://docs.docker.com/reference/builder/)
-- [DockerHub: GitHub automated build](https://docs.docker.com/docker-hub/github/)
-- [DockerHub: Repositories](https://docs.docker.com/userguide/dockerrepos/)
-- [DockerHub: Teams and organizations](https://docs.docker.com/docker-hub/orgs/)
+- [GitHub Container Registry](https://github.com/features/packages)
+- [GithHub Packages documentation](https://docs.github.com/en/packages)
+- [DockerHub: Teams and organizations](https://docs.docker.com/docker-hub/orgs/), [End of Docker free teams](https://www.docker.com/blog/we-apologize-we-did-a-terrible-job-announcing-the-end-of-docker-free-teams/)
 - [Get Docker CE for Debian](https://docs.docker.com/install/linux/docker-ce/debian/)
 - [Install Docker Compose](https://docs.docker.com/compose/install/)
 - [Interactive Docker training portal](https://www.katacoda.com/courses/docker/) on [Katakoda](https://www.katacoda.com/)
 - [Service management: Nginx in the foreground](http://nginx.org/en/docs/ngx_core_module.html#daemon)
 - [Service management: Using supervisord](https://docs.docker.com/articles/using_supervisord/)
 - [Volumes](https://docs.docker.com/storage/volumes/)
-- [Volumes](https://docs.docker.com/userguide/dockervolumes/)
 - [Where are Docker images stored?](http://blog.thoward37.me/articles/where-are-docker-images-stored/)
 - [docker create](https://docs.docker.com/engine/reference/commandline/create/)
 - [Docker Documentation](https://docs.docker.com/)

--- a/doc/md/dev/Development.md
+++ b/doc/md/dev/Development.md
@@ -154,7 +154,7 @@ After all jobs have finished, Github Actions returns the results to GitHub:
 - a status icon represents the result for the `master` branch: [![Build Status](https://github.com/shaarli/Shaarli/actions/workflows/ci.yml/badge.svg)](https://github.com/shaarli/Shaarli/actions)
 - Pull Requests are updated with the Github Actions build result.
 
-Github Actions is also used to build and push [Docker](../Docker.md) images to <https://hub.docker.com/r/shaarli/shaarli> for the `master` branch and on every git `tag`/[release](https://github.com/shaarli/Shaarli/releases).
+Github Actions is also used to build and push [Docker](../Docker.md) images to <https://github.com/shaarli/Shaarli/pkgs/container/shaarli> for the `master` branch and on every git `tag`/[release](https://github.com/shaarli/Shaarli/releases).
 
 See [`.github/workflows/`](https://github.com/shaarli/Shaarli/tree/master/.github/workflows).
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,7 +8,7 @@
 # - SHAARLI_VIRTUAL_HOST      Fully Qualified Domain Name for the Shaarli instance
 # - SHAARLI_LETSENCRYPT_EMAIL Contact email for certificate renewal
 # - SHAARLI_DOCKER_TAG        Shaarli docker tag to use
-#                             See: https://hub.docker.com/r/shaarli/shaarli/tags
+#                             See: https://github.com/shaarli/Shaarli/pkgs/container/shaarli/versions?filters%5Bversion_type%5D=tagged
 version: '3'
 
 networks:
@@ -21,7 +21,7 @@ volumes:
 
 services:
   shaarli:
-    image: shaarli/shaarli:${SHAARLI_DOCKER_TAG}
+    image: ghcr.io/shaarli/shaarli:${SHAARLI_DOCKER_TAG}
     build: ./
     networks:
       - http-proxy


### PR DESCRIPTION
- dockerhub free team accounts will be deleted in < 30 days (https://www.docker.com/blog/we-apologize-we-did-a-terrible-job-announcing-the-end-of-docker-free-teams/), this affects the Shaarli team account
- automated builds will keep pushing latest builds to dockerhub in addition to gchr.io, until the account is deleted
- **users relying on `shaarli/shaarli` OCI images are advised to migrate to `ghcr.io/shaarli/shaarli` as soon as possible**
- existing tagged images have been copied from https://hub.docker.com/r/shaarli/shaarli/ to https://github.com/shaarli/Shaarli/pkgs/container/shaarli/versions?filters%5Bversion_type%5D=tagged
- prepend `ghcr.io/` to all references to OCI images
- update all references to dockerhub -> github packages registry, update developer documentation, cleanup dead links
- ref. https://github.com/shaarli/Shaarli/issues/1948