### PR TITLE
doc: fix mkdocs build warnings/relative links

### DIFF
--- a/doc/md/Community-and-related-software.md
+++ b/doc/md/Community-and-related-software.md
@@ -7,7 +7,7 @@ please get in touch with us to help us find a way to adapt your work to our fork
 ## Related software
 
 ### REST API clients
-See [REST API](REST-API) for a list of official and community clients.
+See [REST API](REST-API.md) for a list of official and community clients.
 
 
 ### Third party plugins
@@ -34,7 +34,7 @@ See [REST API](REST-API) for a list of official and community clients.
 
 ### Third-party themes
 
-See [Theming](Theming) for a list of community-contributed themes, and an installation guide.
+See [Theming](dev/Theming.md) for a list of community-contributed themes, and an installation guide.
 
 
 ### Integration with other platforms

--- a/doc/md/Plugins.md
+++ b/doc/md/Plugins.md
@@ -37,7 +37,7 @@ This is important in case plugins depend on each other. Read plugins READMEs for
 
 ## Configuration file
 
-Enabled plugins are stored in your [Configuration file](Shaarli-configuration).
+Enabled plugins are stored in your [Configuration file](Shaarli-configuration.md).
 
 ## Usage
 

--- a/doc/md/REST-API.md
+++ b/doc/md/REST-API.md
@@ -4,7 +4,7 @@
 
 See the **[REST API documentation](http://shaarli.github.io/api-documentation/)** for a list of available endpoints and parameters.
 
-Please ensure that your server meets the requirements and is properly [configured](Server-configuration):
+Please ensure that your server meets the requirements and is properly [configured](Server-configuration.md):
 
 - URL rewriting is enabled (see specific Apache and Nginx sections)
 - the server's timezone is properly defined

--- a/doc/md/Reverse-proxy.md
+++ b/doc/md/Reverse-proxy.md
@@ -7,7 +7,7 @@ If Shaarli is hosted on a server behind a [reverse proxy](https://en.wikipedia.o
 - Shaarli's Fully Qualified Domain Name (FQDN) is `shaarli.mydomain.org`.
 - No HTTPS is setup on the application server, SSL termination is done at the reverse proxy.
 
-In your [Shaarli configuration](Shaarli-configuration) `data/config.json.php`, add the public IP of your proxy under `security.trusted_proxies`.
+In your [Shaarli configuration](Shaarli-configuration.md) `data/config.json.php`, add the public IP of your proxy under `security.trusted_proxies`.
 
 See also [proxy-related](https://github.com/shaarli/Shaarli/issues?utf8=%E2%9C%93&q=label%3Aproxy+) issues.
 

--- a/doc/md/Server-configuration.md
+++ b/doc/md/Server-configuration.md
@@ -134,7 +134,7 @@ The following examples assume a Debian-based operating system is installed. On o
 sudo mkdir -p /var/www/shaarli.mydomain.org/
 ```
 
-You can install Shaarli at the root of your virtualhost, or in a subdirectory as well. See [Directory structure](Directory-structure)
+You can install Shaarli at the root of your virtualhost, or in a subdirectory as well. See [Directory structure](dev/Development.md#directory-structure)
 
 
 ### Apache

--- a/doc/md/Shaarli-configuration.md
+++ b/doc/md/Shaarli-configuration.md
@@ -188,7 +188,7 @@ Additional settings applied to formatters.
 
 ### Translation
 
-- **language**: translation language (also see [Translations](Translations))
+- **language**: translation language (also see [Translations](dev/Translations.md))
     - **auto** (default): The translation language is chosen from the browser locale.
     It means that the language can be different for 2 different visitors depending on their locale.
     - **en**: Use the English translation.

--- a/doc/md/dev/Development.md
+++ b/doc/md/dev/Development.md
@@ -6,10 +6,10 @@ Please read [Contributing to Shaarli](https://github.com/shaarli/Shaarli/tree/ma
 ## Guidelines
 
 
-- [Unit tests](Unit-tests)
+- [Unit tests](Unit-tests.md)
 - Javascript linting - Shaarli uses [Airbnb JavaScript Style Guide](https://github.com/airbnb/javascript).
 Run `make eslint` to check JS style.
-- [GnuPG signature](GnuPG-signature) for tags/releases
+- [GnuPG signature](GnuPG-signature.md) for tags/releases
 
 
 ## Third-party libraries

--- a/doc/md/dev/GnuPG-signature.md
+++ b/doc/md/dev/GnuPG-signature.md
@@ -67,4 +67,4 @@ gpg: sending key A9D53A3E to hkp server pgp.mit.edu
 
 ## Create and push a GPG-signed tag
 
-See [Release Shaarli](Release Shaarli).
+See [Release Shaarli](Release-Shaarli.md).

--- a/doc/md/dev/Theming.md
+++ b/doc/md/dev/Theming.md
@@ -79,7 +79,7 @@ Get config written:
 - fill the install form
 - log in to Shaarli
 
-Edit Shaarli's [configuration](Shaarli-configuration):
+Edit Shaarli's [configuration](../Shaarli-configuration.md):
 ```bash
 # the file should be owned by Apache, thus not writeable => sudo
 $ sudo sed -i s=tpl=tpl/albinomouse-template=g shaarli/data/config.php

--- a/doc/md/dev/Translations.md
+++ b/doc/md/dev/Translations.md
@@ -67,7 +67,7 @@ Save when you're done, then you can submit a pull request containing the new `sh
 
 ### Theme translations
 
-[Theme](Theming) translation extensions are loaded automatically if they're present.
+[Theme](Theming.md) translation extensions are loaded automatically if they're present.
 
 As a theme developer, all you have to do is to add the `.po` and `.mo` compiled file like this:
 

--- a/doc/md/index.md
+++ b/doc/md/index.md
@@ -51,8 +51,8 @@ Shaarli can be used:
 - [Search](Usage.md#search) in all fields
 - Unique [permalinks](Usage.md#permalinks) for easy reference
 - Paginated Shaares list view (with image and video thumbnails)
-- [Tag cloud/list](Usage#tag-cloud) views
-- [Picture wall](Usage#picture-wall)/thumbnails view (with lazy loading)
+- [Tag cloud/list](Usage.md#tag-cloud) views
+- [Picture wall](Usage.md#picture-wall)/thumbnails view (with lazy loading)
 - [ATOM and RSS feeds](Usage.md#rss-feeds) (can also be filtered using tags or text search)
 - [Daily](Usage.md#daily): newspaper-like daily digest (and daily RSS feed)
 - URL cleanup: automatic removal of `?utm_source=...`, `fb=...` tracking parameters
@@ -80,7 +80,7 @@ Shaarli can be used:
 ### Self-hosted
 
 - Shaarli is an alternative to commercial services such as StumbleUpon, Delicio.us, Diigo...
-- The data is yours, [import and export](Usage#import-export) it to HTML bookmarksformat compatible with most web browser, and from a variety of formats
+- The data is yours, [import and export](Usage.md#import-export) it to HTML bookmarksformat compatible with most web browser, and from a variety of formats
 - Shaarli does not send any telemetry/metrics/private information to developers
 - Shaarli is Free and Open-Source software, inspect and change how the program works in the [source code](https://github.com/shaarli/Shaarli)
 - Built-in [Security](dev/Development.md#security) features to help you protect your Shaarli instance


### PR DESCRIPTION
Stumbled across this while building the docs using mkdocs 1.5.2, following readthedocs' email `Make sure your project is compatible with MkDocs >= 1.x` from 2023/08/02

```
INFO    -  Cleaning site directory
INFO    -  Building documentation to directory: /home/live/GIT/Shaarli/doc/html
INFO    -  Doc file 'index.md' contains an unrecognized relative link 'Usage#tag-cloud', it was left
           as is. Did you mean 'Usage.md#tag-cloud'?
INFO    -  Doc file 'index.md' contains an unrecognized relative link 'Usage#picture-wall', it was
           left as is. Did you mean 'Usage.md#picture-wall'?
INFO    -  Doc file 'index.md' contains an unrecognized relative link 'Usage#import-export', it was
           left as is. Did you mean 'Usage.md#import-export'?
INFO    -  Doc file 'Community-and-related-software.md' contains an unrecognized relative link
           'REST-API', it was left as is. Did you mean 'REST-API.md'?
INFO    -  Doc file 'Community-and-related-software.md' contains an unrecognized relative link
           'Theming', it was left as is.
INFO    -  Doc file 'Installation.md' contains an unrecognized relative link
           'dev/Development#third-party-libraries', it was left as is. Did you mean
           'dev/Development.md#third-party-libraries'?
INFO    -  Doc file 'Installation.md' contains an unrecognized relative link
           'Upgrade-and-migration', it was left as is. Did you mean 'Upgrade-and-migration.md'?
INFO    -  Doc file 'Plugins.md' contains an unrecognized relative link 'Shaarli-configuration', it
           was left as is. Did you mean 'Shaarli-configuration.md'?
INFO    -  Doc file 'REST-API.md' contains an unrecognized relative link 'Server-configuration', it
           was left as is. Did you mean 'Server-configuration.md'?
INFO    -  Doc file 'Reverse-proxy.md' contains an unrecognized relative link
           'Shaarli-configuration', it was left as is. Did you mean 'Shaarli-configuration.md'?
INFO    -  Doc file 'Server-configuration.md' contains an unrecognized relative link
           'Directory-structure', it was left as is.
INFO    -  Doc file 'Shaarli-configuration.md' contains an unrecognized relative link
           'Translations', it was left as is.
INFO    -  Doc file 'dev/Development.md' contains an unrecognized relative link 'Unit-tests', it was
           left as is. Did you mean 'Unit-tests.md'?
INFO    -  Doc file 'dev/Development.md' contains an unrecognized relative link 'GnuPG-signature',
           it was left as is. Did you mean 'GnuPG-signature.md'?
INFO    -  Doc file 'dev/GnuPG-signature.md' contains an unrecognized relative link 'Release
           Shaarli', it was left as is.
INFO    -  Doc file 'dev/Theming.md' contains an unrecognized relative link 'Shaarli-configuration',
           it was left as is.
INFO    -  Doc file 'dev/Translations.md' contains an unrecognized relative link 'Theming', it was
           left as is. Did you mean 'Theming.md'?
INFO    -  Documentation built in 0.40 seconds
```