### PR TITLE
docker: update base alpine linux docker image to v3.16.8

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,7 +25,7 @@ RUN cd shaarli \
 
 # Stage 4:
 # - Shaarli image
-FROM alpine:3.16.7
+FROM alpine:3.16.8
 LABEL maintainer="Shaarli Community"
 
 RUN apk --update --no-cache add \


### PR DESCRIPTION
- https://alpinelinux.org/posts/Alpine-3.15.11-3.16.8-3.17.6-3.18.5-released.html