### PR TITLE
docker: update base alpine linux image to v3.19.4

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,7 +25,7 @@ RUN cd shaarli \
 
 # Stage 4:
 # - Shaarli image
-FROM docker.io/alpine:3.19.1
+FROM docker.io/alpine:3.19.2
 LABEL maintainer="Shaarli Community"
 
 RUN apk --update --no-cache add \

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,7 +25,7 @@ RUN cd shaarli \
 
 # Stage 4:
 # - Shaarli image
-FROM docker.io/alpine:3.19.3
+FROM docker.io/alpine:3.19.4
 LABEL maintainer="Shaarli Community"
 
 RUN apk --update --no-cache add \

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,7 +25,7 @@ RUN cd shaarli \
 
 # Stage 4:
 # - Shaarli image
-FROM docker.io/alpine:3.19.2
+FROM docker.io/alpine:3.19.3
 LABEL maintainer="Shaarli Community"
 
 RUN apk --update --no-cache add \

--- a/doc/md/dev/Development.md
+++ b/doc/md/dev/Development.md
@@ -277,7 +277,7 @@ Unit tests can be run inside [Docker](../Docker.md) containers.
 
 Test Dockerfiles are located under `tests/docker/<distribution>/Dockerfile`, and can be used to build Docker images to run Shaarli test suites under commonLinux environments. Dockerfiles are provided for the following environments:
 
-- [`alpine319`](https://github.com/shaarli/Shaarli/blob/master/tests/docker/alpine319/Dockerfile) - [Alpine Linux 3.18](https://www.alpinelinux.org/downloads/)
+- [`alpine319`](https://github.com/shaarli/Shaarli/blob/master/tests/docker/alpine319/Dockerfile) - [Alpine Linux 3.19](https://www.alpinelinux.org/downloads/)
 - [`debian8`](https://github.com/shaarli/Shaarli/blob/master/tests/docker/debian8/Dockerfile) - [Debian 8 Jessie](https://wiki.debian.org/DebianJessie) (oldoldstable)
 - [`debian9`](https://github.com/shaarli/Shaarli/blob/master/tests/docker/debian9/Dockerfile) - [Debian 9 Stretch](https://wiki.debian.org/DebianStretch) (oldstable)
 - [`ubuntu16`](https://github.com/shaarli/Shaarli/blob/master/tests/docker/ubuntu16/Dockerfile) - [Ubuntu 16.04 Xenial Xerus](https://releases.ubuntu.com/16.04/) (old LTS)

--- a/tests/docker/alpine319/Dockerfile
+++ b/tests/docker/alpine319/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker.io/alpine:3.19.2
+FROM docker.io/alpine:3.19.3
 MAINTAINER Shaarli Community
 
 RUN apk --update --no-cache add \

--- a/tests/docker/alpine319/Dockerfile
+++ b/tests/docker/alpine319/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker.io/alpine:3.19.1
+FROM docker.io/alpine:3.19.2
 MAINTAINER Shaarli Community
 
 RUN apk --update --no-cache add \

--- a/tests/docker/alpine319/Dockerfile
+++ b/tests/docker/alpine319/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker.io/alpine:3.19.3
+FROM docker.io/alpine:3.19.4
 MAINTAINER Shaarli Community
 
 RUN apk --update --no-cache add \


### PR DESCRIPTION
- https://www.alpinelinux.org/posts/Alpine-3.19.0-released.html
- https://www.alpinelinux.org/posts/Alpine-3.19.1-released.html
- https://www.alpinelinux.org/posts/Alpine-3.17.8-3.18.7-3.19.2-released.html
- https://www.alpinelinux.org/posts/Alpine-3.17.9-3.18.8-3.19.3-released.html
- https://alpinelinux.org/posts/Alpine-3.17.10-3.18.9-3.19.4-3.20.3-released.html