### PR TITLE
[CI] tests: update with narrow no-break space in date format

### DIFF
--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,8 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:noNamespaceSchemaLocation="http://schema.phpunit.de/4.5/phpunit.xsd"
+    xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd"
     colors="true">
+  <coverage includeUncoveredFiles="true">
+    <include>
+      <directory suffix=".php">application</directory>
+    </include>
+  </coverage>
   <testsuites>
     <testsuite name="unit-tests">
       <directory>tests</directory>
@@ -18,10 +23,4 @@
       <directory>tests/languages/fr</directory>
     </testsuite>
   </testsuites>
-
-  <filter>
-    <whitelist addUncoveredFilesFromWhitelist="true">
-      <directory suffix=".php">application</directory>
-    </whitelist>
-  </filter>
 </phpunit>

--- a/tests/languages/en/UtilsEnTest.php
+++ b/tests/languages/en/UtilsEnTest.php
@@ -23,7 +23,7 @@ class UtilsEnTest extends UtilsTest
         $current = get_locale(LC_ALL);
         autoLocale('en_US.UTF-8');
         $date = DateTime::createFromFormat('Ymd_His', '20170102_201112');
-        $this->assertRegExp('/January 2, 2017 (at )?8:11:12 PM GMT\+0?3(:00)?/', format_date($date, true, true));
+        $this->assertRegExp('/January 2, 2017 (at )?8:11:12 PM GMT\+0?3(:00)?/', format_date($date, true, true));
         setlocale(LC_ALL, $current);
     }
 


### PR DESCRIPTION
A NNBS (narrow no-break space) is now used it seems before the AM/PM indicator since recent update of libraries.
A correct approach is to avoid updates in CI, always use fixed versions for libraries thanks to compositors lock files.

This is very close to a workaround than an actual fix.