### PR TITLE
fix(import): handle Netscape bookmarks without a creation date

### DIFF
--- a/application/netscape/NetscapeBookmarkUtils.php
+++ b/application/netscape/NetscapeBookmarkUtils.php
@@ -156,7 +156,13 @@ class NetscapeBookmarkUtils
                 $link->setUpdated(new DateTime());
                 $overwriteCount++;
             } else {
-                $newLinkDate = new DateTime('@' . $bkm['dateCreated']);
+                if (empty($bkm['dateCreated'])) {
+                    // Some browsers (e.g. Safari) export bookmarks without an
+                    // ADD_DATE attribute: fall back to the current date/time.
+                    $newLinkDate = new DateTime();
+                } else {
+                    $newLinkDate = new DateTime('@' . $bkm['dateCreated']);
+                }
                 $newLinkDate->setTimezone(new DateTimeZone(date_default_timezone_get()));
                 $link->setCreated($newLinkDate);
             }

--- a/tests/netscape/BookmarkImportTest.php
+++ b/tests/netscape/BookmarkImportTest.php
@@ -440,6 +440,36 @@ class BookmarkImportTest extends TestCase
     }
 
     /**
+     * Import bookmarks that do not provide a creation date.
+     *
+     * Some browsers (e.g. Safari) export Netscape bookmark files without the
+     * ADD_DATE attribute. The parser then returns a null date, which used to
+     * abort the whole import with a DateTime parsing error. Such bookmarks must
+     * be imported using the current date as a fallback.
+     *
+     * @see https://github.com/shaarli/Shaarli/issues/2152
+     */
+    public function testImportBookmarkWithoutCreationDate()
+    {
+        $files = file2array('netscape_nodate.htm');
+        $this->assertStringMatchesFormat(
+            'File netscape_nodate.htm (286 bytes) was successfully processed in %d seconds:'
+            . ' 1 bookmarks imported, 0 bookmarks overwritten, 0 bookmarks skipped.',
+            $this->netscapeBookmarkUtils->import([], $files)
+        );
+
+        $this->assertEquals(1, $this->bookmarkService->count());
+
+        $bookmark = $this->bookmarkService->findByUrl('https://no.date.tld');
+        $this->assertEquals(0, $bookmark->getId());
+        $this->assertEquals('Bookmark without date', $bookmark->getTitle());
+        $this->assertEquals('safari import', $bookmark->getTagsString());
+        // A missing creation date falls back to the current date/time.
+        $this->assertTrue(new DateTime('-5 seconds') < $bookmark->getCreated());
+        $this->assertTrue(new DateTime('+1 minute') > $bookmark->getCreated());
+    }
+
+    /**
      * Overwrite private bookmarks so they become public
      */
     public function testOverwriteAsPublic()

--- a/tests/netscape/input/netscape_nodate.htm
+++ b/tests/netscape/input/netscape_nodate.htm
@@ -1,0 +1,9 @@
+<!DOCTYPE NETSCAPE-Bookmark-file-1>
+<!-- This is an automatically generated file.
+It will be read and overwritten.
+Do Not Edit! -->
+<TITLE>Bookmarks</TITLE>
+<H1>Bookmarks</H1>
+<DL><p>
+<DT><A HREF="https://no.date.tld" PRIVATE="0" TAGS="safari import">Bookmark without date</A>
+</DL><p>


### PR DESCRIPTION
Fixes #2152

### Problem

Some browsers (notably Safari) export Netscape bookmark files without an `ADD_DATE` attribute. The bookmark parser correctly returns a null creation date for those entries, but the importer built the date with `new DateTime('@' . $bkm['dateCreated'])`. With a null date this becomes `new DateTime('@')`, which throws and aborts the *entire* import — no bookmarks are imported at all.

### Fix

Fall back to the current date/time when a bookmark provides no creation date (mirroring how the overwrite branch already uses `new DateTime()`), so dateless exports import successfully. Bookmarks that do carry a date are unaffected.

### Tests

Added `tests/netscape/input/netscape_nodate.htm` (a Safari-style export with no `ADD_DATE`) and `testImportBookmarkWithoutCreationDate`, which errors on `master` (`DateMalformedStringException: Failed to parse time string (@)`) and passes with this change. The full `tests/netscape/` suite is green (24 tests, 247 assertions) and phpcs is clean.

---
Disclosure: this patch was prepared with AI assistance (Claude) and reviewed and tested by me before submission.
