### PR TITLE
docs: add origr3n theme to Community & Related Software

### DIFF
--- a/doc/md/Community-and-related-software.md
+++ b/doc/md/Community-and-related-software.md
@@ -41,6 +41,7 @@ See [REST API](REST-API.md) for a list of official and community clients.
 
 ### Themes
 
+- [gruenheit/origr3n](https://github.com/gruenheit/origr3n) - A dark-first theme for Shaarli with timeline view, search overlay (`/` shortcut), and i18n support (DE/EN)
 - [kalvn/Shaarli-Material](https://github.com/kalvn/Shaarli-Material) - A theme (template) based on Google's Material Design for Shaarli, the superfast delicious clone
 - [ManufacturaInd/shaarli-2004licious-theme](https://github.com/ManufacturaInd/shaarli-2004licious-theme) - A template/theme as a humble homage to the early looks of the del.icio.us site
 - [RolandTi/shaarli-stack](https://github.com/RolandTi/shaarli-stack) - A miminalist template/theme for Shaarli


### PR DESCRIPTION
## Summary

Adds [origr3n](https://github.com/gruenheit/origr3n) to the Themes section of the Community & Related Software page.

origr3n is a dark-first Shaarli theme I've been actively developing and maintaining. The community page mentions *"If you maintain one of these, please get in touch with us"* — this PR is that outreach.

**Key features:**
- Dark mode by default, light mode toggle
- Timeline view: date separators between link cards, togglable via header icon
- Search overlay with `/` keyboard shortcut
- i18n (DE/EN, follows `document.documentElement.lang`)
- Redesigned empty state for 0 search results
- Compatible with `markdown` and `markdown_toolbar` plugins

Showcase: https://origr3n.gr3n.de
Live instance (read-only): https://gr3n.de

## Change

One line inserted in the Themes section, alphabetically by username (`gruenheit` before `kalvn`):

```diff
 ### Themes
 
+- [gruenheit/origr3n](https://github.com/gruenheit/origr3n) - A dark-first theme for Shaarli with timeline view, search overlay (`/` shortcut), and i18n support (DE/EN)
 - [kalvn/Shaarli-Material](https://github.com/kalvn/Shaarli-Material) - A theme (template) ...
```