### PR TITLE
tools: update trivy security scanner to v0.49.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -194,7 +194,7 @@ sasslint:
 ##
 
 # trivy version (https://github.com/aquasecurity/trivy/releases)
-TRIVY_VERSION=0.44.0
+TRIVY_VERSION=0.49.0
 # default trivy exit code when vulnerabilities are found
 TRIVY_EXIT_CODE=1
 # default docker image to scan with trivy


### PR DESCRIPTION
- https://github.com/aquasecurity/trivy/releases/tag/v0.47.0
- https://github.com/aquasecurity/trivy/releases/tag/v0.48.0
- https://github.com/aquasecurity/trivy/releases/tag/v0.48.1
- https://github.com/aquasecurity/trivy/releases/tag/v0.48.2
- https://github.com/aquasecurity/trivy/releases/tag/v0.48.3
- https://github.com/aquasecurity/trivy/releases/tag/v0.49.0