### PR TITLE
dockerfile: update base alpine linux docker image to v3.18.6

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,7 +25,7 @@ RUN cd shaarli \
 
 # Stage 4:
 # - Shaarli image
-FROM docker.io/alpine:3.18.5
+FROM docker.io/alpine:3.18.6
 LABEL maintainer="Shaarli Community"
 
 RUN apk --update --no-cache add \


### PR DESCRIPTION
- https://alpinelinux.org/posts/Alpine-3.16.9-3.17.7-3.18.6-released.html