### PR TITLE
Fix Logger exception: gracefully handle permission issue

### DIFF
--- a/index.php
+++ b/index.php
@@ -59,7 +59,7 @@ if ($conf->get('dev.debug', false)) {
 }
 
 $logger = new Logger(
-    dirname($conf->get('resource.log')),
+    is_writable($conf->get('resource.log')) ? dirname($conf->get('resource.log')) : 'php://temp',
     !$conf->get('dev.debug') ? LogLevel::INFO : LogLevel::DEBUG,
     ['filename' => basename($conf->get('resource.log'))]
 );


### PR DESCRIPTION
If the log file is not writable, create a LoggerInterface instance writing in php://temp instead of getting the library to throw an exception and land in a fatal error. In case of a new installation, the permission issue will be displayed along with the server requirements.

Fixes #1904