### PR TITLE
fix(LoginController): call session_regenerate_id() before authentication to prevent session fixation

### DIFF
--- a/application/front/controller/visitor/LoginController.php
+++ b/application/front/controller/visitor/LoginController.php
@@ -142,14 +142,15 @@ class LoginController extends ShaarliVisitorController
 
     protected function renewUserSession(string $cookiePath, int $expirationTime): void
     {
-        // Send cookie with the new expiration date to the browser
-        $this->container->sessionManager->destroy();
+        // Quoting https://www.php.net/manual/en/features.session.security.management.php
+        // "Session IDs must be regenerated when user privileges are elevated,
+        // such as after authenticating. session_regenerate_id()
+        // must be called prior to setting the authentication information to \$_SESSION."
+        $this->container->sessionManager->regenerateId(true);
         $this->container->sessionManager->cookieParameters(
             $expirationTime,
             $cookiePath,
             $this->container->environment['SERVER_NAME']
         );
-        $this->container->sessionManager->start();
-        $this->container->sessionManager->regenerateId(true);
     }
 }

--- a/tests/front/controller/visitor/LoginControllerTest.php
+++ b/tests/front/controller/visitor/LoginControllerTest.php
@@ -201,14 +201,12 @@ class LoginControllerTest extends TestCase
         $this->container->loginManager->method('getStaySignedInToken')->willReturn(bin2hex(random_bytes(8)));
 
         $this->container->sessionManager->expects(static::never())->method('extendSession');
-        $this->container->sessionManager->expects(static::once())->method('destroy');
+        $this->container->sessionManager->expects(static::once())->method('regenerateId')->with(true);
         $this->container->sessionManager
             ->expects(static::once())
             ->method('cookieParameters')
             ->with(0, '/subfolder/', 'shaarli')
         ;
-        $this->container->sessionManager->expects(static::once())->method('start');
-        $this->container->sessionManager->expects(static::once())->method('regenerateId')->with(true);
 
         $result = $this->controller->login($request, $response);
 
@@ -268,14 +266,12 @@ class LoginControllerTest extends TestCase
         $this->container->loginManager->expects(static::once())->method('checkCredentials')->willReturn(true);
         $this->container->loginManager->method('getStaySignedInToken')->willReturn(bin2hex(random_bytes(8)));
 
-        $this->container->sessionManager->expects(static::once())->method('destroy');
+        $this->container->sessionManager->expects(static::once())->method('regenerateId')->with(true);
         $this->container->sessionManager
             ->expects(static::once())
             ->method('cookieParameters')
             ->with(42, '/subfolder/', 'shaarli')
         ;
-        $this->container->sessionManager->expects(static::once())->method('start');
-        $this->container->sessionManager->expects(static::once())->method('regenerateId')->with(true);
         $this->container->sessionManager->expects(static::once())->method('extendSession')->willReturn(42);
 
         $this->container->cookieManager = $this->createMock(CookieManager::class);


### PR DESCRIPTION
* PHP documentation (https://www.php.net/manual/en/features.session.security.management.php) mandates: "Session IDs must be regenerated when user privileges are elevated, such as after authenticating. `session_regenerate_id()` must be called prior to setting the authentication information to `$_SESSION`.'
* Additionally, `session_regenerate_id(true)` and `session_destroy()` must never be called together for an active session.'
* The old code called `destroy() -> start() -> regenerateId(true)`, which:
1. Violated the ordering requirement (`regenerateId` after auth)
2. Combined `regenerateId(true)` with `destroy()` (forbidden by PHP docs)
* Fix: call `regenerateId(true)` first (it saves session data and creates a new session ID), then set cookie parameters. No need for separate `destroy()` or `start()` calls.

Ref. https://github.com/shaarli/Shaarli/pull/2213