### PR TITLE
fix: fix missing Fork Awesome @font-face import/missing glyphs

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -54,7 +54,15 @@ module.exports = [
               loader: MiniCssExtractPlugin.loader,
             },
             'css-loader',
-            'sass-loader',
+            {
+              loader: 'sass-loader',
+              options: {
+                // Sass emits BOM for CSS with non-ASCII characters in production.
+                // PostCSS 8.5.24+ preserves BOMs, which breaks @font-face parsing.
+                // See: https://github.com/postcss/postcss/issues/2122
+                sassOptions: { charset: false },
+              },
+            },
           ],
         },
         {
@@ -126,7 +134,12 @@ module.exports = [
               loader: MiniCssExtractPlugin.loader,
             },
             'css-loader',
-            'sass-loader',
+            {
+              loader: 'sass-loader',
+              options: {
+                sassOptions: { charset: false },
+              },
+            },
           ],
         },
         {


### PR DESCRIPTION
- disable sass charset to prevent BOM in compiled CSS
- Dart Sass emits a UTF-8 BOM for CSS files containing non-ASCII characters in production (compressed) mode
- PostCSS 8.5.24+ preserves BOMs (byte-fidelity fix, see https://github.com/postcss/postcss/issues/2122).
- The BOM corrupts `@font-face` selectors (e.g. `\uFEFF@font-face)`, causing browsers to ignore them and not load font assets
- Fixes https://github.com/shaarli/Shaarli/issues/2248
- Patch inspired by: https://github.com/nextcloud-libraries/webpack-vue-config/pull/798