### PR TITLE
Support: ignore disk_free_space if the function is unavailable

### DIFF
--- a/application/bookmark/BookmarkIO.php
+++ b/application/bookmark/BookmarkIO.php
@@ -168,6 +168,10 @@ class BookmarkIO
      */
     public function checkDiskSpace(string $data): bool
     {
+        if (function_exists('disk_free_space') === false) {
+            return true;
+        }
+
         return disk_free_space(dirname($this->datastore)) > (strlen($data) + 1024 * 500);
     }
 }


### PR DESCRIPTION
Some shared hosting providers are disabling this function.

Fixes #1968