### PR TITLE
docker: update base alpine docker image to 3.16.7

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,7 +26,7 @@ RUN cd shaarli \
 
 # Stage 4:
 # - Shaarli image
-FROM alpine:3.16
+FROM alpine:3.16.7
 LABEL maintainer="Shaarli Community"
 
 RUN apk --update --no-cache add \


### PR DESCRIPTION
- the previous (0.12.2) release image was based on 3.16.4 since the .patch version was not specified, which shows vulnerabilities when scanned with trivy (https://github.com/shaarli/Shaarli/pull/2019)