### PR TITLE
Expose tags_separator config through /info API

### DIFF
--- a/application/api/controllers/Info.php
+++ b/application/api/controllers/Info.php
@@ -35,6 +35,7 @@ class Info extends ApiController
                 'timezone' => $this->conf->get('general.timezone', 'UTC'),
                 'enabled_plugins' => $this->conf->get('general.enabled_plugins', []),
                 'default_private_links' => $this->conf->get('privacy.default_private_links', false),
+                'tags_separator' => $this->conf->get('general.tags_separator', ' '),
             ],
         ];
 


### PR DESCRIPTION
Expose the value of the configured tags_separator through the /info API endpoint.
This value can be used by clients (such as Shaarlier, see issue [#55 on Shaarlier](https://github.com/dimtion/Shaarlier/issues/55#)) for consistency.