### PR TITLE
Fix a bug when using '/' as a tag separator

### DIFF
--- a/application/bookmark/LinkUtils.php
+++ b/application/bookmark/LinkUtils.php
@@ -217,9 +217,9 @@ function is_note($linkUrl)
 function tags_str2array(?string $tags, string $separator): array
 {
     // For whitespaces, we use the special \s regex character
-    $separator = $separator === ' ' ? '\s' : $separator;
+    $separator = str_replace([' ', '/'], ['\s', '\/'], $separator);
 
-    return preg_split('/\s*' . $separator . '+\s*/', trim($tags ?? ''), -1, PREG_SPLIT_NO_EMPTY);
+    return preg_split('/\s*' . $separator . '+\s*/', trim($tags ?? ''), -1, PREG_SPLIT_NO_EMPTY) ?: [];
 }
 
 /**

--- a/tests/bookmark/LinkUtilsTest.php
+++ b/tests/bookmark/LinkUtilsTest.php
@@ -653,6 +653,25 @@ class LinkUtilsTest extends TestCase
     }
 
     /**
+     * Test tags_str2array with / separator.
+     */
+    public function testTagsStr2ArrayWithRegexDelimiterSeparator(): void
+    {
+        $separator = '/';
+
+        static::assertSame(['tag1', 'tag2', 'tag3'], tags_str2array('tag1/tag2/tag3', $separator));
+        static::assertSame(['tag1', 'tag2', 'tag3'], tags_str2array('tag1////tag2////tag3', $separator));
+        static::assertSame(['tag1', 'tag2', 'tag3'], tags_str2array('///tag1///tag2////tag3//', $separator));
+        static::assertSame(
+            ['tag1#', 'tag2, and other', '.tag3'],
+            tags_str2array('///   tag1#     /// tag2, and other ////.tag3//', $separator)
+        );
+        static::assertSame([], tags_str2array('', $separator));
+        static::assertSame([], tags_str2array('   ', $separator));
+        static::assertSame([], tags_str2array(null, $separator));
+    }
+
+    /**
      * Test tags_array2str with ' ' separator.
      */
     public function testTagsArray2StrWithSpaceSeparator(): void


### PR DESCRIPTION
Also in case of any other regex error, just return an empty array instead of a fatal error.

Fixes #1944