### PR TITLE
sanitize general.header_link against javascript: URIs

### DIFF
--- a/application/front/controller/admin/ConfigureController.php
+++ b/application/front/controller/admin/ConfigureController.php
@@ -75,7 +75,12 @@ class ConfigureController extends ShaarliAdminController
 
         $this->container->conf->set('general.timezone', $tz);
         $this->container->conf->set('general.title', escape($request->getParam('title')));
-        $this->container->conf->set('general.header_link', escape($request->getParam('titleLink')));
+        $allowedProtocols = $this->container->conf->get('security.allowed_protocols', []);
+        $allowedProtocols = is_array($allowedProtocols) ? $allowedProtocols : [];
+        $this->container->conf->set(
+            'general.header_link',
+            escape(whitelist_protocols($request->getParam('titleLink'), $allowedProtocols))
+        );
         $this->container->conf->set('general.retrieve_description', !empty($request->getParam('retrieveDescription')));
         $this->container->conf->set('resource.theme', escape($request->getParam('theme')));
         $this->container->conf->set(

--- a/tests/front/controller/admin/ConfigureControllerTest.php
+++ b/tests/front/controller/admin/ConfigureControllerTest.php
@@ -80,7 +80,7 @@ class ConfigureControllerTest extends TestCase
             'continent' => 'Europe',
             'city' => 'Moscow',
             'title' => 'Shaarli',
-            'titleLink' => './',
+            'titleLink' => '/',
             'retrieveDescription' => 'on',
             'theme' => 'vintage',
             'disablesessionprotection' => null,

--- a/tpl/vintage/page.header.html
+++ b/tpl/vintage/page.header.html
@@ -1,5 +1,5 @@
 
-<div id="logo" title="Share your links !" onclick="document.location='{$titleLink}';"></div>
+<div id="logo" title="Share your links !" onclick="document.location='{$titleLink|escape}';"></div>
 
 <div id="linkcount" class="nomobile">
   {if="$is_logged_in"}


### PR DESCRIPTION
- The "Home link" config value (`general.header_link`) was stored with `htmlspecialchars()` only, which does not prevent javascript: URIs.
- An administrator sets this value to inline javascript, any visitor who clicks the title/logo link executes the script.
- protect this value by `whitelist_protocols()` blocking `javascript:` and other non-allowed schemes
- Also add |escape filter to the vintage template's onclick handler
- use the default titleLink value of `/` instaed of `./` in the test, otherwise whitelist_protocols() would convert it to `http://./`
- fixes https://github.com/shaarli/Shaarli/security/advisories/GHSA-rvrg-mx59-mv8x