### PR TITLE
build: fix inconsistent permissions in release archives, only build and release full .zip archives, not tar.gz

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,6 +54,7 @@ tpl/*
 
 # Front end
 node_modules
+/.yarn
 tpl/default/js
 tpl/default/css
 tpl/default/fonts

--- a/Makefile
+++ b/Makefile
@@ -117,24 +117,27 @@ build_frontend: frontend_dependencies
 
 ### generate a release tarball and include 3rd-party dependencies and translations
 release_tar: composer_dependencies htmldoc translate build_frontend
-	git archive --prefix=$(ARCHIVE_PREFIX) -o $(ARCHIVE_VERSION).tar HEAD
-	$(TAR) rvf $(ARCHIVE_VERSION).tar --transform "s|^vendor|$(ARCHIVE_PREFIX)vendor|" vendor/
-	$(TAR) rvf $(ARCHIVE_VERSION).tar --transform "s|^doc/html|$(ARCHIVE_PREFIX)doc/html|" doc/html/
-	$(TAR) rvf $(ARCHIVE_VERSION).tar --transform "s|^tpl|$(ARCHIVE_PREFIX)tpl|" tpl/
+	umask 0022; \
+	git archive --prefix=$(ARCHIVE_PREFIX) -o $(ARCHIVE_VERSION).tar HEAD; \
+	$(TAR) rvf $(ARCHIVE_VERSION).tar --transform "s|^vendor|$(ARCHIVE_PREFIX)vendor|" vendor/; \
+	$(TAR) rvf $(ARCHIVE_VERSION).tar --transform "s|^doc/html|$(ARCHIVE_PREFIX)doc/html|" doc/html/; \
+	$(TAR) rvf $(ARCHIVE_VERSION).tar --transform "s|^tpl|$(ARCHIVE_PREFIX)tpl|" tpl/; \
 	gzip $(ARCHIVE_VERSION).tar
 
 ### generate a release zip and include 3rd-party dependencies and translations
 release_zip: composer_dependencies htmldoc translate build_frontend
-	git archive --prefix=$(ARCHIVE_PREFIX) -o $(ARCHIVE_VERSION).zip -9 HEAD
-	mkdir -p $(ARCHIVE_PREFIX)/doc
-	mkdir -p $(ARCHIVE_PREFIX)/vendor
-	rsync -a doc/html/ $(ARCHIVE_PREFIX)doc/html/
-	zip -r $(ARCHIVE_VERSION).zip $(ARCHIVE_PREFIX)doc/
-	rsync -a vendor/ $(ARCHIVE_PREFIX)vendor/
-	zip -r $(ARCHIVE_VERSION).zip $(ARCHIVE_PREFIX)vendor/
-	rsync -a tpl/ $(ARCHIVE_PREFIX)tpl/
-	zip -r $(ARCHIVE_VERSION).zip $(ARCHIVE_PREFIX)tpl/
-	rm -rf $(ARCHIVE_PREFIX)
+	(umask 0022; \
+	mkdir -p $(ARCHIVE_PREFIX); \
+	git archive HEAD | tar -C $(ARCHIVE_PREFIX) -x; \
+	mkdir -p $(ARCHIVE_PREFIX)/doc; \
+	mkdir -p $(ARCHIVE_PREFIX)/vendor; \
+	rsync -a doc/html/ $(ARCHIVE_PREFIX)doc/html/; \
+	rsync -a vendor/ $(ARCHIVE_PREFIX)vendor/; \
+	rsync -a tpl/ $(ARCHIVE_PREFIX)tpl/; \
+	find $(ARCHIVE_PREFIX) -type d -exec chmod 755 {} +; \
+	find $(ARCHIVE_PREFIX) -type f -exec chmod 644 {} +; \
+	zip -r $(ARCHIVE_VERSION).zip $(ARCHIVE_PREFIX); \
+	rm -rf $(ARCHIVE_PREFIX))
 
 ### bump version number in all relevant files
 bump_version:

--- a/Makefile
+++ b/Makefile
@@ -24,13 +24,6 @@ docker_%:
 ##
 PHPCS := $(BIN)/phpcs
 
-# Use GNU Tar where available
-ifneq (, $(shell which gtar))
-TAR := gtar
-else
-TAR := tar
-endif
-
 code_sniffer:
 	@$(PHPCS)
 
@@ -100,7 +93,7 @@ composer_dependencies_dev: clean
 ARCHIVE_VERSION := shaarli-$$(git describe)-full
 ARCHIVE_PREFIX=Shaarli/
 
-release_archive: release_tar release_zip
+release_archive: release_zip
 
 ### download 3rd-party PHP libraries
 composer_dependencies: clean
@@ -114,15 +107,6 @@ frontend_dependencies:
 ### Build frontend dependencies
 build_frontend: frontend_dependencies
 	yarnpkg run build
-
-### generate a release tarball and include 3rd-party dependencies and translations
-release_tar: composer_dependencies htmldoc translate build_frontend
-	umask 0022; \
-	git archive --prefix=$(ARCHIVE_PREFIX) -o $(ARCHIVE_VERSION).tar HEAD; \
-	$(TAR) rvf $(ARCHIVE_VERSION).tar --transform "s|^vendor|$(ARCHIVE_PREFIX)vendor|" vendor/; \
-	$(TAR) rvf $(ARCHIVE_VERSION).tar --transform "s|^doc/html|$(ARCHIVE_PREFIX)doc/html|" doc/html/; \
-	$(TAR) rvf $(ARCHIVE_VERSION).tar --transform "s|^tpl|$(ARCHIVE_PREFIX)tpl|" tpl/; \
-	gzip $(ARCHIVE_VERSION).tar
 
 ### generate a release zip and include 3rd-party dependencies and translations
 release_zip: composer_dependencies htmldoc translate build_frontend

--- a/Makefile
+++ b/Makefile
@@ -24,19 +24,19 @@ docker_%:
 ##
 PHPCS := $(BIN)/phpcs
 
-code_sniffer:
+code_sniffer: composer_dependencies_dev
 	@$(PHPCS)
 
 ### - errors by Git author
-code_sniffer_blame:
+code_sniffer_blame: composer_dependencies_dev
 	@$(PHPCS) --report-gitblame
 
 ### - all errors/warnings
-code_sniffer_full:
+code_sniffer_full: composer_dependencies_dev
 	@$(PHPCS) --report-full --report-width=200
 
 ### - errors grouped by kind
-code_sniffer_source:
+code_sniffer_source: composer_dependencies_dev
 	@$(PHPCS) --report-source || exit 0
 
 ##
@@ -78,7 +78,7 @@ locale_test_%:
 all_tests: test locale_test_de_DE locale_test_en_US locale_test_fr_FR
 
 ### download 3rd-party PHP libraries, including dev dependencies
-composer_dependencies_dev: clean
+composer_dependencies_dev:
 	composer install --prefer-dist
 
 ##
@@ -143,7 +143,7 @@ endif
 
 ### remove all unversioned files
 clean:
-	@git clean -df
+	@git clean -xdff
 	@rm -rf sandbox trivy*
 
 ### generate the AUTHORS file from Git commit information

--- a/doc/md/dev/Development.md
+++ b/doc/md/dev/Development.md
@@ -418,8 +418,6 @@ sudo apt install composer yarnpkg gettext phpunit yarnpkg php8.2-mbstring php8.2
 make composer_dependencies_dev
 ```
 
-Make sure you have GNU `tar` installed (not BSD `tar`). On macOS, you can install it with `brew install gnu-tar`.
-
 ### Release notes and `CHANGELOG.md`
 
 Update `CHANGELOG.md` to:
@@ -521,7 +519,7 @@ make clean && git clean -xdiff
 make release_archive
 ```
 
-This will create `shaarli-v0.x.y-full.tar`, `shaarli-v0.x.y-full.zip`. These archives need to be manually uploaded on the previously created GitHub [release](https://github.com/shaarli/Shaarli/releases).
+This will create `shaarli-v0.x.y-full.zip`. This archive needs to be manually uploaded on the previously created GitHub [release](https://github.com/shaarli/Shaarli/releases).
 
 
 ### Update the `release` branch


### PR DESCRIPTION
**build: fix inconsistent permissions in release archives:**
- set umask 0022 in release archive targets
- run git-archive through tar -C to extract only git-tracked files
- add a chmod final chmod step before building the zip, so that both files generated by git-archive, by the frontend build process, and by rsync have the correct permissions
- the 0.16.2 release tarball had overly restrictive permissions (660/770) on generated files, causing the web server to be unable to read CSS/JS files. This ensures the release zip has consistent 644/755 permissions regardless of the build machine's umask
- Fixes #2214

**build/release: simplify, only build and release full .zip archives, remove .tar.gz builds**
- file permissions/ownership are easier to manage in .zip files
- removes duplicate packaging logic with little benefit

**build: improve make clean target**
- really remove all untracked and ignored files
- add composer_dependencies_dev as a dependency of code_sniffer targets so vendor/bin/phpcs is always available
- remove clean dependency from composer_dependencies_dev so it doesn't wipe the working tree
