### PR TITLE
tools: run trivy vulnerability scanner on the 'latest' docker image

### DIFF
--- a/.github/workflows/docker-latest.yml
+++ b/.github/workflows/docker-latest.yml
@@ -1,7 +1,7 @@
 name: Build/push Docker image (master/latest)
 on:
   push:
-    branches: [ master ]
+    branches: [ master, trivy ]
 jobs:
   docker-build:
     runs-on: ubuntu-latest
@@ -11,11 +11,11 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
 
-      - name: Login to DockerHub
-        uses: docker/login-action@v2
-        with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      # - name: Login to DockerHub
+      #   uses: docker/login-action@v2
+      #   with:
+      #     username: ${{ secrets.DOCKERHUB_USERNAME }}
+      #     password: ${{ secrets.DOCKERHUB_TOKEN }}
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v2
         with:
@@ -35,9 +35,11 @@ jobs:
         with:
           context: .
           push: true
-          platforms: linux/amd64,linux/arm64,linux/arm/v7
-          tags: |
-            ${{ secrets.DOCKER_IMAGE }}:latest
-            ghcr.io/${{ secrets.DOCKER_IMAGE }}:latest
+          # tags: |
+          #   ${{ secrets.DOCKER_IMAGE }}:trivy
+          #   ghcr.io/${{ secrets.DOCKER_IMAGE }}:trivy
+          tags: ghcr.io/${{ secrets.DOCKER_IMAGE }}:trivy
       - name: Image digest
         run: echo ${{ steps.docker_build.outputs.digest }}
+      - name: Run trivy image scanner
+        run: make test_trivy TRIVY_TARGET_DOCKER_IMAGE=ghcr.io/${{ secrets.DOCKER_IMAGE }}:trivy

--- a/.github/workflows/docker-latest.yml
+++ b/.github/workflows/docker-latest.yml
@@ -1,7 +1,7 @@
 name: Build/push Docker image (master/latest)
 on:
   push:
-    branches: [ master, trivy ]
+    branches: [ master ]
 jobs:
   docker-build:
     runs-on: ubuntu-latest
@@ -11,11 +11,11 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
 
-      # - name: Login to DockerHub
-      #   uses: docker/login-action@v2
-      #   with:
-      #     username: ${{ secrets.DOCKERHUB_USERNAME }}
-      #     password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - name: Login to DockerHub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v2
         with:
@@ -35,10 +35,10 @@ jobs:
         with:
           context: .
           push: true
-          # tags: |
-          #   ${{ secrets.DOCKER_IMAGE }}:trivy
-          #   ghcr.io/${{ secrets.DOCKER_IMAGE }}:trivy
-          tags: ghcr.io/${{ secrets.DOCKER_IMAGE }}:trivy
+          platforms: linux/amd64,linux/arm64,linux/arm/v7
+          tags: |
+            ${{ secrets.DOCKER_IMAGE }}:latest
+            ghcr.io/${{ secrets.DOCKER_IMAGE }}:latest
       - name: Image digest
         run: echo ${{ steps.docker_build.outputs.digest }}
       - name: Run trivy image scanner

--- a/Makefile
+++ b/Makefile
@@ -82,6 +82,15 @@ locale_test_%:
 		--bootstrap tests/languages/bootstrap.php \
 		--testsuite language-$(firstword $(subst _, ,$*))
 
+# trivy version (https://github.com/aquasecurity/trivy/releases)
+TRIVY_VERSION=0.39.0
+# default docker image to scan with trivy
+TRIVY_TARGET_DOCKER_IMAGE=ghcr.io/shaarli/shaarli:latest
+test_trivy:
+	wget --quiet --continue -O trivy_$(TRIVY_VERSION)_Linux-64bit.tar.gz https://github.com/aquasecurity/trivy/releases/download/v$(TRIVY_VERSION)/trivy_$(TRIVY_VERSION)_Linux-64bit.tar.gz
+	tar -zxf trivy_$(TRIVY_VERSION)_Linux-64bit.tar.gz
+	./trivy image $(TRIVY_TARGET_DOCKER_IMAGE)
+
 all_tests: test locale_test_de_DE locale_test_en_US locale_test_fr_FR
 	@# --The current version is not compatible with PHP 7.2
 	@#$(BIN)/phpcov merge --html coverage coverage


### PR DESCRIPTION
- run trivy from makefile so that it can be run both locally and through github actions
- usage: `make test_trivy TRIVY_TARGET_DOCKER_IMAGE=regist.ry/user/image:tag`
- tested by downgrading the base image to alpine 3.15.7 and verifying that vulnerabilities are reported (https://github.com/nodiscc/Shaarli/actions/runs/4860040980/jobs/8663400103)
- ref. https://github.com/shaarli/Shaarli/issues/1531