### PR TITLE
tools/CI: scan repository with trivy security scanner (yarn.lock, composer.lock)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -98,3 +98,12 @@ jobs:
 
       - name: Build documentation
         run: mkdocs build --clean
+
+  trivy-repo:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Run trivy scanner on repository (non-blocking)
+        run: make test_trivy_repo TRIVY_EXIT_CODE=0

--- a/.github/workflows/docker-latest.yml
+++ b/.github/workflows/docker-latest.yml
@@ -41,5 +41,5 @@ jobs:
             ghcr.io/${{ secrets.DOCKER_IMAGE }}:latest
       - name: Image digest
         run: echo ${{ steps.docker_build.outputs.digest }}
-      - name: Run trivy image scanner
-        run: make test_trivy TRIVY_TARGET_DOCKER_IMAGE=ghcr.io/${{ secrets.DOCKER_IMAGE }}:latest
+      - name: Run trivy scanner on latest docker image
+        run: make test_trivy_docker TRIVY_TARGET_DOCKER_IMAGE=ghcr.io/${{ secrets.DOCKER_IMAGE }}:latest

--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,7 @@ sandbox
 phpmd.html
 phpdoc.xml
 .phpunit.result.cache
+trivy
 
 # User plugin configuration
 plugins/*


### PR DESCRIPTION
- run scan on each push/pull request update
- can be run locally using make test_trivy_repo
- exit with error code 0/success when vulnerabilities are found,  as not to make the workflow fail, a separate periodic run that exits with code 1 should be added in parallel
- update trivy to v0.43.0 (https://github.com/aquasecurity/trivy/releases/tag/v0.43.0)
- also consider TRIVY_EXIT_CODE when running trivy on the latest docker image
- ref. https://github.com/shaarli/Shaarli/issues/1531

---------

This is reproduces functionality provided by Github's [dependabot alerts](https://github.com/shaarli/Shaarli/security/dependabot), but with the ability to run locally/more portable, and reuses an already existing tool (`trivy` can run on `yarn/composer.lock` as well as Docker images). In a separate PR I will add a separate workflow that runs on a schedule on `master` and reports a failure when vulnerabilities are found. The main CI workflow will **not** report failure in case vulnerabilities are found, to prevent the workflow from failing due to unrelated third-party libraries/changes.