### PR TITLE
tools/tests: update trivy vulnerability scanner to v0.56.2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -194,7 +194,7 @@ sasslint:
 ##
 
 # trivy version (https://github.com/aquasecurity/trivy/releases)
-TRIVY_VERSION=0.51.2
+TRIVY_VERSION=0.56.2
 # default trivy exit code when vulnerabilities are found
 TRIVY_EXIT_CODE=1
 # default docker image to scan with trivy


### PR DESCRIPTION
- https://github.com/aquasecurity/trivy/releases/tag/v0.51.4
- https://github.com/aquasecurity/trivy/releases/tag/v0.52.0
- https://github.com/aquasecurity/trivy/releases/tag/v0.52.1
- https://github.com/aquasecurity/trivy/releases/tag/v0.52.2
- https://github.com/aquasecurity/trivy/releases/tag/v0.53.0
- https://github.com/aquasecurity/trivy/releases/tag/v0.54.0
- https://github.com/aquasecurity/trivy/releases/tag/v0.54.1
- https://github.com/aquasecurity/trivy/releases/tag/v0.55.0
- https://github.com/aquasecurity/trivy/releases/tag/v0.55.1
- https://github.com/aquasecurity/trivy/releases/tag/v0.55.2
- https://github.com/aquasecurity/trivy/releases/tag/v0.56.0
- https://github.com/aquasecurity/trivy/releases/tag/v0.56.1
- https://github.com/aquasecurity/trivy/releases/tag/v0.56.2