### PR TITLE
doc: server configuration: add PHP 8.2 to PHP compatibility table

### DIFF
--- a/doc/md/Server-configuration.md
+++ b/doc/md/Server-configuration.md
@@ -40,6 +40,7 @@ Supported PHP versions:
 
 Version | Status | Shaarli compatibility
 :---:|:---:|:---:
+8.2 | Supported | Yes
 8.1 | Supported | Yes
 8.0 | EOL: 2023-11-26| Yes
 7.4 | EOL: 2022-11-28 | Yes


### PR DESCRIPTION
- Tested with php-fpm 8.2.7-1~deb12u1 on Debian 12
- ref. https://github.com/shaarli/Shaarli/issues/2020