### PR TITLE
github actions: don't attempt to push docker image from forks

### DIFF
--- a/.github/workflows/docker-latest.yml
+++ b/.github/workflows/docker-latest.yml
@@ -12,11 +12,13 @@ jobs:
         uses: docker/setup-buildx-action@v2
 
       - name: Login to DockerHub
+        if: github.repository == 'shaarli/Shaarli'
         uses: docker/login-action@v2
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
       - name: Login to GitHub Container Registry
+        if: github.repository == 'shaarli/Shaarli'
         uses: docker/login-action@v2
         with:
           registry: ghcr.io
@@ -34,7 +36,7 @@ jobs:
         uses: docker/build-push-action@v4
         with:
           context: .
-          push: true
+          push: ${{ github.repository == 'shaarli/Shaarli' }}
           platforms: linux/amd64,linux/arm64,linux/arm/v7
           tags: |
             ${{ secrets.DOCKER_IMAGE }}:latest
@@ -42,4 +44,5 @@ jobs:
       - name: Image digest
         run: echo ${{ steps.docker_build.outputs.digest }}
       - name: Run trivy scanner on latest docker image
+        if: github.repository == 'shaarli/Shaarli'
         run: make test_trivy_docker TRIVY_EXIT_CODE=0 TRIVY_TARGET_DOCKER_IMAGE=ghcr.io/${{ secrets.DOCKER_IMAGE }}:latest

--- a/.github/workflows/docker-tags.yml
+++ b/.github/workflows/docker-tags.yml
@@ -18,12 +18,13 @@ jobs:
         uses: docker/setup-buildx-action@v2
 
       - name: Login to DockerHub
+        if: github.repository == 'shaarli/Shaarli'
         uses: docker/login-action@v2
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
-      -
-        name: Login to GitHub Container Registry
+      - name: Login to GitHub Container Registry
+        if: github.repository == 'shaarli/Shaarli'
         uses: docker/login-action@v2
         with:
           registry: ghcr.io
@@ -34,7 +35,7 @@ jobs:
         id: docker_build
         uses: docker/build-push-action@v3
         with:
-          push: true
+          push: ${{ github.repository == 'shaarli/Shaarli' }}
           platforms: linux/amd64,linux/arm/v7
           tags: |
             ${{ secrets.DOCKER_IMAGE }}:${{ env.REF }}


### PR DESCRIPTION
- only push the docker image to the ghcr registry when on the original shaarli/Shaarli fork
- only run trivy docker image scans on the original shaarli/Shaarli fork
- prevents 'Username and password required' errors when committing to forks which do not have the required CI secrets (registry username/password) set