### PR TITLE
docker: add linux/arm64 platform to release Docker builds

### DIFF
--- a/.github/workflows/docker-tags.yml
+++ b/.github/workflows/docker-tags.yml
@@ -36,7 +36,7 @@ jobs:
         uses: docker/build-push-action@v5
         with:
           push: ${{ github.repository == 'shaarli/Shaarli' }}
-          platforms: linux/amd64,linux/arm/v7
+          platforms: linux/amd64,linux/arm64,linux/arm/v7
           tags: |
             ${{ secrets.DOCKER_IMAGE }}:${{ env.REF }}
             ghcr.io/${{ secrets.DOCKER_IMAGE }}:${{ env.REF }}


### PR DESCRIPTION
- docker-tags.yml was missing arm64 in the platforms list, causing release/tagged images (e.g. v0.16.5) to not be available for arm64 while latest was
- aligns release builds with docker-latest.yml which includes arm64
- fixes https://github.com/shaarli/Shaarli/issues/2251