### PR TITLE
Documentation: fix broken link to 3rd party plugins

### DIFF
--- a/tpl/default/tools.html
+++ b/tpl/default/tools.html
@@ -123,7 +123,7 @@
   <div class="pure-u-lg-1-3 pure-u-22-24 page-form page-form-light">
     <h2 class="window-title">{'Third-party resources'|t}</h2>
     <div class="tools-item">
-      <a href="https://shaarli.readthedocs.io/en/master/Community-and-related-software/">
+      <a href="https://shaarli.readthedocs.io/en/master/Community-and-related-software.html">
         <span class="pure-button pure-u-lg-2-3 pure-u-3-4">{'Community and related software'|t}</span>
       </a>
     </div>


### PR DESCRIPTION
https://shaarli.readthedocs.io/en/master/Community-and-related-software/ ends on a 404 error page.