### PR TITLE
fix(xss): escape bookmark title in permalink pagetitle

### DIFF
--- a/application/front/controller/visitor/BookmarkListController.php
+++ b/application/front/controller/visitor/BookmarkListController.php
@@ -147,7 +147,8 @@ class BookmarkListController extends ShaarliVisitorController
         $data = array_merge(
             $this->initializeTemplateVars(),
             [
-                'pagetitle' => $bookmark->getTitle() . ' - ' . $this->container->conf->get('general.title', 'Shaarli'),
+                'pagetitle' => escape($bookmark->getTitle())
+                    . ' - ' . $this->container->conf->get('general.title', 'Shaarli'),
                 'links' => [$formatter->format($bookmark)],
             ]
         );

--- a/tests/front/controller/visitor/BookmarkListControllerTest.php
+++ b/tests/front/controller/visitor/BookmarkListControllerTest.php
@@ -267,6 +267,39 @@ class BookmarkListControllerTest extends TestCase
     }
 
     /**
+     * Test displaying a permalink with a malicious title (XSS prevention).
+     */
+    public function testPermalinkXssPrevention(): void
+    {
+        $hash = 'abcdef';
+        $maliciousTitle = '</title><script>alert(1)</script><title>';
+
+        $assignedVariables = [];
+        $this->assignTemplateVars($assignedVariables);
+
+        $request = $this->createMock(Request::class);
+        $response = new Response();
+
+        $this->container->bookmarkService
+            ->expects(static::once())
+            ->method('findByHash')
+            ->with($hash)
+            ->willReturn((new Bookmark())->setId(123)->setTitle($maliciousTitle)->setUrl('http://url1.tld'))
+        ;
+
+        $result = $this->controller->permalink($request, $response, ['hash' => $hash]);
+
+        static::assertSame(200, $result->getStatusCode());
+        static::assertSame('linklist', (string) $result->getBody());
+
+        // Title must be HTML-escaped, not rendered raw
+        static::assertSame(
+            '&lt;/title&gt;&lt;script&gt;alert(1)&lt;/script&gt;&lt;title&gt; - Shaarli',
+            $assignedVariables['pagetitle']
+        );
+    }
+
+    /**
      * Test displaying a permalink with an unknown small hash : renders a 404 template error
      */
     public function testPermalinkNotFound(): void


### PR DESCRIPTION
- HTML-encode the bookmark title before concatenating it into the pagetitle template variable
- prevents stored XSS via malicious bookmark titles that could close the document title element and inject scripts
- https://github.com/shaarli/Shaarli/security/advisories/GHSA-xm98-h5jj-64xv