### PR TITLE
Fix "PHP message: TypeError: get_headers(): Argument #2 ($associative…

### DIFF
--- a/application/http/HttpUtils.php
+++ b/application/http/HttpUtils.php
@@ -231,7 +231,7 @@ function get_http_response_fallback(
  */
 function get_redirected_headers($url, $redirectionLimit = 3)
 {
-    $headers = get_headers($url, 1);
+    $headers = get_headers($url, true);
     if (!empty($headers['location']) && empty($headers['Location'])) {
         $headers['Location'] = $headers['location'];
     }


### PR DESCRIPTION
The message "PHP message: TypeError: get_headers(): Argument #2 ($associative) must be of type bool, int given"
pops from time to time in php logs, fix get_headers() call to comply with requirement.
Same fix should be applied to https://github.com/ArthurHoaro/web-thumbnailer/blob/master/src/Application/WebAccess/WebAccessPHP.php as it's pulled in the official zip installation archive.
