### PR TITLE
docker: nginx: listen on IPv6 in addition to IPv4

### DIFF
--- a/.docker/nginx.conf
+++ b/.docker/nginx.conf
@@ -18,6 +18,7 @@ http {
 
     server {
         listen      80;
+        listen      [::]:80;
         root        /var/www/shaarli;
 
         access_log  /var/log/nginx/shaarli.access.log;


### PR DESCRIPTION
A very small patch to have Shaarli's container nginx listen on IPv6 addresses as well as IPv4 addresses; this lets it run happily on IPv6-native clusters/networks/etc. and shouldn't impair IPv4 usage.

A test container (that I'm running now) is available at _cerebrate/shaarli:v6test_ .
