### PR TITLE
gihub actions: fix value of TRIVY_TARGET_DOCKER_IMAGE

### DIFF
--- a/.github/workflows/docker-latest.yml
+++ b/.github/workflows/docker-latest.yml
@@ -42,4 +42,4 @@ jobs:
       - name: Image digest
         run: echo ${{ steps.docker_build.outputs.digest }}
       - name: Run trivy image scanner
-        run: make test_trivy TRIVY_TARGET_DOCKER_IMAGE=ghcr.io/${{ secrets.DOCKER_IMAGE }}:trivy
+        run: make test_trivy TRIVY_TARGET_DOCKER_IMAGE=ghcr.io/${{ secrets.DOCKER_IMAGE }}:latest


### PR DESCRIPTION
- fixes Error response from daemon: no such image: ghcr.io/***:trivy: No such image: ghcr.io/***:trivy
- introduced in https://github.com/shaarli/Shaarli/pull/1980 but the test target branch/tag was never reverted to 'latest'