### PR TITLE
[v0.14] Backport CVE-2025-55291: fix GHSA-7w7w-pw4j-265h

### DIFF
--- a/application/front/controller/visitor/TagCloudController.php
+++ b/application/front/controller/visitor/TagCloudController.php
@@ -87,7 +87,7 @@ class TagCloudController extends ShaarliVisitorController
         $searchTags = !empty($searchTags) ? trim(str_replace($tagsSeparator, ' ', $searchTags)) . ' - ' : '';
         $this->assignView(
             'pagetitle',
-            $searchTags . t('Tag ' . $type) . ' - ' . $this->container->conf->get('general.title', 'Shaarli')
+            escape($searchTags) . t('Tag ' . $type) . ' - ' . $this->container->conf->get('general.title', 'Shaarli')
         );
 
         return $response->write($this->render('tag.' . $type));


### PR DESCRIPTION
This PR backports the fix for **CVE-2025-55291** (GHSA-7w7w-pw4j-265h) to the `v0.14` legacy branch.

The fix landed on `master` via merge commit `66faa61335a6` (PR #2157, by @nodiscc). The `v0.14` branch carries the older 0.14 line and does not yet have the fix applied.

### Approach

- `git cherry-pick -x -m 1 66faa61335a6` — applied the mainline parent of the merge commit cleanly with no conflicts.
- Original authorship (@nodiscc) preserved.

### Scope

- 1 file changed (the same fix as on master).
- No tests altered, no behavior changes outside the security fix.

### Notes

If `v0.14` is no longer receiving security fixes, please close — happy to redirect or drop. Submitted as part of an effort to surface unbackported CVE fixes on stable branches.
