### PR TITLE
fix wrong date format when language is not english (Alpine icu package split)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,8 +28,10 @@ RUN cd shaarli \
 FROM docker.io/alpine:3.19.4
 LABEL maintainer="Shaarli Community"
 
-RUN apk --update --no-cache add \
+RUN apk --no-cache del icu-data-en \
+    && apk --update --no-cache add \
         ca-certificates \
+        icu-data-full \
         nginx \
         php82 \
         php82-ctype \


### PR DESCRIPTION
fix for issue #1900 