### PR TITLE
doc: fix issues in the release procedure

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -68,7 +68,7 @@ check_permissions:
 # See phpunit.xml for configuration
 # https://phpunit.de/manual/current/en/appendixes.configuration.html
 ##
-test: translate
+test: composer_dependencies_dev translate
 	@echo "-------"
 	@echo "PHPUNIT"
 	@echo "-------"

--- a/doc/md/dev/Development.md
+++ b/doc/md/dev/Development.md
@@ -462,7 +462,7 @@ git pull upstream master
 # If releasing a new minor version, create a release branch
 $ git checkout -b v0.x
 # Otherwise just use the existing one
-$ git checkout v0.x
+$ git checkout --track upstream/v0.x
 
 # Get the latest changes
 $ git merge master
@@ -515,6 +515,8 @@ Release archives will contain Shaarli code plus all required third-party librari
 ```bash
 # checkout the appropriate tag
 git checkout v0.x.y
+# clean previous build artifacts
+make clean && git clean -xdiff
 # generate zip archives
 make release_archive
 ```


### PR DESCRIPTION
- make test depends on composer_dependencies_dev
- git checkout --track is required when the local copy does not have a local release branch
- should clean the local copy before generating the release archive