### PR TITLE
Makefile: Use GNU tar if available

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,6 +24,13 @@ docker_%:
 ##
 PHPCS := $(BIN)/phpcs
 
+# Use GNU Tar where available
+ifneq (, $(shell which gtar))
+TAR := gtar
+else
+TAR := tar
+endif
+
 code_sniffer:
 	@$(PHPCS)
 
@@ -115,9 +122,9 @@ build_frontend: frontend_dependencies
 ### generate a release tarball and include 3rd-party dependencies and translations
 release_tar: composer_dependencies htmldoc translate build_frontend
 	git archive --prefix=$(ARCHIVE_PREFIX) -o $(ARCHIVE_VERSION).tar HEAD
-	tar rvf $(ARCHIVE_VERSION).tar --transform "s|^vendor|$(ARCHIVE_PREFIX)vendor|" vendor/
-	tar rvf $(ARCHIVE_VERSION).tar --transform "s|^doc/html|$(ARCHIVE_PREFIX)doc/html|" doc/html/
-	tar rvf $(ARCHIVE_VERSION).tar --transform "s|^tpl|$(ARCHIVE_PREFIX)tpl|" tpl/
+	$(TAR) rvf $(ARCHIVE_VERSION).tar --transform "s|^vendor|$(ARCHIVE_PREFIX)vendor|" vendor/
+	$(TAR) rvf $(ARCHIVE_VERSION).tar --transform "s|^doc/html|$(ARCHIVE_PREFIX)doc/html|" doc/html/
+	$(TAR) rvf $(ARCHIVE_VERSION).tar --transform "s|^tpl|$(ARCHIVE_PREFIX)tpl|" tpl/
 	gzip $(ARCHIVE_VERSION).tar
 
 ### generate a release zip and include 3rd-party dependencies and translations

--- a/doc/md/dev/Release-Shaarli.md
+++ b/doc/md/dev/Release-Shaarli.md
@@ -14,6 +14,7 @@ This guide assumes that you have:
     - create a new release
 - [Composer](https://getcomposer.org/) needs to be installed
 - The [venv](https://docs.python.org/3/library/venv.html) Python 3 module needs to be installed for HTML documentation generation.
+- Make sure you have GNU `tar` installed (not BSD `tar`). On macOS, you can install it with `brew install gnu-tar`.
 
 ## Release notes and `CHANGELOG.md`
 


### PR DESCRIPTION
On MacOS, default tar installation is BSD tar which does not support `--transform` flag used in our Makefile.