### PR TITLE
tools/Makefile: update trivy to v0.43.1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -194,7 +194,7 @@ sasslint:
 ##
 
 # trivy version (https://github.com/aquasecurity/trivy/releases)
-TRIVY_VERSION=0.43.0
+TRIVY_VERSION=0.43.1
 # default trivy exit code when vulnerabilities are found
 TRIVY_EXIT_CODE=1
 # default docker image to scan with trivy


### PR DESCRIPTION
- https://github.com/aquasecurity/trivy/releases/tag/v0.43.1