### PR TITLE
[v0.15] Backport CVE-2026-24476: security fix (merge from fork)

### DIFF
--- a/tpl/default/addlink.html
+++ b/tpl/default/addlink.html
@@ -58,7 +58,7 @@
           </div>
           <div>
             <input type="text" name="tags" id="tags" class="lf_input"
-                   data-list="{loop="$tags"}{$key}, {/loop}" data-multiple data-autofirst autocomplete="off">
+                   data-list="{loop="$tags"}{$key|escape}, {/loop}" data-multiple data-autofirst autocomplete="off">
           </div>
 
           <div>

--- a/tpl/default/editlink.html
+++ b/tpl/default/editlink.html
@@ -58,7 +58,7 @@
       </div>
       <div class="{if="$retrieve_description"}{$asyncLoadClass}{/if}">
         <input type="text" name="lf_tags" id="lf_tags{$batchId}" value="{$link.tags}" class="lf_input autofocus"
-          data-list="{loop="$tags"}{$key}, {/loop}" data-multiple data-autofirst autocomplete="off" >
+          data-list="{loop="$tags"}{$key|escape}, {/loop}" data-multiple data-autofirst autocomplete="off" >
         <div class="icon-container">
           <i class="loader"></i>
         </div>

--- a/tpl/default/linklist.html
+++ b/tpl/default/linklist.html
@@ -29,7 +29,7 @@
            value="{$search_tags}"
            {/if}
     autocomplete="off" data-multiple data-autofirst data-minChars="1"
-    data-list="{loop="$tags"}{$key}, {/loop}"
+    data-list="{loop="$tags"}{$key|escape}, {/loop}"
     >
     <button type="submit" class="search-button" aria-label="{'Search'|t}"><i class="fa fa-search" aria-hidden="true"></i></button>
   </form>

--- a/tpl/default/page.header.html
+++ b/tpl/default/page.header.html
@@ -112,7 +112,7 @@
              value="{$search_tags}"
              {/if}
       autocomplete="off" data-multiple data-autofirst data-minChars="1"
-      data-list="{loop="$tags"}{$key}, {/loop}"
+      data-list="{loop="$tags"}{$key|escape}, {/loop}"
       >
       <button type="submit" class="search-button" aria-label="{'Search'|t}"><i class="fa fa-search" aria-hidden="true"></i></button>
     </form>
@@ -157,7 +157,7 @@
                 aria-label="{$value === 'add' ? t('Tag to add') : t('Tag to delete')}"
                 placeholder="{$value === 'add' ? t('Tag to add') : t('Tag to delete')}"
                 autocomplete="off" data-multiple data-autofirst data-minChars="1"
-                data-list="{loop="$tags"}{$key}, {/loop}"
+                data-list="{loop="$tags"}{$key|escape}, {/loop}"
               >
               <input type="hidden" name="action" value="{$value}" />
               <input type="hidden" name="id" value="" />

--- a/tpl/default/tag.cloud.html
+++ b/tpl/default/tag.cloud.html
@@ -31,7 +31,7 @@
                     value="{$search_tags}"
                  {/if}
           autocomplete="off" data-multiple data-autofirst data-minChars="1"
-          data-list="{loop="$tags"}{$key}, {/loop}"
+          data-list="{loop="$tags"}{$key|escape}, {/loop}"
           class="autofocus"
           >
           <button type="submit" class="search-button" aria-label="{'Search'|t}"><i class="fa fa-search" aria-hidden="true"></i></button>

--- a/tpl/default/tag.list.html
+++ b/tpl/default/tag.list.html
@@ -31,7 +31,7 @@
                  value="{$search_tags}"
                  {/if}
           autocomplete="off" data-multiple data-autofirst data-minChars="1"
-          data-list="{loop="$tags"}{$key}, {/loop}"
+          data-list="{loop="$tags"}{$key|escape}, {/loop}"
           >
           <button type="submit" class="search-button" aria-label="{'Search'|t}"><i class="fa fa-search" aria-hidden="true"></i></button>
         </form>

--- a/tpl/vintage/editlink.html
+++ b/tpl/vintage/editlink.html
@@ -33,7 +33,7 @@
             <label for="lf_tags"><i>Tags</i></label>
             <div class="{if="$retrieve_description"}{$asyncLoadClass}{/if}">
               <input type="text" name="lf_tags" id="lf_tags" value="{$link.tags}" class="lf_input"
-                data-list="{loop="$tags"}{$key}, {/loop}" data-multiple autocomplete="off" >
+                data-list="{loop="$tags"}{$key|escape}, {/loop}" data-multiple autocomplete="off" >
               <div class="icon-container">
                 <i class="loader"></i>
               </div>

--- a/tpl/vintage/linklist.html
+++ b/tpl/vintage/linklist.html
@@ -22,7 +22,7 @@
                     value="{$search_tags}"
                 {/if}
                 autocomplete="off" data-multiple data-minChars="1"
-                data-list="{loop="$tags"}{$key}, {/loop}"
+                data-list="{loop="$tags"}{$key|escape}, {/loop}"
             >
             <input type="submit" value="Search" class="bigbutton">
         </form>


### PR DESCRIPTION
Backport of upstream merge `b854c789289c4b0dfbb7c1e5793bae7d8f94e063` (security fix from fork) for CVE-2026-24476 to the `v0.15` branch.

## Why
- The `v0.15` series is missing the security fix. Upstream applied it via a merge from a private fork on the development branch.
- Applying `-m 1` to mainline preserves the original author and commit reference so users on v0.15 receive the same protection without forcing a major upgrade.

## What
- Cherry-picked with `git cherry-pick -x -m 1 b854c789`.
- 8 files changed, 9 insertions(+), 9 deletions(-) — applied without conflicts.

## Notes
- No workflow file modifications.
- Pairs with a previously filed report (issue #2204). Close this PR if the v0.15 line is out of the support window.
