### PR TITLE
doc: server configuration: allow accessing and caching SVG assets

### DIFF
--- a/doc/md/Server-configuration.md
+++ b/doc/md/Server-configuration.md
@@ -202,7 +202,7 @@ MDPrivateKeys RSA 4096
         </FilesMatch>
     </Directory>
     
-    <FilesMatch ".*\.(?!(ico|css|js|gif|jpe?g|png|ttf|oet|woff2?)$)[^\.]*$">
+    <FilesMatch ".*\.(?!(ico|css|js|gif|jpe?g|png|svg|ttf|oet|woff2?)$)[^\.]*$">
         Require all denied
     </FilesMatch>
 
@@ -212,7 +212,7 @@ MDPrivateKeys RSA 4096
         Require all granted
     </Files>
 
-    <FilesMatch "\.(?:ico|css|js|gif|jpe?g|png|ttf|oet|woff2)$">
+    <FilesMatch "\.(?:ico|css|js|gif|jpe?g|png|svg|ttf|oet|woff2)$">
         # allow client-side caching of static files
         Header set Cache-Control "max-age=2628000, public, must-revalidate, proxy-revalidate"
     </FilesMatch>
@@ -319,7 +319,7 @@ server {
     }
 
     # allow client-side caching of static files
-    location ~* \.(?:ico|css|js|gif|jpe?g|png|ttf|oet|woff2?)$ {
+    location ~* \.(?:ico|css|js|gif|jpe?g|png|svg|ttf|oet|woff2?)$ {
         expires    max;
         add_header Cache-Control "public, must-revalidate, proxy-revalidate";
         # HTTP 1.0 compatibility


### PR DESCRIPTION
Some themes (e.g. https://github.com/RolandTi/shaarli-stack) use SVG assets for example to provide the favicon. The web server configuration example provided in Shaarli's documentation does not allow accessing `.svg` files (a HTTP 403 error is returned). 

This Pull Request fixes it by allowing access to `.svg` files in the example configuration for Apache and Nginx.

Even though no SVG files are used in the default template, I think there are no real security concerns allowing them by default. The alternative is to mention in the documentation of those themes, that the virtualhost configuration file should be edited (not very user-friendly)

/cc @rolandTi