### PR TITLE
tools/tests: update trivy security scanner to v0.51.2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -194,7 +194,7 @@ sasslint:
 ##
 
 # trivy version (https://github.com/aquasecurity/trivy/releases)
-TRIVY_VERSION=0.49.1
+TRIVY_VERSION=0.51.2
 # default trivy exit code when vulnerabilities are found
 TRIVY_EXIT_CODE=1
 # default docker image to scan with trivy


### PR DESCRIPTION
- https://github.com/aquasecurity/trivy/releases/tag/v0.50.0
- https://github.com/aquasecurity/trivy/releases/tag/v0.50.1
- https://github.com/aquasecurity/trivy/releases/tag/v0.50.2
- https://github.com/aquasecurity/trivy/releases/tag/v0.50.4
- https://github.com/aquasecurity/trivy/releases/tag/v0.51.0
- https://github.com/aquasecurity/trivy/releases/tag/v0.51.1
- https://github.com/aquasecurity/trivy/releases/tag/v0.51.2