### PR TITLE
Remove remaining references of stable

### DIFF
--- a/doc/md/Docker.md
+++ b/doc/md/Docker.md
@@ -44,7 +44,6 @@ Shaarli images are available on [GitHub Container Registry](https://github.com/s
 - `latest`: master (development) branch
 - `vX.Y.Z`: shaarli [releases](https://github.com/shaarli/Shaarli/releases)
 - `release`: always points to the last release
-- `stable` and `master`: **deprecated**. These tags are no longer maintained and may be removed without notice
 
 These images are built automatically on Github Actions and rely on:
 

--- a/doc/md/Upgrade-and-migration.md
+++ b/doc/md/Upgrade-and-migration.md
@@ -127,22 +127,21 @@ Receiving objects: 100% (3015/3015), 2.59 MiB | 918.00 KiB/s, done.
 Resolving deltas: 100% (1899/1899), completed with 48 local objects.
 From https://github.com/shaarli/Shaarli
  * [new branch]      master     -> origin/master
- * [new branch]      stable     -> origin/stable
 [...]
  * [new tag]         v0.6.4     -> v0.6.4
  * [new tag]         v0.7.0     -> v0.7.0
 ```
 
-### Step 2: use the stable community branch
+### Step 2: use the release community branch
 
 ```bash
-$ git checkout origin/stable -b stable
-Branch stable set up to track remote branch stable from origin.
-Switched to a new branch 'stable'
+$ git checkout origin/release -b release
+Branch release set up to track remote branch release from origin.
+Switched to a new branch 'release'
 
 $ git branch -vv
   master 029f75f [sebsauvage/master] Update README.md
-* stable 890afc3 [origin/stable] Merge pull request #509 from ArthurHoaro/v0.6.5
+* release 890afc3 [origin/release] Merge tag 'v0.13.0' into release
 ```
 
 Shaarli >= `v0.8.x`: install/update third-party PHP dependencies using [Composer](https://getcomposer.org/):


### PR DESCRIPTION
Fixes #1964

All remaining `stable` references are unrelated (except for LegacyUpdater):

```
.readthedocs.yml:# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
CHANGELOG.md:> The `:stable` Docker image has been removed, please use `:release` instead.
CHANGELOG.md:  - Outdated Docker documentation for stable branch
CHANGELOG.md:- Run version check tests against the 'stable' branch
CHANGELOG.md:- Tools: check the 'stable' branch for new versions (updates)
CHANGELOG.md:  Please note that Shaarli CSS are not stable and may completely change on each version
application/legacy/LegacyUpdater.php:     * Note: Due to hardcoded paths, it's not unit testable. But one line of code should be fine.
application/legacy/LegacyUpdater.php:     * otherwise we'll check updates on the `stable` branch.
application/legacy/LegacyUpdater.php:     * Note: due to hardcoded URL and lack of dependency injection, this is not unit testable.
application/legacy/LegacyUpdater.php:            $branch = 'stable';
composer.lock:    "minimum-stability": "stable",
composer.lock:    "prefer-stable": false,
doc/md/Docker.md:sudo add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/debian $(lsb_release -cs) stable"
doc/md/dev/Development.md:- [`debian8`](https://github.com/shaarli/Shaarli/blob/master/tests/docker/debian8/Dockerfile) - [Debian 8 Jessie](https://wiki.debian.org/DebianJessie) (oldoldstable)
doc/md/dev/Development.md:- [`debian9`](https://github.com/shaarli/Shaarli/blob/master/tests/docker/debian9/Dockerfile) - [Debian 9 Stretch](https://wiki.debian.org/DebianStretch) (oldstable)
doc/md/dev/Development.md:- This branch shouldn't be used for production as it isn't necessary stable.
tests/utils/ReferenceSessionIdHashes.php: * Testing the untestable - Session ID generation
yarn.lock:    fast-json-stable-stringify "^2.0.0"
yarn.lock:    json-stable-stringify-without-jsonify "^1.0.1"
yarn.lock:fast-json-stable-stringify@^2.0.0:
yarn.lock:  resolved "https://registry.yarnpkg.com/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz#874bf69c6f404c2b5d99c481341399fd55892633"
yarn.lock:json-stable-stringify-without-jsonify@^1.0.1:
yarn.lock:  resolved "https://registry.yarnpkg.com/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz#9db7b59496ad3f3cfef30a75142d2d930ad72651"
```