### PR TITLE
docker: fix /bin/s6-svscan: no such file or directory when starting the container

### DIFF
--- a/.docker/services.d/php-fpm/run
+++ b/.docker/services.d/php-fpm/run
@@ -1,2 +1,2 @@
 #!/bin/execlineb -P
-php-fpm82 -F
+php-fpm84 -F

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ------------------------
 
+## [v0.16.1](https://github.com/shaarli/Shaarli/releases/tag/v0.16.1) - 2026-11-24
+
+### Fixed
+
+* fix Docker container failing to start (`/bin/s6-svscan: no such file or directory`)
+
+**Full Changelog**: https://github.com/shaarli/Shaarli/compare/v0.16.0...v0.16.1
+
+------------------------
+
 ## [v0.16.0](https://github.com/shaarli/Shaarli/releases/tag/v0.16.0) - 2026-11-24
 
 Small release focused on infrastructure/CI improvements and Docker/security updates.

--- a/Dockerfile
+++ b/Dockerfile
@@ -72,5 +72,5 @@ VOLUME /var/www/shaarli/data
 
 EXPOSE 80
 
-ENTRYPOINT ["/bin/s6-svscan", "/etc/services.d"]
+ENTRYPOINT ["/usr/bin/s6-svscan", "/etc/services.d"]
 CMD []


### PR DESCRIPTION
- s6 executables has been moved to /usr/bin/
- also fix path to php-fpm executable (PHP 8.4)
- https://github.com/shaarli/Shaarli/issues/2181