### PR TITLE
Doc update, WebSub (formerly PubSubHubbub) plugin

### DIFF
--- a/plugins/pubsubhubbub/README.md
+++ b/plugins/pubsubhubbub/README.md
@@ -1,9 +1,9 @@
 # PubSubHubbub plugin
 
-Enable this plugin to notify a Hub everytime you add or edit a link.
+Enable this plugin to notify a [WebSub](https://en.m.wikipedia.org/wiki/WebSub) (formerly PubSubHubbub) Hub everytime you add or edit a link.
  
 This allow hub subcribers to receive update notifications in real time,
-which is useful for feed syndication service which supports PubSubHubbub.
+which is useful for feed syndication service which supports WebSub/PubSubHubbub.
 
 ## Public Hub
 
@@ -11,7 +11,7 @@ By default, Shaarli will use [Google's public hub](http://pubsubhubbub.appspot.c
 
 [Here](https://github.com/pubsubhubbub/PubSubHubbub/wiki/Hubs) is a list of public hubs.
 
-You can also host your own PubSubHubbub server implementation, such as [phubb](https://github.com/cweiske/phubb).
+You can also host your own WebSub/PubSubHubbub server implementation, such as [phubb](https://github.com/cweiske/phubb).
 
 ## cURL
 


### PR DESCRIPTION
Clarify old and new name along with Wikipedia link.