### PR TITLE
Do not display deprecated warnings by default

### DIFF
--- a/init.php
+++ b/init.php
@@ -20,7 +20,7 @@ ini_set('post_max_size', '16M');
 ini_set('upload_max_filesize', '16M');
 
 // See all error except warnings
-error_reporting(E_ALL^E_WARNING);
+error_reporting(E_ALL & ~E_WARNING & ~E_DEPRECATED);
 
 // 3rd-party libraries
 if (! file_exists(__DIR__ . '/vendor/autoload.php')) {


### PR DESCRIPTION
There are a bunch of deprecation warnings that seem to be displayed by default.
They are still displayed in debug mode.

Related to #1935