### PR TITLE
fix: Stay Signed In session duration capped at 1 hour instead of 1 year

### DIFF
--- a/application/security/SessionManager.php
+++ b/application/security/SessionManager.php
@@ -143,7 +143,7 @@ class SessionManager
     {
         $this->session['ip'] = $clientIpId;
         $this->session['username'] = $this->conf->get('credentials.login');
-        $this->extendTimeValidityBy(self::$SHORT_TIMEOUT);
+        $this->extendSession();
     }
 
     /**


### PR DESCRIPTION
* `storeLoginInfo()` was calling `extendTimeValidityBy(self::$SHORT_TIMEOUT)` directly, hardcoding a 1-hour session duration and ignoring the `staySignedIn` flag.
* On every page load after login, the session expiration was overwritten back to 1 hour even when the user had checked 'Stay Signed In'.
* Fix: call `extendSession()` which respects the `staySignedIn` flag and uses the correct timeout (1 year when `staySignedIn` is true, 1 hour otherwise).

Ref. https://github.com/shaarli/Shaarli/pull/2213