### PR TITLE
fix wrong token error when saving links after metadata retrieval

### DIFF
--- a/application/front/controller/admin/MetadataController.php
+++ b/application/front/controller/admin/MetadataController.php
@@ -17,8 +17,6 @@ class MetadataController extends ShaarliAdminController
      */
     public function ajaxRetrieveTitle(Request $request, Response $response): Response
     {
-        $this->checkToken($request);
-
         $url = $request->getParam('url');
 
         // Only try to extract metadata from URL with exact HTTP(s) scheme


### PR DESCRIPTION
- remove CSRF check from metadata endpoint to fix form token reuse
- the XSRF token is single-use: `checkToken()` validates and destroys it
- the metadata XHR fires on page load, consuming the token rendered in the form
- subsequent form submission then fails with 403
- the metadata endpoint is a read-only GET request, already protected against SSRF by scheme/IP/redirect validation. CSRF is unnecessary.
- fixes https://github.com/shaarli/Shaarli/issues/2242