### PR TITLE
Adding datastore2json & json2datastore scripts

### DIFF
--- a/application/bookmark/Bookmark.php
+++ b/application/bookmark/Bookmark.php
@@ -16,7 +16,7 @@ use Shaarli\Bookmark\Exception\InvalidBookmarkException;
  *
  * @package Shaarli\Bookmark
  */
-class Bookmark
+class Bookmark implements \JsonSerializable
 {
     /** @var string Date format used in string (former ID format) */
     public const LINK_DATE_FORMAT = 'Ymd_His';
@@ -542,5 +542,21 @@ class Bookmark
             unset($this->tags[$pos]);
             $this->tags = array_values($this->tags);
         }
+    }
+
+    public function jsonSerialize()
+    {
+        return [
+            'id' => $this->id,
+            'shortUrl' => $this->shortUrl,
+            'url' => $this->url,
+            'title' => $this->title,
+            'description' => $this->description,
+            'tags' => $this->tags,
+            'sticky' => $this->sticky,
+            'created' => $this->created,
+            'updated' => $this->updated,
+            'private' => $this->private,
+        ];
     }
 }

--- a/application/bookmark/BookmarkArray.php
+++ b/application/bookmark/BookmarkArray.php
@@ -14,7 +14,7 @@ use Shaarli\Bookmark\Exception\InvalidBookmarkException;
  *
  * @package Shaarli\Bookmark
  */
-class BookmarkArray implements \Iterator, \Countable, \ArrayAccess
+class BookmarkArray implements \Iterator, \Countable, \ArrayAccess, \JsonSerializable
 {
     /**
      * @var Bookmark[]
@@ -260,5 +260,10 @@ class BookmarkArray implements \Iterator, \Countable, \ArrayAccess
             $this->urls[$bookmark->getUrl()] = $key;
             $this->ids[$bookmark->getId()] = $key;
         }
+    }
+
+    public function jsonSerialize()
+    {
+        return $this->bookmarks;
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -79,5 +79,9 @@
           "Shaarli\\Tests\\": "tests",
           "Shaarli\\Tests\\Utils\\": "tests/utils"
         }
+    },
+    "scripts": {
+        "datastore2json": "php -f datastore2json.php",
+        "json2datastore": "php -f json2datastore.php"
     }
 }

--- a/datastore2json.php
+++ b/datastore2json.php
@@ -1,0 +1,19 @@
+<?php
+require 'vendor/autoload.php';
+
+// Replicates BookmarkIO.read() at https://github.com/shaarli/Shaarli/blob/master/application/bookmark/BookmarkIO.php#L72 :
+
+use Shaarli\Bookmark\BookmarkArray;
+
+if ($argv && $argv[0] && realpath($argv[0]) === __FILE__) {
+    // Code below will only be executed when this script is invoked as a CLI,
+    // not when served as a web page:
+    $phpPrefix = '<?php /* ';
+    $phpSuffix = ' */ ?>';
+    $datastore_filepath = $argc > 1 ? $argv[1] : "data/datastore.php";
+    $content = file_get_contents($datastore_filepath);
+    $links = unserialize(gzinflate(base64_decode(
+        substr($content, strlen($phpPrefix), -strlen($phpSuffix))
+    )));
+    print(json_encode($links).PHP_EOL);
+}

--- a/json2datastore.php
+++ b/json2datastore.php
@@ -1,0 +1,33 @@
+<?php
+require 'vendor/autoload.php';
+
+// Replicates BookmarkIO.write() at https://github.com/shaarli/Shaarli/blob/master/application/bookmark/BookmarkIO.php#L114
+// and BookmarkFileService.add() at https://github.com/shaarli/Shaarli/blob/master/application/bookmark/BookmarkFileService.php
+
+require_once 'application/bookmark/LinkUtils.php'; // imports tags_str2array()
+use Shaarli\Bookmark\Bookmark;
+use Shaarli\Bookmark\BookmarkArray;
+
+if ($argv && $argv[0] && realpath($argv[0]) === __FILE__) {
+    // Code below will only be executed when this script is invoked as a CLI,
+    // not when served as a web page:
+    $phpPrefix = '<?php /* ';
+    $phpSuffix = ' */ ?>';
+    $json_filepath = $argv[1];
+    $json_links = json_decode(file_get_contents($json_filepath), true);
+    $bookmarks = new BookmarkArray();
+    foreach($json_links as &$json_link) {
+        $json_link['created'] = DateTime::createFromFormat(DateTime::ISO8601, $json_link['created']);
+        if ($json_link['updated']) {
+          $json_link['updated'] = DateTime::createFromFormat(DateTime::ISO8601, $json_link['updated']);
+        }
+        $bookmark = new Bookmark();
+        $bookmark->fromArray($json_link, ' ');
+        $bookmark->setId($bookmarks->getNextId());
+        $bookmark->validate();
+        $bookmarks[$bookmark->getId()] = $bookmark;
+    }
+    $bookmarks->reorder();
+    $data = base64_encode(gzdeflate(serialize($bookmarks)));
+    print($data = $phpPrefix . $data . $phpSuffix);
+}


### PR DESCRIPTION
This is a follow-up on a previous PR: https://github.com/shaarli/Shaarli/pull/1823

I made sure that the script works with the latest version of Shaarli,
and added the "inverse" script, that convert from JSON to a `datastore.php` file.

Usage:

	composer datastore2json > datastore.json
	composer json2datastore datastore.json > data/datastore.php

Or:

    php -f datastore2json > datastore.json
    php -f json2datastore datastore.json > data/datastore.json
