### PR TITLE
fix: protect /admin/metadata endpoint against SSRF

### DIFF
--- a/application/front/controller/admin/MetadataController.php
+++ b/application/front/controller/admin/MetadataController.php
@@ -17,10 +17,17 @@ class MetadataController extends ShaarliAdminController
      */
     public function ajaxRetrieveTitle(Request $request, Response $response): Response
     {
+        $this->checkToken($request);
+
         $url = $request->getParam('url');
 
-        // Only try to extract metadata from URL with HTTP(s) scheme
-        if (!empty($url) && strpos(get_url_scheme($url) ?: '', 'http') !== false) {
+        // Only try to extract metadata from URL with exact HTTP(s) scheme
+        $scheme = get_url_scheme($url);
+        if (
+            !empty($url)
+            && in_array(strtolower($scheme), ['http', 'https'], true)
+            && is_safe_url($url)
+        ) {
             return $response->withJson($this->container->metadataRetriever->retrieve($url));
         }
 

--- a/application/http/HttpUtils.php
+++ b/application/http/HttpUtils.php
@@ -74,40 +74,14 @@ function get_http_response(
         return [[0 => 'curl_init() error'], false];
     }
 
-    // General cURL settings
-    curl_setopt($ch, CURLOPT_AUTOREFERER, true);
-    // Disable automatic redirect following — we validate each hop manually
-    curl_setopt($ch, CURLOPT_FOLLOWLOCATION, false);
-    curl_setopt($ch, CURLOPT_PROTOCOLS, CURLPROTO_HTTP | CURLPROTO_HTTPS);
-    // Default header download if the $curlHeaderFunction is not defined
-    curl_setopt($ch, CURLOPT_HEADER, !is_callable($curlHeaderFunction));
-    curl_setopt(
+    _setCurlOptions(
         $ch,
-        CURLOPT_HTTPHEADER,
-        ['Accept-Language: ' . $acceptLanguage]
-    );
-    curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
-    curl_setopt($ch, CURLOPT_TIMEOUT, $timeout);
-    curl_setopt($ch, CURLOPT_USERAGENT, $userAgent);
-
-    // Max download size management
-    curl_setopt($ch, CURLOPT_BUFFERSIZE, 1024 * 16);
-    curl_setopt($ch, CURLOPT_NOPROGRESS, false);
-    if (is_callable($curlHeaderFunction)) {
-        curl_setopt($ch, CURLOPT_HEADERFUNCTION, $curlHeaderFunction);
-    }
-    if (is_callable($curlWriteFunction)) {
-        curl_setopt($ch, CURLOPT_WRITEFUNCTION, $curlWriteFunction);
-    }
-    curl_setopt(
-        $ch,
-        CURLOPT_PROGRESSFUNCTION,
-        function ($arg0, $arg1, $arg2, $arg3, $arg4) use ($maxBytes) {
-            $downloaded = $arg2;
-
-            // Non-zero return stops downloading
-            return ($downloaded > $maxBytes) ? 1 : 0;
-        }
+        $timeout,
+        $maxBytes,
+        $userAgent,
+        $acceptLanguage,
+        $curlHeaderFunction,
+        $curlWriteFunction
     );
 
     $response = curl_exec($ch);
@@ -141,34 +115,14 @@ function get_http_response(
             return [[0 => 'curl_init() error on redirect'], false];
         }
 
-        // Re-apply all cURL options for the new handle
-        curl_setopt($ch, CURLOPT_AUTOREFERER, true);
-        curl_setopt($ch, CURLOPT_FOLLOWLOCATION, false);
-        curl_setopt($ch, CURLOPT_PROTOCOLS, CURLPROTO_HTTP | CURLPROTO_HTTPS);
-        curl_setopt($ch, CURLOPT_HEADER, !is_callable($curlHeaderFunction));
-        curl_setopt(
+        _setCurlOptions(
             $ch,
-            CURLOPT_HTTPHEADER,
-            ['Accept-Language: ' . $acceptLanguage]
-        );
-        curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
-        curl_setopt($ch, CURLOPT_TIMEOUT, $timeout);
-        curl_setopt($ch, CURLOPT_USERAGENT, $userAgent);
-        curl_setopt($ch, CURLOPT_BUFFERSIZE, 1024 * 16);
-        curl_setopt($ch, CURLOPT_NOPROGRESS, false);
-        if (is_callable($curlHeaderFunction)) {
-            curl_setopt($ch, CURLOPT_HEADERFUNCTION, $curlHeaderFunction);
-        }
-        if (is_callable($curlWriteFunction)) {
-            curl_setopt($ch, CURLOPT_WRITEFUNCTION, $curlWriteFunction);
-        }
-        curl_setopt(
-            $ch,
-            CURLOPT_PROGRESSFUNCTION,
-            function ($arg0, $arg1, $arg2, $arg3, $arg4) use ($maxBytes) {
-                $downloaded = $arg2;
-                return ($downloaded > $maxBytes) ? 1 : 0;
-            }
+            $timeout,
+            $maxBytes,
+            $userAgent,
+            $acceptLanguage,
+            $curlHeaderFunction,
+            $curlWriteFunction
         );
 
         $response = curl_exec($ch);
@@ -222,6 +176,94 @@ function get_http_response(
     }
 
     return [$headers, $content];
+}
+
+/**
+ * Set cURL options for outbound HTTP requests with DNS rebinding protection.
+ *
+ * Resolves the hostname to an IP, verifies it is not private/reserved,
+ * and uses CURLOPT_RESOLVE to pin the connection to that verified IP.
+ * This prevents DNS rebinding attacks where the hostname resolves to a
+ * different IP between validation and connection.
+ *
+ * @param resource $ch              cURL handle
+ * @param int      $timeout         Request timeout in seconds
+ * @param int      $maxBytes        Maximum download size in bytes
+ * @param string   $userAgent       User-Agent header
+ * @param string   $acceptLanguage  Accept-Language header
+ * @param callable $headerFunction  CURLOPT_HEADERFUNCTION callback
+ * @param callable $writeFunction   CURLOPT_WRITEFUNCTION callback
+ */
+function _setCurlOptions(
+    $ch,
+    $timeout,
+    $maxBytes,
+    $userAgent,
+    $acceptLanguage,
+    $headerFunction,
+    $writeFunction
+) {
+    // DNS rebinding protection: resolve hostname and pin to verified IP
+    $url = curl_getinfo($ch, CURLINFO_EFFECTIVE_URL);
+    $parsed = parse_url($url);
+    if (isset($parsed['host'])) {
+        $host = $parsed['host'];
+        // Strip brackets from IPv6
+        $host = trim($host, '[]');
+        // Only resolve hostnames, not literal IPs
+        if (!filter_var($host, FILTER_VALIDATE_IP)) {
+            $records = dns_get_record($host, DNS_A | DNS_AAAA);
+            $resolveEntries = [];
+            $port = $parsed['port'] ?? ($parsed['scheme'] === 'https' ? 443 : 80);
+            if (is_array($records)) {
+                foreach ($records as $record) {
+                    $ip = $record['ip'] ?? $record['ipv6'] ?? null;
+                    if ($ip && !is_private_ip($ip)) {
+                        $resolveEntries[] = $host . ':' . $port . ':' . $ip;
+                    }
+                }
+            }
+            if (!empty($resolveEntries)) {
+                curl_setopt($ch, CURLOPT_RESOLVE, $resolveEntries);
+            }
+        }
+    }
+
+    // General cURL settings
+    curl_setopt($ch, CURLOPT_AUTOREFERER, true);
+    // Disable automatic redirect following — we validate each hop manually
+    curl_setopt($ch, CURLOPT_FOLLOWLOCATION, false);
+    curl_setopt($ch, CURLOPT_PROTOCOLS, CURLPROTO_HTTP | CURLPROTO_HTTPS);
+    // Default header download if the $headerFunction is not defined
+    curl_setopt($ch, CURLOPT_HEADER, !is_callable($headerFunction));
+    curl_setopt(
+        $ch,
+        CURLOPT_HTTPHEADER,
+        ['Accept-Language: ' . $acceptLanguage]
+    );
+    curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
+    curl_setopt($ch, CURLOPT_TIMEOUT, $timeout);
+    curl_setopt($ch, CURLOPT_USERAGENT, $userAgent);
+
+    // Max download size management
+    curl_setopt($ch, CURLOPT_BUFFERSIZE, 1024 * 16);
+    curl_setopt($ch, CURLOPT_NOPROGRESS, false);
+    if (is_callable($headerFunction)) {
+        curl_setopt($ch, CURLOPT_HEADERFUNCTION, $headerFunction);
+    }
+    if (is_callable($writeFunction)) {
+        curl_setopt($ch, CURLOPT_WRITEFUNCTION, $writeFunction);
+    }
+    curl_setopt(
+        $ch,
+        CURLOPT_PROGRESSFUNCTION,
+        function ($arg0, $arg1, $arg2, $arg3, $arg4) use ($maxBytes) {
+            $downloaded = $arg2;
+
+            // Non-zero return stops downloading
+            return ($downloaded > $maxBytes) ? 1 : 0;
+        }
+    );
 }
 
 /**

--- a/application/http/HttpUtils.php
+++ b/application/http/HttpUtils.php
@@ -76,7 +76,9 @@ function get_http_response(
 
     // General cURL settings
     curl_setopt($ch, CURLOPT_AUTOREFERER, true);
-    curl_setopt($ch, CURLOPT_FOLLOWLOCATION, true);
+    // Disable automatic redirect following — we validate each hop manually
+    curl_setopt($ch, CURLOPT_FOLLOWLOCATION, false);
+    curl_setopt($ch, CURLOPT_PROTOCOLS, CURLPROTO_HTTP | CURLPROTO_HTTPS);
     // Default header download if the $curlHeaderFunction is not defined
     curl_setopt($ch, CURLOPT_HEADER, !is_callable($curlHeaderFunction));
     curl_setopt(
@@ -84,7 +86,6 @@ function get_http_response(
         CURLOPT_HTTPHEADER,
         ['Accept-Language: ' . $acceptLanguage]
     );
-    curl_setopt($ch, CURLOPT_MAXREDIRS, $maxRedirs);
     curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
     curl_setopt($ch, CURLOPT_TIMEOUT, $timeout);
     curl_setopt($ch, CURLOPT_USERAGENT, $userAgent);
@@ -113,6 +114,69 @@ function get_http_response(
     $errorNo = curl_errno($ch);
     $errorStr = curl_error($ch);
     $headSize = curl_getinfo($ch, CURLINFO_HEADER_SIZE);
+
+    // Follow redirects manually, validating each target
+    $redirects = 0;
+    while ($response !== false && $redirects < $maxRedirs) {
+        $redirectUrl = curl_getinfo($ch, CURLINFO_REDIRECT_URL);
+        if ($redirectUrl === null || $redirectUrl === '' || $redirectUrl === false) {
+            break;
+        }
+
+        // Validate redirect target
+        $redirectObj = new Url($redirectUrl);
+        if (
+            !filter_var($redirectUrl, FILTER_VALIDATE_URL)
+            || !$redirectObj->isHttp()
+            || !is_safe_url($redirectUrl)
+        ) {
+            curl_close($ch);
+            return [[0 => 'Redirect to disallowed URL'], false];
+        }
+
+        $redirects++;
+        curl_close($ch);
+        $ch = curl_init($redirectUrl);
+        if ($ch === false) {
+            return [[0 => 'curl_init() error on redirect'], false];
+        }
+
+        // Re-apply all cURL options for the new handle
+        curl_setopt($ch, CURLOPT_AUTOREFERER, true);
+        curl_setopt($ch, CURLOPT_FOLLOWLOCATION, false);
+        curl_setopt($ch, CURLOPT_PROTOCOLS, CURLPROTO_HTTP | CURLPROTO_HTTPS);
+        curl_setopt($ch, CURLOPT_HEADER, !is_callable($curlHeaderFunction));
+        curl_setopt(
+            $ch,
+            CURLOPT_HTTPHEADER,
+            ['Accept-Language: ' . $acceptLanguage]
+        );
+        curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
+        curl_setopt($ch, CURLOPT_TIMEOUT, $timeout);
+        curl_setopt($ch, CURLOPT_USERAGENT, $userAgent);
+        curl_setopt($ch, CURLOPT_BUFFERSIZE, 1024 * 16);
+        curl_setopt($ch, CURLOPT_NOPROGRESS, false);
+        if (is_callable($curlHeaderFunction)) {
+            curl_setopt($ch, CURLOPT_HEADERFUNCTION, $curlHeaderFunction);
+        }
+        if (is_callable($curlWriteFunction)) {
+            curl_setopt($ch, CURLOPT_WRITEFUNCTION, $curlWriteFunction);
+        }
+        curl_setopt(
+            $ch,
+            CURLOPT_PROGRESSFUNCTION,
+            function ($arg0, $arg1, $arg2, $arg3, $arg4) use ($maxBytes) {
+                $downloaded = $arg2;
+                return ($downloaded > $maxBytes) ? 1 : 0;
+            }
+        );
+
+        $response = curl_exec($ch);
+        $errorNo = curl_errno($ch);
+        $errorStr = curl_error($ch);
+        $headSize = curl_getinfo($ch, CURLINFO_HEADER_SIZE);
+    }
+
     curl_close($ch);
 
     if ($response === false) {

--- a/application/http/UrlUtils.php
+++ b/application/http/UrlUtils.php
@@ -87,3 +87,39 @@ function whitelist_protocols($url, $protocols)
     }
     return $url;
 }
+
+/**
+ * Check if a URL resolves to a private, loopback, or reserved IP address.
+ *
+ * @param string $url URL to check
+ *
+ * @return bool false if the resolved IP is private/loopback/reserved, true otherwise
+ */
+function is_safe_url($url)
+{
+    $parsed = parse_url($url);
+    if (!isset($parsed['host'])) {
+        return false;
+    }
+
+    $host = $parsed['host'];
+    $ip = filter_var($host, FILTER_VALIDATE_IP) ? $host : gethostbyname($host);
+
+    return !is_private_ip($ip);
+}
+
+/**
+ * Check if an IPv4 address is private, loopback, link-local, or reserved.
+ *
+ * @param string $ip IP address to check
+ *
+ * @return bool true if the IP is private/reserved
+ */
+function is_private_ip($ip)
+{
+    if (!filter_var($ip, FILTER_VALIDATE_IP, FILTER_FLAG_IPV4)) {
+        return true; // Not a valid IPv4 — fail closed
+    }
+
+    return filter_var($ip, FILTER_VALIDATE_IP, FILTER_FLAG_NO_PRIV_RANGE | FILTER_FLAG_NO_RES_RANGE) === false;
+}

--- a/assets/common/js/metadata.js
+++ b/assets/common/js/metadata.js
@@ -56,6 +56,7 @@ function updateThumb(basePath, divElement, id) {
 
 (() => {
   const basePath = document.querySelector('input[name="js_base_path"]').value;
+  const token = document.querySelector('#token')?.value || '';
 
   /*
    * METADATA FOR EDIT BOOKMARK PAGE
@@ -74,7 +75,7 @@ function updateThumb(basePath, divElement, id) {
       const url = form.querySelector('input[name="lf_url"]').value;
 
       const xhr = new XMLHttpRequest();
-      xhr.open('GET', `${basePath}/admin/metadata?url=${encodeURI(url)}`, true);
+      xhr.open('GET', `${basePath}/admin/metadata?url=${encodeURI(url)}&token=${encodeURIComponent(token)}`, true);
       xhr.setRequestHeader('Content-Type', 'application/x-www-form-urlencoded');
       xhr.onload = () => {
         const result = JSON.parse(xhr.response);


### PR DESCRIPTION
- the `/admin/metadata` endpoint accepts a URL parameter and fetches it server-side, returning the remote page title and meta tags as JSON.
- the endpoint had three weaknesses:
- no destination validation: loopback, private, and link-local addresses were all reachable from the server
- weak scheme validation: the substring check would allow schemes like `httpoxy` to pass through
- no CSRF protection: the GET endpoint could be triggered cross-site by a logged-in administrator
- add three protections to the controller:
- exact scheme matching (http/https only)
- IP validation via `gethostbyname() + FILTER_FLAG_NO_PRIV_RANGE` to block loopback, RFC 1918, link-local, and reserved addresses
- CSRF token requirement via `checkToken()`

Also ensure that IP validation cannot be bypassed through redirects or DNS rebinding

Fixes https://github.com/shaarli/Shaarli/security/advisories/GHSA-85jx-fhrf-q9w7