### PR TITLE
2084: Ensure tags are unique when renaming

### DIFF
--- a/application/bookmark/Bookmark.php
+++ b/application/bookmark/Bookmark.php
@@ -505,7 +505,7 @@ class Bookmark
     }
 
     /**
-     * Rename a tag in tags list.
+     * Rename a tag in tags list. If the new tag already exists, merge them
      *
      * @param string $fromTag
      * @param string $toTag
@@ -513,7 +513,11 @@ class Bookmark
     public function renameTag(string $fromTag, string $toTag): void
     {
         if (($pos = array_search($fromTag, $this->tags ?? [])) !== false) {
-            $this->tags[$pos] = trim($toTag);
+            if (in_array($toTag, $this->tags ?? []) !== false) {
+                $this->deleteTag($fromTag);
+            } else {
+                $this->tags[$pos] = trim($toTag);
+            }
         }
     }
 

--- a/tests/bookmark/BookmarkTest.php
+++ b/tests/bookmark/BookmarkTest.php
@@ -397,6 +397,17 @@ class BookmarkTest extends TestCase
     }
 
     /**
+     * Test renameTag() avoid duplicating existing tag
+     */
+    public function testRenameTagNotDuplicated()
+    {
+        $bookmark = new Bookmark();
+        $bookmark->setTags(['tag1', 'tag2', 'chair']);
+        $bookmark->renameTag('tag1', 'chair');
+        $this->assertEquals(['tag2', 'chair'], $bookmark->getTags());
+    }
+
+    /**
      * Test deleteTag()
      */
     public function testDeleteTag()

--- a/tests/bookmark/BookmarkTest.php
+++ b/tests/bookmark/BookmarkTest.php
@@ -374,6 +374,9 @@ class BookmarkTest extends TestCase
     public function testRenameTag()
     {
         $bookmark = new Bookmark();
+        $bookmark->renameTag('chair', 'table');
+        $this->assertEquals([], $bookmark->getTags());
+
         $bookmark->setTags(['tag1', 'tag2', 'chair']);
         $bookmark->renameTag('chair', 'table');
         $this->assertEquals(['tag1', 'tag2', 'table'], $bookmark->getTags());

--- a/tests/front/controller/admin/ManageTagControllerTest.php
+++ b/tests/front/controller/admin/ManageTagControllerTest.php
@@ -13,7 +13,6 @@ use Shaarli\Security\SessionManager;
 use Shaarli\TestCase;
 use Slim\Http\Request;
 use Slim\Http\Response;
-
 // These are declared for the bookmark service
 use malkusch\lock\mutex\NoMutex;
 use Shaarli\History;
@@ -56,8 +55,18 @@ class ManageTagControllerTest extends TestCase
         self::$refDB = new ReferenceLinkDB();
         self::$refDB->write(self::$testDatastore);
         $history = new History('sandbox/history.php');
-        $this->container->bookmarkService = new FakeBookmarkService($conf, static::$pluginManager, $history, $mutex, true);
-        $this->linkFilter = new BookmarkFilter($this->container->bookmarkService->getBookmarks(), $conf, static::$pluginManager);
+        $this->container->bookmarkService = new FakeBookmarkService(
+            $conf,
+            static::$pluginManager,
+            $history,
+            $mutex,
+            true
+        );
+        $this->linkFilter = new BookmarkFilter(
+            $this->container->bookmarkService->getBookmarks(),
+            $conf,
+            static::$pluginManager
+        );
     }
 
     /**


### PR DESCRIPTION
#2084 - If a bookmark already includes the tag that the old tag is being renamed to, effectively merge the tags by removing the old and keeping the new. Previously, the new tag would be duplicated.