### PR TITLE
Rename authors makefile target to avoid conflicts with filename

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -143,7 +143,7 @@ clean:
 	@rm -rf sandbox
 
 ### generate the AUTHORS file from Git commit information
-authors:
+generate_authors:
 	@cp .github/mailmap .mailmap
 	@git shortlog -sne > AUTHORS
 	@rm .mailmap

--- a/doc/md/dev/Release-Shaarli.md
+++ b/doc/md/dev/Release-Shaarli.md
@@ -46,7 +46,7 @@ GitHub allows drafting the release notes for the upcoming release, from the [Rel
 ## Update the list of Git contributors
 
 ```bash
-$ make authors
+$ make generate_authors
 $ git commit -s -m "Update AUTHORS"
 ```
 


### PR DESCRIPTION
It's not possible to have a make target with the same name as an existing file in the folder.
https://stackoverflow.com/questions/3931741/why-does-make-think-the-target-is-up-to-date

And there is an `AUTHORS` file, which conflicts if the file system is not case-sensitive (e.g. default mode of APFS).